### PR TITLE
Fixing Python Kafka Source with Multiple Threads

### DIFF
--- a/morpheus/pipeline/source_stage.py
+++ b/morpheus/pipeline/source_stage.py
@@ -99,8 +99,5 @@ class SourceStage(_pipeline.StreamWrapper):
     def _start(self):
         self._source_stream.start()
 
-    def stop(self):
-        self._source_stream.stop()
-
     async def join(self):
         pass


### PR DESCRIPTION
A small regression in PR #257 that would duplicate messages in the `from-kafka` stage when `--use_cpp=False`. If you used 3 threads you would process each message in Kafka 3 times instead of dividing the messages between threads.

This also improves the shutdown behavior of the `from-kafka` stage when pressing Ctrl+C to close the pipeline.