### PR TITLE
MonitorStage add a blank space between the rate and the unit description

### DIFF
--- a/morpheus/stages/general/monitor_stage.py
+++ b/morpheus/stages/general/monitor_stage.py
@@ -206,7 +206,7 @@ class MonitorStage(SinglePortStage):
             self._progress = MorpheusTqdm(desc=self._description,
                                           smoothing=self._smoothing,
                                           dynamic_ncols=True,
-                                          unit=" {}".format(self._unit),
+                                          unit=(self._unit if self._unit.startswith(" ") else " {}".format(self._unit)),
                                           mininterval=0.25,
                                           maxinterval=1.0,
                                           miniters=1,

--- a/morpheus/stages/general/monitor_stage.py
+++ b/morpheus/stages/general/monitor_stage.py
@@ -206,7 +206,7 @@ class MonitorStage(SinglePortStage):
             self._progress = MorpheusTqdm(desc=self._description,
                                           smoothing=self._smoothing,
                                           dynamic_ncols=True,
-                                          unit=self._unit,
+                                          unit=" {}".format(self._unit),
                                           mininterval=0.25,
                                           maxinterval=1.0,
                                           miniters=1,


### PR DESCRIPTION
Improves readability of the output from the monitor stage
Changes output from:
```
FromFile rate[Complete]: 93085messages [00:01, 89424.59messages/s]
```

To:
```
FromFile rate[Complete]: 93085 messages [00:01, 89424.59 messages/s]
```

All I did was just insert a blank space in front of the unit name. As far as I can tell tqdm doesn't give control over the `rate_fmt`:
https://github.com/tqdm/tqdm/blob/master/tqdm/std.py#L445