### PR TITLE
Rollback CI images and fix dev container

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,21 +62,7 @@ rapids_cmake_build_type(Release)
 include(cmake/configure_toolchain.cmake)
 
 # Project definition
-project(morpheus LANGUAGES C CXX)
-
-# Delay enabling CUDA until after we have determined our CXX compiler
-if(NOT DEFINED CMAKE_CUDA_HOST_COMPILER)
-  message(STATUS "Setting CUDA host compiler to match CXX compiler: ${CMAKE_CXX_COMPILER}")
-
-  # Only set the host compiler if we arent using clang. Using clang > 8ish is
-  # incompatible with CUDA 11.4/11.5/11.6. See Issue #102
-  if(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    set(CMAKE_CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER})
-  endif()
-endif()
-
-# Now enable CUDA
-enable_language(CUDA)
+project(morpheus LANGUAGES C CXX CUDA)
 
 # Ccache configuration
 include(setup_cache)

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
                     when { environment name: 'BUILD_TYPE', value: 'pull-request' }
                     agent {
                         docker {
-                            image 'gpuci/rapidsai-driver:22.06-cuda11.5-devel-centos7-py3.8'
+                            image 'gpuci/rapidsai-driver:22.04-cuda11.5-devel-centos7-py3.8'
                             label 'cpu'
                         }
                     }
@@ -50,7 +50,7 @@ pipeline {
                     }
                     agent {
                         docker {
-                            image 'gpuci/rapidsai:22.06-cuda11.5-devel-centos7-py3.8'
+                            image 'gpuci/rapidsai:22.04-cuda11.5-devel-centos7-py3.8'
                             label 'driver-495'
                             args '--runtime "nvidia" -e "NVIDIA_VISIBLE_DEVICES=$EXECUTOR_NUMBER"'
                         }
@@ -83,7 +83,7 @@ pipeline {
                     }
                     agent {
                         docker {
-                            image 'gpuci/rapidsai:22.06-cuda11.5-devel-centos7-py3.8'
+                            image 'gpuci/rapidsai:22.04-cuda11.5-devel-centos7-py3.8'
                             label 'driver-495'
                             args '--runtime "nvidia" -e "NVIDIA_VISIBLE_DEVICES=$EXECUTOR_NUMBER"'
                         }
@@ -114,7 +114,7 @@ pipeline {
                     }
                     agent {
                         docker {
-                            image 'gpuci/rapidsai:22.06-cuda11.5-devel-centos7-py3.8'
+                            image 'gpuci/rapidsai:22.04-cuda11.5-devel-centos7-py3.8'
                             label 'driver-495'
                             args '--runtime "nvidia" -e "NVIDIA_VISIBLE_DEVICES=$EXECUTOR_NUMBER"'
                         }


### PR DESCRIPTION
Rolls back the ci images to 22.04 and removes the ci build fix necessary for those images, because the fixes are causing issues for compilations done from within the dev container.

Closes #190