### PR TITLE
[gpuCI] Forward-merge branch-22.06 to branch-22.08 [skip gpuci]

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # This file controls which features from the `ops-bot` repository below are enabled.
 # - https://github.com/rapidsai/ops-bot
 

--- a/cmake/deps/Configure_srf.cmake
+++ b/cmake/deps/Configure_srf.cmake
@@ -38,7 +38,7 @@ function(find_and_configure_srf version)
                       "SRF_USE_CONDA ${MORPHEUS_USE_CONDA}"
                       "SRF_USE_CCACHE ${MORPHEUS_USE_CCACHE}"
                       "SRF_USE_CLANG_TIDY ${MORPHEUS_USE_CLANG_TIDY}"
-                      "SRF_PYTHON_INPLACE_BUILD ${MORPHEUS_PYTHON_INPLACE_BUILD}"
+                      "SRF_PYTHON_INPLACE_BUILD OFF"
                       "SRF_PYTHON_PERFORM_INSTALL ON"
                       "SRF_PYTHON_BUILD_STUBS ${MORPHEUS_BUILD_PYTHON_STUBS}"
                       "RMM_VERSION ${RAPIDS_VERSION}"

--- a/morpheus/pipeline/source_stage.py
+++ b/morpheus/pipeline/source_stage.py
@@ -99,8 +99,5 @@ class SourceStage(_pipeline.StreamWrapper):
     def _start(self):
         self._source_stream.start()
 
-    def stop(self):
-        self._source_stream.stop()
-
     async def join(self):
         pass


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.06` that creates a PR to keep `branch-22.08` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.