### PR TITLE
Fixes Pipeline.visualize

### DIFF
--- a/morpheus/pipeline/pipeline.py
+++ b/morpheus/pipeline/pipeline.py
@@ -70,6 +70,7 @@ class Pipeline():
         self._graph = networkx.DiGraph()
 
         self._is_built = False
+        self._build_complete = False
         self._is_started = False
 
         self._srf_executor: srf.Executor = None
@@ -176,6 +177,7 @@ class Pipeline():
                     p.link()
 
             logger.info("====Building Pipeline Complete!====")
+            self._build_complete = True
 
             # Finally call _on_start
             self._on_start()
@@ -282,6 +284,16 @@ class Pipeline():
                 return len(n.input_ports) > 0
             else:
                 return len(n.output_ports) > 0
+
+        if (not self.is_built):
+            try:
+                self.build()
+            except Exception:
+                logger.exception("Error occurred during Pipeline.build(). Exiting.", exc_info=True)
+                return
+
+        while not self._build_complete:
+            time.sleep(0.1)
 
         # Now build up the nodes
         for n, attrs in typing.cast(typing.Mapping[StreamWrapper, dict], self._graph.nodes).items():

--- a/morpheus/pipeline/pipeline.py
+++ b/morpheus/pipeline/pipeline.py
@@ -292,6 +292,7 @@ class Pipeline():
                 logger.exception("Error occurred during Pipeline.build(). Exiting.", exc_info=True)
                 return
 
+        # The pipeline build is performed asynchronously, block until the build is completed
         while not self._build_complete:
             time.sleep(0.1)
 

--- a/tests/test_pipe_viz.py
+++ b/tests/test_pipe_viz.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import imghdr
+import os
+
+from morpheus.pipeline import LinearPipeline
+from morpheus.stages.input.file_source_stage import FileSourceStage
+from morpheus.stages.output.write_to_file_stage import WriteToFileStage
+from morpheus.stages.postprocess.add_classifications_stage import AddClassificationsStage
+from morpheus.stages.postprocess.serialize_stage import SerializeStage
+from morpheus.stages.preprocess.deserialize_stage import DeserializeStage
+from utils import TEST_DIRS
+from utils import ConvMsg
+
+
+def test_add_classifications_stage_pipe(config, tmp_path):
+    config.class_labels = ['frogs', 'lizards', 'toads', 'turtles']
+    config.num_threads = 1
+
+    # Silly data with all false values
+    input_file = os.path.join(TEST_DIRS.tests_data_dir, "filter_probs.csv")
+    out_file = os.path.join(tmp_path, 'results.csv')
+    viz_file = os.path.join(tmp_path, 'pipeline.png')
+
+    pipe = LinearPipeline(config)
+    pipe.set_source(FileSourceStage(config, filename=input_file, iterative=False))
+    pipe.add_stage(DeserializeStage(config))
+    pipe.add_stage(ConvMsg(config, input_file))
+    pipe.add_stage(AddClassificationsStage(config))
+    pipe.add_stage(SerializeStage(config, include=["^{}$".format(c) for c in config.class_labels]))
+    pipe.add_stage(WriteToFileStage(config, filename=out_file, overwrite=False))
+    pipe.visualize(viz_file, rankdir="LR")
+
+    # Verify that the output file exists and is a valid png file
+    assert os.path.exists(viz_file)
+    assert imghdr.what(viz_file) == 'png'


### PR DESCRIPTION
Adds a busy-loop to block until pipeline build is completed. 
Fixes #188

Ideally https://github.com/nv-morpheus/SRF/issues/68 would provide a better way to do this.