### PR TITLE
Add CLI Relative Path Fallback

### DIFF
--- a/morpheus/cli.py
+++ b/morpheus/cli.py
@@ -14,6 +14,7 @@
 
 import logging
 import os
+import typing
 import warnings
 from functools import update_wrapper
 
@@ -71,6 +72,48 @@ class AliasedGroup(click.Group):
         except KeyError:
             pass
         return super().get_command(ctx, cmd_name)
+
+
+class MorpheusRelativePath(click.Path):
+    """
+    A specialization of the `click.Path` class that falls back to using package relative paths if the file cannot be
+    found. Takes the exact same parameters as `click.Path`
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Append "data" to the name so it can be different than normal click.Path
+        self.name = "data " + self.name
+
+    def convert(self,
+                value: typing.Any,
+                param: typing.Optional["click.Parameter"],
+                ctx: typing.Optional["click.Context"]) -> typing.Any:
+
+        # First check if the path is relative
+        if (not os.path.isabs(value)):
+
+            # See if the file exists.
+            does_exist = os.path.exists(value)
+
+            if (not does_exist):
+                # If it doesnt exist, then try to make it relative to the morpheus library root
+                morpheus_root = os.path.dirname(morpheus.__file__)
+
+                value_abs_to_root = os.path.join(morpheus_root, value)
+
+                # If the file relative to our package exists, use that instead
+                if (os.path.exists(value_abs_to_root)):
+                    logger.debug(("Parameter, '%s', with relative path, '%s', does not exist. "
+                                  "Using package relative location: '%s'"),
+                                 param.name,
+                                 value,
+                                 value_abs_to_root)
+
+                    return super().convert(value_abs_to_root, param, ctx)
+
+        return super().convert(value, param, ctx)
 
 
 def _without_empty_args(passed_args):
@@ -312,6 +355,17 @@ def run(ctx: click.Context, **kwargs):
     pass
 
 
+def validate_rolls(ctx, param, value):
+    if isinstance(value, tuple):
+        return value
+
+    try:
+        rolls, _, dice = value.partition("d")
+        return int(dice), int(rolls)
+    except ValueError:
+        raise click.BadParameter("format must be 'NdM'")
+
+
 @click.group(chain=True,
              short_help="Run the inference pipeline with a NLP model",
              no_args_is_help=True,
@@ -325,8 +379,8 @@ def run(ctx: click.Context, **kwargs):
                     "do_truncate == False, there will be multiple returned sequences containing the "
                     "overflowing token-ids. Default value is 256"))
 @click.option('--labels_file',
-              default=os.path.join(morpheus.DATA_DIR, "labels_nlp.txt"),
-              type=click.Path(dir_okay=False, exists=True, file_okay=True),
+              default="data/labels_nlp.txt",
+              type=MorpheusRelativePath(dir_okay=False, exists=True, file_okay=True),
               help=("Specifies a file to read labels from in order to convert class IDs into labels. "
                     "A label file is a simple text file where each line corresponds to a label"))
 @click.option('--viz_file',
@@ -382,13 +436,13 @@ def pipeline_nlp(ctx: click.Context, **kwargs):
               help="Number of features trained in the model")
 @click.option('--labels_file',
               default=None,
-              type=click.Path(dir_okay=False, exists=True, file_okay=True),
+              type=MorpheusRelativePath(dir_okay=False, exists=True, file_okay=True),
               help=("Specifies a file to read labels from in order to convert class IDs into labels. "
                     "A label file is a simple text file where each line corresponds to a label. "
                     "If unspecified, only a single output label is created for FIL"))
 @click.option('--columns_file',
-              default=os.path.join(morpheus.DATA_DIR, "columns_fil.txt"),
-              type=click.Path(dir_okay=False, exists=True, file_okay=True),
+              default="data/columns_fil.txt",
+              type=MorpheusRelativePath(dir_okay=False, exists=True, file_okay=True),
               help=("Specifies a file to read column features."))
 @click.option('--viz_file',
               default=None,
@@ -450,12 +504,12 @@ def pipeline_fil(ctx: click.Context, **kwargs):
              cls=AliasedGroup,
              **command_kwargs)
 @click.option('--columns_file',
-              default=os.path.join(morpheus.DATA_DIR, "columns_ae.txt"),
-              type=click.Path(dir_okay=False, exists=True, file_okay=True),
+              default="data/columns_ae.txt",
+              type=MorpheusRelativePath(dir_okay=False, exists=True, file_okay=True),
               help=(""))
 @click.option('--labels_file',
               default=None,
-              type=click.Path(dir_okay=False, exists=True, file_okay=True),
+              type=MorpheusRelativePath(dir_okay=False, exists=True, file_okay=True),
               help=("Specifies a file to read labels from in order to convert class IDs into labels. "
                     "A label file is a simple text file where each line corresponds to a label. "
                     "If unspecified, only a single output label is created for FIL"))
@@ -841,11 +895,11 @@ def train_ae(ctx: click.Context, **kwargs):
 
 @click.command(name="preprocess", short_help="Convert messages to tokens", **command_kwargs)
 @click.option('--vocab_hash_file',
-              default=os.path.join(morpheus.DATA_DIR, "bert-base-cased-hash.txt"),
-              type=click.Path(exists=True, dir_okay=False),
+              default="data/bert-base-cased-hash.txt",
+              type=MorpheusRelativePath(exists=True, dir_okay=False),
               help=("Path to hash file containing vocabulary of words with token-ids. "
                     "This can be created from the raw vocabulary using the cudf.utils.hash_vocab_utils.hash_vocab "
-                    "function. Default value is 'data/bert-base-cased-hash.txt'"))
+                    "function."))
 @click.option('--truncation',
               default=False,
               type=bool,

--- a/morpheus/cli.py
+++ b/morpheus/cli.py
@@ -380,7 +380,7 @@ def validate_rolls(ctx, param, value):
                     "overflowing token-ids. Default value is 256"))
 @click.option('--labels_file',
               default="data/labels_nlp.txt",
-              type=MorpheusRelativePath(dir_okay=False, exists=True, file_okay=True),
+              type=MorpheusRelativePath(dir_okay=False, exists=True, file_okay=True, resolve_path=True),
               help=("Specifies a file to read labels from in order to convert class IDs into labels. "
                     "A label file is a simple text file where each line corresponds to a label"))
 @click.option('--viz_file',
@@ -436,13 +436,13 @@ def pipeline_nlp(ctx: click.Context, **kwargs):
               help="Number of features trained in the model")
 @click.option('--labels_file',
               default=None,
-              type=MorpheusRelativePath(dir_okay=False, exists=True, file_okay=True),
+              type=MorpheusRelativePath(dir_okay=False, exists=True, file_okay=True, resolve_path=True),
               help=("Specifies a file to read labels from in order to convert class IDs into labels. "
                     "A label file is a simple text file where each line corresponds to a label. "
                     "If unspecified, only a single output label is created for FIL"))
 @click.option('--columns_file',
               default="data/columns_fil.txt",
-              type=MorpheusRelativePath(dir_okay=False, exists=True, file_okay=True),
+              type=MorpheusRelativePath(dir_okay=False, exists=True, file_okay=True, resolve_path=True),
               help=("Specifies a file to read column features."))
 @click.option('--viz_file',
               default=None,
@@ -505,11 +505,11 @@ def pipeline_fil(ctx: click.Context, **kwargs):
              **command_kwargs)
 @click.option('--columns_file',
               default="data/columns_ae.txt",
-              type=MorpheusRelativePath(dir_okay=False, exists=True, file_okay=True),
+              type=MorpheusRelativePath(dir_okay=False, exists=True, file_okay=True, resolve_path=True),
               help=(""))
 @click.option('--labels_file',
               default=None,
-              type=MorpheusRelativePath(dir_okay=False, exists=True, file_okay=True),
+              type=MorpheusRelativePath(dir_okay=False, exists=True, file_okay=True, resolve_path=True),
               help=("Specifies a file to read labels from in order to convert class IDs into labels. "
                     "A label file is a simple text file where each line corresponds to a label. "
                     "If unspecified, only a single output label is created for FIL"))
@@ -896,7 +896,7 @@ def train_ae(ctx: click.Context, **kwargs):
 @click.command(name="preprocess", short_help="Convert messages to tokens", **command_kwargs)
 @click.option('--vocab_hash_file',
               default="data/bert-base-cased-hash.txt",
-              type=MorpheusRelativePath(exists=True, dir_okay=False),
+              type=MorpheusRelativePath(exists=True, dir_okay=False, resolve_path=True),
               help=("Path to hash file containing vocabulary of words with token-ids. "
                     "This can be created from the raw vocabulary using the cudf.utils.hash_vocab_utils.hash_vocab "
                     "function."))


### PR DESCRIPTION
In PR #130 we moved the `data` directory into `morpheus/data` and installed it with the python package. This required changing some of the default CLI arguments from relative paths like `data/labels_nlp.txt` to absolute paths like `morpheus.DATA_DIR/labels_nlp.txt`.

To make it easy for the user to see how to change the labels file, we respecified the default argument value in documentation (i.e. `--labels_file=data/labels_nlp.txt`). Now that this needs to be an absolute path, the command in the documentation does not work. Adding absolute paths in the documentation is not feasible since this would require very long paths that would change from machine to machine.

Instead, if the user specifies a data file with a relative path, we first check to see if a file exists relative to the current working directory. If it doesnt exist, then we check for a relative file to the current morpheus install. This allows commands from the documentation like: `morpheus run pipeline-nlp --labels_file=data/labels_nlp.txt` to find the correct path. We only choose the fallback value when no other file is found.

Related to PR #200 