### PR TITLE
Pin Conda Package `cuda-python <=11.7.0` to Fix Conda Build

### DIFF
--- a/ci/conda/recipes/morpheus/meta.yaml
+++ b/ci/conda/recipes/morpheus/meta.yaml
@@ -55,7 +55,7 @@ outputs:
         - ccache
         - ninja
       host:
-        - cuda-python <=11.7.0
+        - cuda-python <=11.7.0 # Remove when Issue #251 is closed
         - cudf {{ rapids_version }}
         - cython >=0.29,<0.30
         - libcudf {{ rapids_version }}
@@ -69,7 +69,7 @@ outputs:
         - versioneer-518
       run:
         - click >=8
-        - cuda-python <=11.7.0
+        - cuda-python <=11.7.0 # Remove when Issue #251 is closed
         - cudf {{ rapids_version }}
         - cudf_kafka {{ rapids_version }}
         - cupy # Version determined from cudf

--- a/ci/conda/recipes/morpheus/meta.yaml
+++ b/ci/conda/recipes/morpheus/meta.yaml
@@ -55,7 +55,7 @@ outputs:
         - ccache
         - ninja
       host:
-        - cuda-python <= 11.7.0
+        - cuda-python <=11.7.0
         - cudf {{ rapids_version }}
         - cython >=0.29,<0.30
         - libcudf {{ rapids_version }}
@@ -69,7 +69,7 @@ outputs:
         - versioneer-518
       run:
         - click >=8
-        - cuda-python <= 11.7.0
+        - cuda-python <=11.7.0
         - cudf {{ rapids_version }}
         - cudf_kafka {{ rapids_version }}
         - cupy # Version determined from cudf

--- a/ci/conda/recipes/morpheus/meta.yaml
+++ b/ci/conda/recipes/morpheus/meta.yaml
@@ -55,19 +55,21 @@ outputs:
         - ccache
         - ninja
       host:
+        - cuda-python <= 11.7.0
         - cudf {{ rapids_version }}
         - cython >=0.29,<0.30
         - libcudf {{ rapids_version }}
         - librdkafka 1.7
-        - srf {{ minor_version }}
         - pip
         - pybind11-stubgen
         - python {{ python }}
         - rapidjson 1.1
         - scikit-build >=0.12
+        - srf {{ minor_version }}
         - versioneer-518
       run:
         - click >=8
+        - cuda-python <= 11.7.0
         - cudf {{ rapids_version }}
         - cudf_kafka {{ rapids_version }}
         - cupy # Version determined from cudf

--- a/docker/conda/environments/cuda11.5_dev.yml
+++ b/docker/conda/environments/cuda11.5_dev.yml
@@ -29,7 +29,7 @@ dependencies:
     - ccache>=3.7
     - cmake=3.22
     - cuda-nvml-dev=11.5
-    - cuda-python<=11.7.0 # 11.7.1 Breaks the cuda bindings
+    - cuda-python<=11.7.0 # Remove when Issue #251 is closed
     - cudatoolkit=11.5
     - cudf 22.06
     - cudf_kafka 22.06.*


### PR DESCRIPTION
The release of `cuda-python=11.7.1` has broken both the builds and the CI. See PR #246 which fixed the CI. This PR fixes the conda build.

Issue #251 has been created to remove this dependency in the future.

Fixes #250 