### PR TITLE
[gpuCI] Forward-merge branch-22.06 to branch-22.08 [skip gpuci]

### DIFF
--- a/ci/conda/recipes/morpheus/meta.yaml
+++ b/ci/conda/recipes/morpheus/meta.yaml
@@ -55,19 +55,21 @@ outputs:
         - ccache
         - ninja
       host:
+        - cuda-python <=11.7.0 # Remove when Issue #251 is closed
         - cudf {{ rapids_version }}
         - cython >=0.29,<0.30
         - libcudf {{ rapids_version }}
         - librdkafka 1.7
-        - srf {{ minor_version }}
         - pip
         - pybind11-stubgen
         - python {{ python }}
         - rapidjson 1.1
         - scikit-build >=0.12
+        - srf {{ minor_version }}
         - versioneer-518
       run:
         - click >=8
+        - cuda-python <=11.7.0 # Remove when Issue #251 is closed
         - cudf {{ rapids_version }}
         - cudf_kafka {{ rapids_version }}
         - cupy # Version determined from cudf

--- a/docker/conda/environments/cuda11.5_dev.yml
+++ b/docker/conda/environments/cuda11.5_dev.yml
@@ -29,7 +29,7 @@ dependencies:
     - ccache>=3.7
     - cmake=3.22
     - cuda-nvml-dev=11.5
-    - cuda-python<=11.7.0 # 11.7.1 Breaks the cuda bindings
+    - cuda-python<=11.7.0 # Remove when Issue #251 is closed
     - cudatoolkit=11.5
     - cudf 22.06
     - cudf_kafka 22.06.*


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.06` that creates a PR to keep `branch-22.08` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.