### PR TITLE
[gpuCI] Forward-merge branch-22.06 to branch-22.08 [skip gpuci]

### DIFF
--- a/docker/conda/environments/cuda11.5_dev.yml
+++ b/docker/conda/environments/cuda11.5_dev.yml
@@ -29,6 +29,7 @@ dependencies:
     - ccache>=3.7
     - cmake=3.22
     - cuda-nvml-dev=11.5
+    - cuda-python<=11.7.0 # 11.7.1 Breaks the cuda bindings
     - cudatoolkit=11.5
     - cudf 22.06
     - cudf_kafka 22.06.*


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.06` that creates a PR to keep `branch-22.08` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.