### PR TITLE
Missing 'supports_cpp_node' impl function

### DIFF
--- a/examples/log_parsing/postprocessing.py
+++ b/examples/log_parsing/postprocessing.py
@@ -50,6 +50,9 @@ class LogParsingPostProcessingStage(SinglePortStage):
     def name(self) -> str:
         return "logparsing-postproc"
 
+    def supports_cpp_node(self):
+        return False
+
     def accepted_types(self) -> typing.Tuple:
         return (MultiResponseLogParsingMessage, )
 

--- a/examples/log_parsing/preprocessing.py
+++ b/examples/log_parsing/preprocessing.py
@@ -83,6 +83,9 @@ class PreprocessLogParsingStage(PreprocessBaseStage):
     def name(self) -> str:
         return "preprocess-logparsing"
 
+    def supports_cpp_node(self):
+        return False
+
     @staticmethod
     def pre_process_batch(x: MultiMessage,
                           vocab_hash_file: str,


### PR DESCRIPTION
Added missing abstract implementation function to `log_parsing` example preproc and postproc stages.