### PR TITLE
Ensure TableInfo only appears in one lib

### DIFF
--- a/morpheus/_lib/cmake/libraries/cuda_utils.cmake
+++ b/morpheus/_lib/cmake/libraries/cuda_utils.cmake
@@ -12,6 +12,10 @@
 # the License.
 # =============================================================================
 
+list(APPEND CMAKE_MESSAGE_CONTEXT "cuda_utils")
+
+find_package(pybind11 REQUIRED)
+
 add_library(cuda_utils
     SHARED
       ${MORPHEUS_LIB_ROOT}/src/objects/dev_mem_info.cpp
@@ -34,6 +38,7 @@ target_link_libraries(cuda_utils
       matx::matx
       cudf::cudf
       Python3::NumPy
+      pybind11::pybind11
 )
 
 set_target_properties(cuda_utils
@@ -54,3 +59,5 @@ install(
 if (MORPHEUS_PYTHON_INPLACE_BUILD)
   inplace_build_copy(cuda_utils ${MORPHEUS_LIB_ROOT})
 endif()
+
+list(POP_BACK CMAKE_MESSAGE_CONTEXT)

--- a/morpheus/_lib/cmake/libraries/morpheus.cmake
+++ b/morpheus/_lib/cmake/libraries/morpheus.cmake
@@ -34,7 +34,6 @@ add_library(morpheus
     ${MORPHEUS_LIB_ROOT}/src/objects/wrapped_tensor.cpp
     ${MORPHEUS_LIB_ROOT}/src/objects/python_data_table.cpp
     ${MORPHEUS_LIB_ROOT}/src/objects/rmm_tensor.cpp
-    ${MORPHEUS_LIB_ROOT}/src/objects/table_info.cpp
     ${MORPHEUS_LIB_ROOT}/src/objects/tensor.cpp
     ${MORPHEUS_LIB_ROOT}/src/stages/add_classification.cpp
     ${MORPHEUS_LIB_ROOT}/src/stages/add_scores.cpp
@@ -57,6 +56,7 @@ add_library(${PROJECT_NAME}::morpheus ALIAS morpheus)
 
 target_link_libraries(morpheus
     PUBLIC
+      cuda_utils
       ${cudf_helpers_target}
       TritonClient::httpclient_static
       RDKAFKA::RDKAFKA

--- a/morpheus/_lib/include/morpheus/objects/table_info.hpp
+++ b/morpheus/_lib/include/morpheus/objects/table_info.hpp
@@ -74,9 +74,11 @@ struct TableInfo
     cudf::size_type num_rows() const;
 
     /**
-     * TODO(Documentation)
+     * @brief Returns the underlying cuDF DataFrame as a python object
+     *
+     * Note: The attribute is needed here as pybind11 requires setting symbol visibility to hidden by default.
      */
-    pybind11::object as_py_object() const;
+    pybind11::object __attribute__((visibility("default"))) as_py_object() const;
 
     /**
      * TODO(Documentation)
@@ -104,4 +106,5 @@ struct TableInfo
     std::vector<std::string> m_column_names;
     std::vector<std::string> m_index_names;
 };
+
 }  // namespace morpheus


### PR DESCRIPTION
* Removes `table_info.cpp` from `morpheus.cmake`
* Sets visibility on the `TableInfo.as_py_object` method, this was showing up as undefined in `libmorpheus.so`. 

I tried just setting `#pragma GCC visibility push(default)` at the top of the class definition, but this didn't work, according to the gcc docs this is intentional:
> In C++, ‘#pragma GCC visibility’ affects only namespace-scope declarations. Class members and template specializations are not affected; if you want to override the visibility for a particular member or instantiation, you must use an attribute.
https://gcc.gnu.org/onlinedocs/gcc-4.9.2/gcc/Visibility-Pragmas.html

fixes #271