### PR TITLE
[REVIEW] FIX Use GitHub for LFS

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,0 +1,4 @@
+[lfs]
+        url = https://github.com/NVIDIA/Morpheus.git/info/lfs
+[lfs "https://github.com/NVIDIA/Morpheus.git/info/lfs"]
+        access = basic


### PR DESCRIPTION
This PR changes the default LFS endpoint to the GitHub default endpoint: `https://github.com/NVIDIA/Morpheus.git/info/lfs`

I have also pushed the LFS objects to this new endpoint, allowing for the cloning of the repository to not error out.