### PR TITLE
Fix for CI check script

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -8,6 +8,7 @@ pipeline {
         RAPIDS_VER = '21.10'
         CUDA_VER = '11.4'
         HOME = "${WORKSPACE}"
+        GH_TOKEN = credentials('gputester-github-token')
     }
     stages {
         stage('Checks & Builds') {

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,3 +1,5 @@
+@Library('jenkins_shared_lib') _
+
 pipeline {
     agent any
     options {
@@ -9,6 +11,7 @@ pipeline {
         CUDA_VER = '11.4'
         HOME = "${WORKSPACE}"
         GH_TOKEN = credentials('gputester-github-token')
+        BUILD_TYPE = sh(returnStdout: true, script: 'rapids-build-type')
     }
     stages {
         stage('Checks & Builds') {
@@ -18,6 +21,7 @@ pipeline {
                     options {
                         timeout(time: 1, unit: 'HOURS')
                     }
+                    when { environment name: 'BUILD_TYPE', value: 'pull-request' }
                     agent {
                         docker {
                             image 'gpuci/rapidsai-driver:21.10-cuda11.4-devel-ubuntu20.04-py3.8'

--- a/ci/scripts/jenkins/common.sh
+++ b/ci/scripts/jenkins/common.sh
@@ -38,7 +38,11 @@ curl \
     "https://api.github.com/repos/${ORG_NAME}/${REPO_NAME}/pulls/${PR_NUM}"
 )
 
-export CHANGE_TARGET "origin/$(echo "${RESP}" | jq -r '.base.ref')"
+BASE_BRANCH=$(echo "${RESP}" | jq -r '.base.ref')
+
+# Change target is the branch name we are merging into but due to the weird way jenkins does
+# the checkout it isn't recognized by git without the origin/ prefix
+export CHANGE_TARGET "origin/${BASE_BRANCH}"
 
 # S3 vars
 export S3_URL="s3://rapids-downloads/ci/morpheus"

--- a/ci/scripts/jenkins/common.sh
+++ b/ci/scripts/jenkins/common.sh
@@ -42,7 +42,7 @@ BASE_BRANCH=$(echo "${RESP}" | jq -r '.base.ref')
 
 # Change target is the branch name we are merging into but due to the weird way jenkins does
 # the checkout it isn't recognized by git without the origin/ prefix
-export CHANGE_TARGET "origin/${BASE_BRANCH}"
+export CHANGE_TARGET="origin/${BASE_BRANCH}"
 
 # S3 vars
 export S3_URL="s3://rapids-downloads/ci/morpheus"

--- a/ci/scripts/jenkins/common.sh
+++ b/ci/scripts/jenkins/common.sh
@@ -32,7 +32,7 @@ ORG_NAME=$(basename "$(dirname "${GIT_URL}")")
 PR_NUM="${GIT_BRANCH##*/}"
 [[ -n "$GH_TOKEN" ]] && CURL_HEADERS=('-H' "Authorization: token ${GH_TOKEN}")
 RESP=$(
-curl \
+curl -s \
     -H "Accept: application/vnd.github.v3+json" \
     "${CURL_HEADERS[@]}" \
     "https://api.github.com/repos/${ORG_NAME}/${REPO_NAME}/pulls/${PR_NUM}"

--- a/ci/scripts/jenkins/common.sh
+++ b/ci/scripts/jenkins/common.sh
@@ -48,9 +48,9 @@ gpuci_logger "Base branch: ${BASE_BRANCH}"
 # S3 vars
 export S3_URL="s3://rapids-downloads/ci/morpheus"
 export DISPLAY_URL="https://downloads.rapids.ai/ci/morpheus"
-export ARTIFACT_ENDPOINT="/pull-request/${CHANGE_ID}/${GIT_COMMIT}/${NVARCH}"
+export ARTIFACT_ENDPOINT="/pull-request/${PR_NUM}/${GIT_COMMIT}/${NVARCH}"
 export ARTIFACT_URL="${S3_URL}${ARTIFACT_ENDPOINT}"
-export DISPLAY_ARTIFACT_URL="${DISPLAY_URL}/pull-request/${CHANGE_ID}/${GIT_COMMIT}/${NVARCH}/"
+export DISPLAY_ARTIFACT_URL="${DISPLAY_URL}/pull-request/${PR_NUM}/${GIT_COMMIT}/${NVARCH}/"
 
 # Set sccache env vars
 export SCCACHE_S3_KEY_PREFIX=morpheus-${NVARCH}

--- a/ci/scripts/jenkins/common.sh
+++ b/ci/scripts/jenkins/common.sh
@@ -27,7 +27,7 @@ id
 
 # Change target is the branch name we are merging into but due to the weird way jenkins does
 # the checkout it isn't recognized by git without the origin/ prefix
-export CHANGE_TARGET="origin/${CHANGE_TARGET}"
+#export CHANGE_TARGET="origin/${CHANGE_TARGET}"
 
 # S3 vars
 export S3_URL="s3://rapids-downloads/ci/morpheus"

--- a/ci/scripts/jenkins/common.sh
+++ b/ci/scripts/jenkins/common.sh
@@ -25,7 +25,7 @@ gpuci_logger "Memory"
 gpuci_logger "User Info"
 id
 
-gpuci_logger "Retrieving base branch from GitHub API:"
+gpuci_logger "Retrieving base branch from GitHub API"
 # For PRs, $GIT_BRANCH is like: pull-request/989
 REPO_NAME=$(basename "${GIT_URL}" .git)
 ORG_NAME=$(basename "$(dirname "${GIT_URL}")")
@@ -43,6 +43,7 @@ BASE_BRANCH=$(echo "${RESP}" | jq -r '.base.ref')
 # Change target is the branch name we are merging into but due to the weird way jenkins does
 # the checkout it isn't recognized by git without the origin/ prefix
 export CHANGE_TARGET="origin/${BASE_BRANCH}"
+gpuci_logger "Base branch: ${BASE_BRANCH}"
 
 # S3 vars
 export S3_URL="s3://rapids-downloads/ci/morpheus"


### PR DESCRIPTION
+ Use Github's rest API to determine base branch.
+ Only run check stage on pull requests