### PR TITLE
Draft: Update include ordering and style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -66,20 +66,42 @@ ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
-IncludeBlocks: Preserve
+IncludeBlocks: Regroup
 IncludeCategories:
-  - Regex:           '^<ext/.*\.h>'
-    Priority:        2
-  - Regex:           '^<.*\.h>'
-    Priority:        1
-  - Regex:           '^<.*'
-    Priority:        2
-  - Regex:           '.*'
+  # The order of the groups is
+  # 0 - Main include file for .cpp
+  # 1 - source relative files `#include "./some_header.hpp"` (Grouped with 2)
+  # 2 - source relative files starting with internal/public `#include "internal/some_header.hpp"`
+  # 3 - Python SRF public API files `#include "pysrf/srf_header.hpp"`
+  # 4 - SRF public API files `#include "srf/srf_header.hpp"`
+  # 5 - NVRPC public API files `#include "nvrpc/some_header.hpp"`
+  # 6 - External installed libraries `#include <external_lib/some_header.hpp>`
+  # 7 - System includes `#include <string>`
+  # First match any Python SRF public API headers with quotes
+  - Regex:           '^"pysrf\/.*\.(h|hpp)"'
     Priority:        3
+  # Next match any SRF public API headers with quotes
+  - Regex:           '^"srf\/.*\.(h|hpp)"'
+    Priority:        4
+  # Next match public NVRPC headers with quotes
+  - Regex:           '^<nvrpc\/.*\.(h|hpp)>'
+    Priority:        5
+  # Next find any headers in internal or public
+  - Regex:           '^"(internal|public)\/.*\.(h|hpp)"'
+    Priority:        2
+  # Any other quoted includes need to be with internal/public but on top (Thats why this group is last)
+  - Regex:           '^".*\.(h|hpp)"'
+    Priority:        1
+  # Last is system includes which dont have a '/' like <string> or <mutex>
+  - Regex:           '<([a-z_])+>'
+    Priority:        7
+  # Finally, put all 3rd party includes before the system includes
+  - Regex:           '^<.*'
+    Priority:        6
 IncludeIsMainRegex: '([-_](test|unittest))?$'
 IndentCaseBlocks: false
 IndentCaseLabels: false
-IndentPPDirectives: None
+IndentPPDirectives: BeforeHash
 IndentWidth:     4
 IndentWrappedFunctionNames: false
 JavaScriptQuotes: Leave
@@ -148,7 +170,7 @@ SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard: Cpp11
+Standard: c++17
 StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION

--- a/.clang-format
+++ b/.clang-format
@@ -71,33 +71,21 @@ IncludeCategories:
   # The order of the groups is
   # 0 - Main include file for .cpp
   # 1 - source relative files `#include "./some_header.hpp"` (Grouped with 2)
-  # 2 - source relative files starting with internal/public `#include "internal/some_header.hpp"`
-  # 3 - Python SRF public API files `#include "pysrf/srf_header.hpp"`
-  # 4 - SRF public API files `#include "srf/srf_header.hpp"`
-  # 5 - NVRPC public API files `#include "nvrpc/some_header.hpp"`
-  # 6 - External installed libraries `#include <external_lib/some_header.hpp>`
-  # 7 - System includes `#include <string>`
-  # First match any Python SRF public API headers with quotes
-  - Regex:           '^"pysrf\/.*\.(h|hpp)"'
-    Priority:        3
-  # Next match any SRF public API headers with quotes
-  - Regex:           '^"srf\/.*\.(h|hpp)"'
-    Priority:        4
-  # Next match public NVRPC headers with quotes
-  - Regex:           '^<nvrpc\/.*\.(h|hpp)>'
-    Priority:        5
-  # Next find any headers in internal or public
-  - Regex:           '^"(internal|public)\/.*\.(h|hpp)"'
+  # 2 - Morpheus API files `#include "morpheus/messages/meta.hpp`
+  # 3 - External installed libraries `#include <external_lib/some_header.hpp>`
+  # 4 - System includes `#include <string>`
+  # First match any Morpheus  headers
+  - Regex:           '^"morpheus\/.*\.(h|hpp)"'
     Priority:        2
-  # Any other quoted includes need to be with internal/public but on top (Thats why this group is last)
+  # Any relative quoted includes need to be with internal/public but on top (Thats why this group is last)
   - Regex:           '^".*\.(h|hpp)"'
     Priority:        1
   # Last is system includes which dont have a '/' like <string> or <mutex>
   - Regex:           '<([a-z_])+>'
-    Priority:        7
+    Priority:        4
   # Finally, put all 3rd party includes before the system includes
   - Regex:           '^<.*'
-    Priority:        6
+    Priority:        3
 IncludeIsMainRegex: '([-_](test|unittest))?$'
 IndentCaseBlocks: false
 IndentCaseLabels: false

--- a/ci/scripts/cpp_checks.sh
+++ b/ci/scripts/cpp_checks.sh
@@ -27,6 +27,7 @@ if [[ "${SKIP_IWYU}" == "" && -z "${IWYU_TOOL}" ]]; then
 fi
 
 # Pre-populate the return values in case they are skipped
+PRAGMA_CHECK_RETVAL=0
 CLANG_TIDY_RETVAL=0
 CLANG_FORMAT_RETVAL=0
 IWYU_RETVAL=0
@@ -41,6 +42,16 @@ if [[ -n "${MORPHEUS_MODIFIED_FILES}" ]]; then
    for f in "${MORPHEUS_MODIFIED_FILES[@]}"; do
       echo "  $f"
    done
+
+   # Check for `#pragma once` in any .hpp or .h file
+   if [[ "${SKIP_PRAGMA_CHECK}" == "" ]]; then
+
+      PRAGMA_CHECK_OUTPUT=`grep -rL --include=\*.{h,hpp} --exclude-dir={build,.cache} -e '#pragma once' $(get_modified_files $CPP_FILE_REGEX)`
+
+      if [[ -n "${PRAGMA_CHECK_OUTPUT}" ]]; then
+         PRAGMA_CHECK_RETVAL=1
+      fi
+   fi
 
    # Clang-tidy
    if [[ "${SKIP_CLANG_TIDY}" == "" ]]; then
@@ -79,6 +90,19 @@ else
 fi
 
 # Now check the values
+if [[ "${SKIP_PRAGMA_CHECK}" != "" ]]; then
+   echo -e "\n\n>>>> SKIPPED: pragma check\n\n"
+elif [[ "${PRAGMA_CHECK_RETVAL}" != "0" ]]; then
+   echo -e "\n\n>>>> FAILED: pragma check; begin output\n\n"
+   echo -e "Missing \`#pragma once\` in the following files:"
+   echo -e "${PRAGMA_CHECK_OUTPUT}"
+   echo -e "\n\n>>>> FAILED: pragma check; end output\n\n" \
+           "To auto-fix many issues (not all) run:\n" \
+           "   ./ci/scripts/fix_all.sh\n\n"
+else
+   echo -e "\n\n>>>> PASSED: pragma check\n\n"
+fi
+
 if [[ "${SKIP_CLANG_TIDY}" != "" ]]; then
    echo -e "\n\n>>>> SKIPPED: clang-tidy check\n\n"
 elif [[ "${CLANG_TIDY_RETVAL}" != "0" ]]; then

--- a/ci/scripts/jenkins/checks.sh
+++ b/ci/scripts/jenkins/checks.sh
@@ -30,5 +30,8 @@ show_conda_info
 gpuci_logger "Runing Python style checks"
 ${MORPHEUS_ROOT}/ci/scripts/python_checks.sh
 
+gpuci_logger "Runing C++ style checks"
+${MORPHEUS_ROOT}/ci/scripts/cpp_checks.sh
+
 gpuci_logger "Checking copyright headers"
 python ${MORPHEUS_ROOT}/ci/scripts/copyright.py --verify-apache-v2 --git-diff-commits ${CHANGE_TARGET} ${GIT_COMMIT}

--- a/morpheus/_lib/include/morpheus/io/serializers.hpp
+++ b/morpheus/_lib/include/morpheus/io/serializers.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <morpheus/objects/table_info.hpp>
+#include "morpheus/objects/table_info.hpp"
 
 #include <ostream>
 #include <string>

--- a/morpheus/_lib/include/morpheus/messages/memory/inference_memory.hpp
+++ b/morpheus/_lib/include/morpheus/messages/memory/inference_memory.hpp
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#include <morpheus/objects/tensor.hpp>
-#include <morpheus/objects/tensor_object.hpp>
+#include "morpheus/objects/tensor.hpp"
+#include "morpheus/objects/tensor_object.hpp"
 
 #include <cstddef>
 #include <map>

--- a/morpheus/_lib/include/morpheus/messages/memory/inference_memory_fil.hpp
+++ b/morpheus/_lib/include/morpheus/messages/memory/inference_memory_fil.hpp
@@ -17,13 +17,12 @@
 
 #pragma once
 
-#include <morpheus/messages/memory/inference_memory.hpp>
-#include <morpheus/objects/python_data_table.hpp>
-#include <morpheus/objects/tensor.hpp>
-#include <morpheus/objects/tensor_object.hpp>
+#include "morpheus/messages/memory/inference_memory.hpp"
+#include "morpheus/objects/python_data_table.hpp"
+#include "morpheus/objects/tensor.hpp"
+#include "morpheus/objects/tensor_object.hpp"
 
 #include <cudf/io/types.hpp>
-
 #include <pybind11/pybind11.h>
 
 #include <cstddef>

--- a/morpheus/_lib/include/morpheus/messages/memory/inference_memory_nlp.hpp
+++ b/morpheus/_lib/include/morpheus/messages/memory/inference_memory_nlp.hpp
@@ -17,9 +17,9 @@
 
 #pragma once
 
-#include <morpheus/messages/memory/inference_memory.hpp>
-#include <morpheus/objects/tensor.hpp>
-#include <morpheus/objects/tensor_object.hpp>
+#include "morpheus/messages/memory/inference_memory.hpp"
+#include "morpheus/objects/tensor.hpp"
+#include "morpheus/objects/tensor_object.hpp"
 
 #include <pybind11/pytypes.h>
 

--- a/morpheus/_lib/include/morpheus/messages/memory/response_memory.hpp
+++ b/morpheus/_lib/include/morpheus/messages/memory/response_memory.hpp
@@ -17,10 +17,10 @@
 
 #pragma once
 
-#include <morpheus/objects/tensor.hpp>
+#include "morpheus/objects/tensor.hpp"
 
-#include <pybind11/pytypes.h>
 #include <cudf/io/types.hpp>
+#include <pybind11/pytypes.h>
 
 #include <string>
 #include <vector>

--- a/morpheus/_lib/include/morpheus/messages/memory/response_memory_probs.hpp
+++ b/morpheus/_lib/include/morpheus/messages/memory/response_memory_probs.hpp
@@ -17,13 +17,12 @@
 
 #pragma once
 
-#include <morpheus/messages/memory/response_memory.hpp>
-#include <morpheus/objects/tensor.hpp>
-#include <morpheus/objects/tensor_object.hpp>
+#include "morpheus/messages/memory/response_memory.hpp"
+#include "morpheus/objects/tensor.hpp"
+#include "morpheus/objects/tensor_object.hpp"
 
 #include <cudf/io/types.hpp>
 #include <cudf/types.hpp>
-
 #include <pybind11/pytypes.h>
 
 #include <cstddef>

--- a/morpheus/_lib/include/morpheus/messages/meta.hpp
+++ b/morpheus/_lib/include/morpheus/messages/meta.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <morpheus/objects/table_info.hpp>
+#include "morpheus/objects/table_info.hpp"
 
 #include <cudf/io/types.hpp>
 #include <pybind11/pybind11.h>
@@ -26,76 +26,77 @@
 #include <string>
 
 namespace morpheus {
-    /****** Component public implementations ******************/
-    /****** MessageMeta****************************************/
+/****** Component public implementations ******************/
+/****** MessageMeta****************************************/
+/**
+ * TODO(Documentation)
+ */
+#pragma GCC visibility push(default)
+class MessageMeta
+{
+  public:
     /**
      * TODO(Documentation)
      */
-#pragma GCC visibility push(default)
-    class MessageMeta {
-    public:
-        /**
-         * TODO(Documentation)
-         */
-        pybind11::object get_py_table() const;
+    pybind11::object get_py_table() const;
 
-        /**
-         * TODO(Documentation)
-         */
-        size_t count() const;
-
-        /**
-         * TODO(Documentation)
-         */
-        TableInfo get_info() const;
-
-        /**
-         * TODO(Documentation)
-         */
-        static std::shared_ptr<MessageMeta> create_from_python(pybind11::object &&data_table);
-
-        /**
-         * TODO(Documentation)
-         */
-        static std::shared_ptr<MessageMeta> create_from_cpp(cudf::io::table_with_metadata &&data_table,
-                                                            int index_col_count = 0);
-
-    private:
-        MessageMeta(std::shared_ptr<IDataTable> data);
-
-        /**
-         * TODO(Documentation)
-         */
-        static pybind11::object cpp_to_py(cudf::io::table_with_metadata &&table, int index_col_count = 0);
-
-        std::shared_ptr<IDataTable> m_data;
-    };
-
-
-    /****** MessageMetaInterfaceProxy**************************/
     /**
-     * @brief Interface proxy, used to insulate python bindings.
+     * TODO(Documentation)
      */
-    struct MessageMetaInterfaceProxy {
-        /**
-         * TODO(Documentation)
-         */
-        static std::shared_ptr<MessageMeta> init_cpp(const std::string& filename);
+    size_t count() const;
 
-        /**
-         * TODO(Documentation)
-         */
-        static std::shared_ptr<MessageMeta> init_python(pybind11::object&& data_frame);
+    /**
+     * TODO(Documentation)
+     */
+    TableInfo get_info() const;
 
-        /**
-         * TODO(Documentation)
-         */
-        static cudf::size_type count(MessageMeta& self);
+    /**
+     * TODO(Documentation)
+     */
+    static std::shared_ptr<MessageMeta> create_from_python(pybind11::object&& data_table);
 
-        /**
-         * TODO(Documentation)
-         */
-        static pybind11::object get_data_frame(MessageMeta& self);
-    };
+    /**
+     * TODO(Documentation)
+     */
+    static std::shared_ptr<MessageMeta> create_from_cpp(cudf::io::table_with_metadata&& data_table,
+                                                        int index_col_count = 0);
+
+  private:
+    MessageMeta(std::shared_ptr<IDataTable> data);
+
+    /**
+     * TODO(Documentation)
+     */
+    static pybind11::object cpp_to_py(cudf::io::table_with_metadata&& table, int index_col_count = 0);
+
+    std::shared_ptr<IDataTable> m_data;
+};
+
+/****** MessageMetaInterfaceProxy**************************/
+/**
+ * @brief Interface proxy, used to insulate python bindings.
+ */
+struct MessageMetaInterfaceProxy
+{
+    /**
+     * TODO(Documentation)
+     */
+    static std::shared_ptr<MessageMeta> init_cpp(const std::string& filename);
+
+    /**
+     * TODO(Documentation)
+     */
+    static std::shared_ptr<MessageMeta> init_python(pybind11::object&& data_frame);
+
+    /**
+     * TODO(Documentation)
+     */
+    static cudf::size_type count(MessageMeta& self);
+
+    /**
+     * TODO(Documentation)
+     */
+    static pybind11::object get_data_frame(MessageMeta& self);
+};
 #pragma GCC visibility pop
-}
+}  // namespace morpheus

--- a/morpheus/_lib/include/morpheus/messages/multi.hpp
+++ b/morpheus/_lib/include/morpheus/messages/multi.hpp
@@ -17,16 +17,15 @@
 
 #pragma once
 
-#include <morpheus/messages/meta.hpp>
-#include <morpheus/objects/table_info.hpp>
-#include <morpheus/objects/tensor.hpp>
-#include <morpheus/objects/tensor_object.hpp>
+#include "morpheus/messages/meta.hpp"
+#include "morpheus/objects/table_info.hpp"
+#include "morpheus/objects/tensor.hpp"
+#include "morpheus/objects/tensor_object.hpp"
 
 #include <cudf/copying.hpp>
 #include <cudf/io/types.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
-
 #include <pybind11/cast.h>
 #include <pybind11/gil.h>
 #include <pybind11/pybind11.h>

--- a/morpheus/_lib/include/morpheus/messages/multi_inference.hpp
+++ b/morpheus/_lib/include/morpheus/messages/multi_inference.hpp
@@ -17,14 +17,14 @@
 
 #pragma once
 
-#include <morpheus/messages/memory/inference_memory.hpp>
-#include <morpheus/messages/meta.hpp>
-#include <morpheus/messages/multi.hpp>
-#include <morpheus/objects/tensor.hpp>
-#include <morpheus/objects/tensor_object.hpp>
+#include "morpheus/messages/memory/inference_memory.hpp"
+#include "morpheus/messages/meta.hpp"
+#include "morpheus/messages/multi.hpp"
+#include "morpheus/objects/tensor.hpp"
+#include "morpheus/objects/tensor_object.hpp"
 
-#include <pybind11/pytypes.h>
 #include <cudf/types.hpp>
+#include <pybind11/pytypes.h>
 
 #include <cstddef>
 #include <memory>

--- a/morpheus/_lib/include/morpheus/messages/multi_inference_fil.hpp
+++ b/morpheus/_lib/include/morpheus/messages/multi_inference_fil.hpp
@@ -17,9 +17,9 @@
 
 #pragma once
 
-#include <morpheus/messages/multi_inference.hpp>
-#include <morpheus/objects/tensor.hpp>
-#include <morpheus/objects/tensor_object.hpp>
+#include "morpheus/messages/multi_inference.hpp"
+#include "morpheus/objects/tensor.hpp"
+#include "morpheus/objects/tensor_object.hpp"
 
 #include <cudf/io/types.hpp>
 #include <cudf/types.hpp>

--- a/morpheus/_lib/include/morpheus/messages/multi_inference_nlp.hpp
+++ b/morpheus/_lib/include/morpheus/messages/multi_inference_nlp.hpp
@@ -17,12 +17,11 @@
 
 #pragma once
 
-#include <morpheus/messages/multi_inference.hpp>
-#include <morpheus/objects/tensor.hpp>
-#include <morpheus/objects/tensor_object.hpp>
+#include "morpheus/messages/multi_inference.hpp"
+#include "morpheus/objects/tensor.hpp"
+#include "morpheus/objects/tensor_object.hpp"
 
 #include <cudf/types.hpp>
-
 #include <pybind11/pybind11.h>
 
 #include <cstddef>

--- a/morpheus/_lib/include/morpheus/messages/multi_response.hpp
+++ b/morpheus/_lib/include/morpheus/messages/multi_response.hpp
@@ -17,16 +17,15 @@
 
 #pragma once
 
-#include <morpheus/messages/memory/response_memory.hpp>
-#include <morpheus/messages/meta.hpp>
-#include <morpheus/messages/multi.hpp>
-#include <morpheus/objects/table_info.hpp>
-#include <morpheus/objects/tensor.hpp>
-#include <morpheus/objects/tensor_object.hpp>
-#include <morpheus/utilities/table_util.hpp>
+#include "morpheus/messages/memory/response_memory.hpp"
+#include "morpheus/messages/meta.hpp"
+#include "morpheus/messages/multi.hpp"
+#include "morpheus/objects/table_info.hpp"
+#include "morpheus/objects/tensor.hpp"
+#include "morpheus/objects/tensor_object.hpp"
+#include "morpheus/utilities/table_util.hpp"
 
 #include <cudf/types.hpp>
-
 #include <pybind11/pytypes.h>
 
 #include <cstddef>

--- a/morpheus/_lib/include/morpheus/messages/multi_response_probs.hpp
+++ b/morpheus/_lib/include/morpheus/messages/multi_response_probs.hpp
@@ -17,15 +17,15 @@
 
 #pragma once
 
-#include <morpheus/messages/memory/response_memory.hpp>
-#include <morpheus/messages/meta.hpp>
-#include <morpheus/messages/multi.hpp>
-#include <morpheus/messages/multi_response.hpp>
-#include <morpheus/objects/tensor.hpp>
-#include <morpheus/objects/tensor_object.hpp>
+#include "morpheus/messages/memory/response_memory.hpp"
+#include "morpheus/messages/meta.hpp"
+#include "morpheus/messages/multi.hpp"
+#include "morpheus/messages/multi_response.hpp"
+#include "morpheus/objects/tensor.hpp"
+#include "morpheus/objects/tensor_object.hpp"
 
-#include <pybind11/pytypes.h>
 #include <cudf/types.hpp>
+#include <pybind11/pytypes.h>
 
 #include <memory>
 

--- a/morpheus/_lib/include/morpheus/objects/dev_mem_info.hpp
+++ b/morpheus/_lib/include/morpheus/objects/dev_mem_info.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <morpheus/utilities/type_util_detail.hpp>
+#include "morpheus/utilities/type_util_detail.hpp"
 
 #include <rmm/device_buffer.hpp>
 

--- a/morpheus/_lib/include/morpheus/objects/python_data_table.hpp
+++ b/morpheus/_lib/include/morpheus/objects/python_data_table.hpp
@@ -17,36 +17,37 @@
 
 #pragma once
 
-#include <morpheus/objects/table_info.hpp>
+#include "morpheus/objects/table_info.hpp"
 
 #include <pybind11/pybind11.h>
 
 namespace morpheus {
-    /****** Component public implementations *******************/
-    /****** PyDataTable****************************************/
+/****** Component public implementations *******************/
+/****** PyDataTable****************************************/
+/**
+ * TODO(Documentation)
+ */
+struct PyDataTable : public IDataTable
+{
+    PyDataTable(pybind11::object &&py_table);
+    ~PyDataTable();
+
     /**
      * TODO(Documentation)
      */
-    struct PyDataTable : public IDataTable {
-        PyDataTable(pybind11::object &&py_table);
-        ~PyDataTable();
+    cudf::size_type count() const override;
 
-        /**
-         * TODO(Documentation)
-         */
-        cudf::size_type count() const override;
+    /**
+     * TODO(Documentation)
+     */
+    TableInfo get_info() const override;
 
-        /**
-         * TODO(Documentation)
-         */
-        TableInfo get_info() const override;
+    /**
+     * TODO(Documentation)
+     */
+    const pybind11::object &get_py_object() const override;
 
-        /**
-         * TODO(Documentation)
-         */
-        const pybind11::object &get_py_object() const override;
-
-    private:
-        pybind11::object m_py_table;
-    };
-}
+  private:
+    pybind11::object m_py_table;
+};
+}  // namespace morpheus

--- a/morpheus/_lib/include/morpheus/objects/rmm_tensor.hpp
+++ b/morpheus/_lib/include/morpheus/objects/rmm_tensor.hpp
@@ -17,11 +17,10 @@
 
 #pragma once
 
-#include <morpheus/objects/tensor_object.hpp>
-#include <morpheus/utilities/type_util.hpp>
+#include "morpheus/objects/tensor_object.hpp"
+#include "morpheus/utilities/type_util.hpp"
 
 #include <cudf/types.hpp>
-
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_uvector.hpp>
 

--- a/morpheus/_lib/include/morpheus/objects/table_info.hpp
+++ b/morpheus/_lib/include/morpheus/objects/table_info.hpp
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#include <morpheus/objects/data_table.hpp>
-#include <morpheus/utilities/type_util_detail.hpp>
+#include "morpheus/objects/data_table.hpp"
+#include "morpheus/utilities/type_util_detail.hpp"
 
 #include <cudf/table/table_view.hpp>
 

--- a/morpheus/_lib/include/morpheus/objects/tensor.hpp
+++ b/morpheus/_lib/include/morpheus/objects/tensor.hpp
@@ -17,20 +17,17 @@
 
 #pragma once
 
-#include <morpheus/objects/rmm_tensor.hpp>
-#include <morpheus/objects/tensor_object.hpp>
-#include <morpheus/utilities/matx_util.hpp>
-#include <morpheus/utilities/type_util.hpp>
-
-#include <pysrf/node.hpp>
+#include "morpheus/objects/rmm_tensor.hpp"
+#include "morpheus/objects/tensor_object.hpp"
+#include "morpheus/utilities/matx_util.hpp"
+#include "morpheus/utilities/type_util.hpp"
 
 #include <cudf/types.hpp>
-
-#include <rmm/device_buffer.hpp>
-#include <rmm/device_uvector.hpp>
-
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
+#include <pysrf/node.hpp>
+#include <rmm/device_buffer.hpp>
+#include <rmm/device_uvector.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/morpheus/_lib/include/morpheus/objects/tensor_object.hpp
+++ b/morpheus/_lib/include/morpheus/objects/tensor_object.hpp
@@ -17,18 +17,16 @@
 
 #pragma once
 
-#include <morpheus/utilities/type_util_detail.hpp>
-
-#include <morpheus/utilities/string_util.hpp>
-
-#include <srf/cuda/common.hpp>
-#include <srf/memory/blob.hpp>
-#include <srf/memory/default_resources.hpp>
-#include <srf/memory/memory_kind.hpp>  // for memory_kind_type
+#include "morpheus/utilities/string_util.hpp"
+#include "morpheus/utilities/type_util_detail.hpp"
 
 #include <cuda_runtime.h>  // for cudaMemcpyDeviceToHost & cudaMemcpy
 #include <glog/logging.h>  // for CHECK
 #include <rmm/device_uvector.hpp>
+#include <srf/cuda/common.hpp>
+#include <srf/memory/blob.hpp>
+#include <srf/memory/default_resources.hpp>
+#include <srf/memory/memory_kind.hpp>  // for memory_kind_type
 
 #include <algorithm>
 #include <array>

--- a/morpheus/_lib/include/morpheus/objects/triton_in_out.hpp
+++ b/morpheus/_lib/include/morpheus/objects/triton_in_out.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <morpheus/utilities/type_util.hpp>
+#include "morpheus/utilities/type_util.hpp"
 
 #include <string>
 #include <vector>

--- a/morpheus/_lib/include/morpheus/objects/wrapped_tensor.hpp
+++ b/morpheus/_lib/include/morpheus/objects/wrapped_tensor.hpp
@@ -18,11 +18,10 @@
 
 #pragma once
 
-#include <morpheus/objects/tensor_object.hpp>
+#include "morpheus/objects/tensor_object.hpp"
 
 #include <boost/fiber/buffered_channel.hpp>
 #include <boost/fiber/channel_op_status.hpp>
-
 #include <pybind11/pytypes.h>
 
 #include <chrono>

--- a/morpheus/_lib/include/morpheus/stages/add_classification.hpp
+++ b/morpheus/_lib/include/morpheus/stages/add_classification.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <morpheus/messages/multi_response_probs.hpp>
+#include "morpheus/messages/multi_response_probs.hpp"
 
 #include <pysrf/node.hpp>
 #include <srf/segment/builder.hpp>

--- a/morpheus/_lib/include/morpheus/stages/add_scores.hpp
+++ b/morpheus/_lib/include/morpheus/stages/add_scores.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <morpheus/messages/multi_response_probs.hpp>
+#include "morpheus/messages/multi_response_probs.hpp"
 
 #include <pysrf/node.hpp>
 #include <srf/segment/builder.hpp>

--- a/morpheus/_lib/include/morpheus/stages/deserialization.hpp
+++ b/morpheus/_lib/include/morpheus/stages/deserialization.hpp
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#include <morpheus/messages/meta.hpp>
-#include <morpheus/messages/multi.hpp>
+#include "morpheus/messages/meta.hpp"
+#include "morpheus/messages/multi.hpp"
 
 #include <pysrf/node.hpp>
 #include <srf/segment/builder.hpp>

--- a/morpheus/_lib/include/morpheus/stages/file_source.hpp
+++ b/morpheus/_lib/include/morpheus/stages/file_source.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <morpheus/messages/meta.hpp>
+#include "morpheus/messages/meta.hpp"
 
 #include <pysrf/node.hpp>
 #include <srf/segment/builder.hpp>

--- a/morpheus/_lib/include/morpheus/stages/filter_detection.hpp
+++ b/morpheus/_lib/include/morpheus/stages/filter_detection.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <morpheus/messages/multi_response_probs.hpp>
+#include "morpheus/messages/multi_response_probs.hpp"
 
 #include <pysrf/node.hpp>
 #include <srf/segment/builder.hpp>

--- a/morpheus/_lib/include/morpheus/stages/kafka_source.hpp
+++ b/morpheus/_lib/include/morpheus/stages/kafka_source.hpp
@@ -17,15 +17,14 @@
 
 #pragma once
 
-#include <morpheus/messages/meta.hpp>
+#include "morpheus/messages/meta.hpp"
 
+#include <cudf/io/types.hpp>
+#include <librdkafka/rdkafkacpp.h>
 #include <pysrf/node.hpp>
 #include <srf/core/fiber_meta_data.hpp>
 #include <srf/core/task_queue.hpp>
 #include <srf/segment/builder.hpp>
-
-#include <librdkafka/rdkafkacpp.h>
-#include <cudf/io/types.hpp>
 
 #include <memory>
 #include <string>

--- a/morpheus/_lib/include/morpheus/stages/preprocess_fil.hpp
+++ b/morpheus/_lib/include/morpheus/stages/preprocess_fil.hpp
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#include <morpheus/messages/multi.hpp>
-#include <morpheus/messages/multi_inference.hpp>
+#include "morpheus/messages/multi.hpp"
+#include "morpheus/messages/multi_inference.hpp"
 
 #include <pysrf/node.hpp>
 #include <srf/segment/builder.hpp>

--- a/morpheus/_lib/include/morpheus/stages/preprocess_nlp.hpp
+++ b/morpheus/_lib/include/morpheus/stages/preprocess_nlp.hpp
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#include <morpheus/messages/multi.hpp>
-#include <morpheus/messages/multi_inference.hpp>
+#include "morpheus/messages/multi.hpp"
+#include "morpheus/messages/multi_inference.hpp"
 
 #include <pysrf/node.hpp>
 #include <srf/segment/builder.hpp>

--- a/morpheus/_lib/include/morpheus/stages/serialize.hpp
+++ b/morpheus/_lib/include/morpheus/stages/serialize.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <morpheus/messages/multi.hpp>
+#include "morpheus/messages/multi.hpp"
 
 #include <pysrf/node.hpp>
 #include <srf/segment/builder.hpp>

--- a/morpheus/_lib/include/morpheus/stages/triton_inference.hpp
+++ b/morpheus/_lib/include/morpheus/stages/triton_inference.hpp
@@ -17,14 +17,13 @@
 
 #pragma once
 
-#include <morpheus/messages/multi_inference.hpp>
-#include <morpheus/messages/multi_response_probs.hpp>
-#include <morpheus/objects/triton_in_out.hpp>
-
-#include <pysrf/node.hpp>
-#include <srf/segment/builder.hpp>
+#include "morpheus/messages/multi_inference.hpp"
+#include "morpheus/messages/multi_response_probs.hpp"
+#include "morpheus/objects/triton_in_out.hpp"
 
 #include <http_client.h>
+#include <pysrf/node.hpp>
+#include <srf/segment/builder.hpp>
 
 #include <memory>
 #include <string>

--- a/morpheus/_lib/include/morpheus/stages/write_to_file.hpp
+++ b/morpheus/_lib/include/morpheus/stages/write_to_file.hpp
@@ -17,10 +17,10 @@
 
 #pragma once
 
-#include <morpheus/io/serializers.hpp>
-#include <morpheus/messages/meta.hpp>
-#include <morpheus/objects/file_types.hpp>
-#include <morpheus/utilities/string_util.hpp>
+#include "morpheus/io/serializers.hpp"
+#include "morpheus/messages/meta.hpp"
+#include "morpheus/objects/file_types.hpp"
+#include "morpheus/utilities/string_util.hpp"
 
 #include <pysrf/node.hpp>
 #include <srf/segment/builder.hpp>

--- a/morpheus/_lib/include/morpheus/utilities/cudf_util.hpp
+++ b/morpheus/_lib/include/morpheus/utilities/cudf_util.hpp
@@ -17,36 +17,34 @@
 
 #pragma once
 
-#include <morpheus/objects/table_info.hpp>
+#include "morpheus/objects/table_info.hpp"
 
 #include <cudf/io/types.hpp>
-
 #include <pybind11/pytypes.h>
 
-
 namespace morpheus {
-    /****** Component public free function implementations******/
-    /**
-     * TODO(Documentation)
-     */
+/****** Component public free function implementations******/
+/**
+ * TODO(Documentation)
+ */
 #pragma GCC visibility push(default)
-    void load_cudf_helpers();
+void load_cudf_helpers();
 #pragma GCC visibility pop
 
-    /**
-     * @brief These proxy functions allow us to have a shared set of cudf_helpers interfaces declarations, which proxy
-     * the actual generated cython calls. The cython implementation in 'cudf_helpers_api.h' can only appear in the
-     * translation unit for the pybind module declaration.
-     */
-    pybind11::object proxy_table_from_table_with_metadata(cudf::io::table_with_metadata&&, int);
-    TableInfo proxy_table_info_from_table(pybind11::object table, std::shared_ptr<morpheus::IDataTable const > idata_table);
+/**
+ * @brief These proxy functions allow us to have a shared set of cudf_helpers interfaces declarations, which proxy
+ * the actual generated cython calls. The cython implementation in 'cudf_helpers_api.h' can only appear in the
+ * translation unit for the pybind module declaration.
+ */
+pybind11::object proxy_table_from_table_with_metadata(cudf::io::table_with_metadata &&, int);
+TableInfo proxy_table_info_from_table(pybind11::object table, std::shared_ptr<morpheus::IDataTable const> idata_table);
 
-    /**
-     * @brief cudf_helper stubs -- currently not used anywhere
-     */
-     pybind11::object /*PyColumn*/ proxy_column_from_view(cudf::column_view view);
-     cudf::column_view proxy_view_from_column(pybind11::object *column /*PyColumn**/);
-     pybind11::object /*PyTable*/ proxy_table_from_table_info(morpheus::TableInfo table_info, pybind11::object *object);
-     pybind11::object /*PyTable*/ proxy_series_from_table_info(morpheus::TableInfo table_info, pybind11::object *object);
+/**
+ * @brief cudf_helper stubs -- currently not used anywhere
+ */
+pybind11::object /*PyColumn*/ proxy_column_from_view(cudf::column_view view);
+cudf::column_view proxy_view_from_column(pybind11::object *column /*PyColumn**/);
+pybind11::object /*PyTable*/ proxy_table_from_table_info(morpheus::TableInfo table_info, pybind11::object *object);
+pybind11::object /*PyTable*/ proxy_series_from_table_info(morpheus::TableInfo table_info, pybind11::object *object);
 
 }  // namespace morpheus

--- a/morpheus/_lib/include/morpheus/utilities/cupy_util.hpp
+++ b/morpheus/_lib/include/morpheus/utilities/cupy_util.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <morpheus/objects/tensor_object.hpp>
+#include "morpheus/objects/tensor_object.hpp"
 
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>

--- a/morpheus/_lib/include/morpheus/utilities/matx_util.hpp
+++ b/morpheus/_lib/include/morpheus/utilities/matx_util.hpp
@@ -17,10 +17,10 @@
 
 #pragma once
 
-#include <morpheus/objects/dev_mem_info.hpp>
-#include <morpheus/objects/rmm_tensor.hpp>
-#include <morpheus/objects/tensor_object.hpp>
-#include <morpheus/utilities/type_util_detail.hpp>
+#include "morpheus/objects/dev_mem_info.hpp"
+#include "morpheus/objects/rmm_tensor.hpp"
+#include "morpheus/objects/tensor_object.hpp"
+#include "morpheus/utilities/type_util_detail.hpp"
 
 #include <cstddef>
 #include <memory>

--- a/morpheus/_lib/include/morpheus/utilities/tensor_util.hpp
+++ b/morpheus/_lib/include/morpheus/utilities/tensor_util.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <morpheus/objects/tensor_object.hpp>
+#include "morpheus/objects/tensor_object.hpp"
 
 #include <iosfwd>  // for ostream
 #include <string>  // for string

--- a/morpheus/_lib/include/morpheus/utilities/type_util.hpp
+++ b/morpheus/_lib/include/morpheus/utilities/type_util.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <morpheus/utilities/type_util_detail.hpp>
+#include "morpheus/utilities/type_util_detail.hpp"
 
 #include <cudf/types.hpp>
 #include <cudf/utilities/traits.hpp>

--- a/morpheus/_lib/src/io/serializers.cpp
+++ b/morpheus/_lib/src/io/serializers.cpp
@@ -15,13 +15,13 @@
  * limitations under the License.
  */
 
-#include <morpheus/io/serializers.hpp>
+#include "morpheus/io/serializers.hpp"
 
+#include <cudf/io/csv.hpp>
+#include <cudf/io/data_sink.hpp>
 #include <pybind11/gil.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
-#include <cudf/io/csv.hpp>
-#include <cudf/io/data_sink.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
 
 #include <ostream>

--- a/morpheus/_lib/src/messages/memory/inference_memory.cpp
+++ b/morpheus/_lib/src/messages/memory/inference_memory.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include <morpheus/messages/memory/inference_memory.hpp>
+#include "morpheus/messages/memory/inference_memory.hpp"
 
 #include <cudf/io/types.hpp>
 
@@ -23,16 +23,18 @@
 #include <vector>
 
 namespace morpheus {
-    /****** Component public implementations *******************/
-    /****** InferenceMemory****************************************/
-    InferenceMemory::InferenceMemory(size_t count) : count(count) {}
+/****** Component public implementations *******************/
+/****** InferenceMemory****************************************/
+InferenceMemory::InferenceMemory(size_t count) : count(count) {}
 
-    bool InferenceMemory::has_input(const std::string &name) const  {
-        return this->inputs.find(name) != this->inputs.end();
-    }
-
-    /****** InferenceMemoryInterfaceProxy *************************/
-    std::size_t InferenceMemoryInterfaceProxy::get_count(InferenceMemory& self) {
-        return self.count;
-    }
+bool InferenceMemory::has_input(const std::string& name) const
+{
+    return this->inputs.find(name) != this->inputs.end();
 }
+
+/****** InferenceMemoryInterfaceProxy *************************/
+std::size_t InferenceMemoryInterfaceProxy::get_count(InferenceMemory& self)
+{
+    return self.count;
+}
+}  // namespace morpheus

--- a/morpheus/_lib/src/messages/memory/inference_memory_fil.cpp
+++ b/morpheus/_lib/src/messages/memory/inference_memory_fil.cpp
@@ -15,14 +15,14 @@
  * limitations under the License.
  */
 
-#include <morpheus/messages/memory/inference_memory.hpp>
-#include <morpheus/messages/memory/inference_memory_fil.hpp>
-#include <morpheus/objects/tensor.hpp>
-#include <morpheus/utilities/cupy_util.hpp>
+#include "morpheus/messages/memory/inference_memory_fil.hpp"
+
+#include "morpheus/messages/memory/inference_memory.hpp"
+#include "morpheus/objects/tensor.hpp"
+#include "morpheus/utilities/cupy_util.hpp"
 
 #include <cudf/io/types.hpp>
 #include <cudf/types.hpp>
-
 #include <pybind11/pytypes.h>
 
 #include <memory>

--- a/morpheus/_lib/src/messages/memory/inference_memory_nlp.cpp
+++ b/morpheus/_lib/src/messages/memory/inference_memory_nlp.cpp
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-#include <morpheus/messages/memory/inference_memory.hpp>
-#include <morpheus/messages/memory/inference_memory_nlp.hpp>
-#include <morpheus/objects/tensor.hpp>
-#include <morpheus/utilities/cupy_util.hpp>
+#include "morpheus/messages/memory/inference_memory_nlp.hpp"
+
+#include "morpheus/messages/memory/inference_memory.hpp"
+#include "morpheus/objects/tensor.hpp"
+#include "morpheus/utilities/cupy_util.hpp"
 
 #include <pybind11/cast.h>
 #include <pybind11/pytypes.h>

--- a/morpheus/_lib/src/messages/memory/response_memory.cpp
+++ b/morpheus/_lib/src/messages/memory/response_memory.cpp
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
-#include <morpheus/messages/memory/response_memory.hpp>
-#include <morpheus/objects/tensor.hpp>
-#include <morpheus/utilities/cupy_util.hpp>
+#include "morpheus/messages/memory/response_memory.hpp"
+
+#include "morpheus/objects/tensor.hpp"
+#include "morpheus/utilities/cupy_util.hpp"
 
 #include <cudf/io/types.hpp>
-
 #include <pybind11/pytypes.h>
 
 #include <string>

--- a/morpheus/_lib/src/messages/memory/response_memory_probs.cpp
+++ b/morpheus/_lib/src/messages/memory/response_memory_probs.cpp
@@ -15,14 +15,14 @@
  * limitations under the License.
  */
 
-#include <morpheus/messages/memory/response_memory.hpp>
-#include <morpheus/messages/memory/response_memory_probs.hpp>
-#include <morpheus/objects/tensor.hpp>
-#include <morpheus/utilities/cupy_util.hpp>
+#include "morpheus/messages/memory/response_memory_probs.hpp"
+
+#include "morpheus/messages/memory/response_memory.hpp"
+#include "morpheus/objects/tensor.hpp"
+#include "morpheus/utilities/cupy_util.hpp"
 
 #include <cudf/io/types.hpp>
 #include <cudf/types.hpp>
-
 #include <pybind11/pytypes.h>
 
 #include <cstddef>

--- a/morpheus/_lib/src/messages/meta.cpp
+++ b/morpheus/_lib/src/messages/meta.cpp
@@ -15,15 +15,14 @@
  * limitations under the License.
  */
 
-#include <morpheus/messages/meta.hpp>
+#include "morpheus/messages/meta.hpp"
 
-#include <morpheus/objects/python_data_table.hpp>
-#include <morpheus/objects/table_info.hpp>
-#include <morpheus/utilities/cudf_util.hpp>
-#include <morpheus/utilities/table_util.hpp>
+#include "morpheus/objects/python_data_table.hpp"
+#include "morpheus/objects/table_info.hpp"
+#include "morpheus/utilities/cudf_util.hpp"
+#include "morpheus/utilities/table_util.hpp"
 
 #include <cudf/io/types.hpp>
-
 #include <pybind11/gil.h>
 #include <pybind11/pytypes.h>
 
@@ -93,78 +92,88 @@ struct MessageMetaImpl {
 
 /****** Component public implementations *******************/
 /****** MessageMeta ****************************************/
-    pybind11::object MessageMeta::get_py_table() const {
-        return m_data->get_py_object();
-    }
+pybind11::object MessageMeta::get_py_table() const
+{
+    return m_data->get_py_object();
+}
 
-    size_t MessageMeta::count() const {
-        return m_data->count();
-    }
+size_t MessageMeta::count() const
+{
+    return m_data->count();
+}
 
-    TableInfo MessageMeta::get_info() const {
-        return this->m_data->get_info();
-    }
+TableInfo MessageMeta::get_info() const
+{
+    return this->m_data->get_info();
+}
 
-    std::shared_ptr<MessageMeta> MessageMeta::create_from_python(pybind11::object &&data_table) {
-        auto data = std::make_unique<PyDataTable>(std::move(data_table));
+std::shared_ptr<MessageMeta> MessageMeta::create_from_python(pybind11::object &&data_table)
+{
+    auto data = std::make_unique<PyDataTable>(std::move(data_table));
 
-        return std::shared_ptr<MessageMeta>(new MessageMeta(std::move(data)));
-    }
+    return std::shared_ptr<MessageMeta>(new MessageMeta(std::move(data)));
+}
 
-    std::shared_ptr<MessageMeta> MessageMeta::create_from_cpp(cudf::io::table_with_metadata &&data_table,
-                                                              int index_col_count) {
-        // Convert to py first
-        pybind11::object py_dt = cpp_to_py(std::move(data_table), index_col_count);
+std::shared_ptr<MessageMeta> MessageMeta::create_from_cpp(cudf::io::table_with_metadata &&data_table,
+                                                          int index_col_count)
+{
+    // Convert to py first
+    pybind11::object py_dt = cpp_to_py(std::move(data_table), index_col_count);
 
-        auto data = std::make_unique<PyDataTable>(std::move(py_dt));
+    auto data = std::make_unique<PyDataTable>(std::move(py_dt));
 
-        return std::shared_ptr<MessageMeta>(new MessageMeta(std::move(data)));
-    }
+    return std::shared_ptr<MessageMeta>(new MessageMeta(std::move(data)));
+}
 
-    MessageMeta::MessageMeta(std::shared_ptr<IDataTable> data) : m_data(std::move(data)) {}
+MessageMeta::MessageMeta(std::shared_ptr<IDataTable> data) : m_data(std::move(data)) {}
 
-    pybind11::object MessageMeta::cpp_to_py(cudf::io::table_with_metadata &&table, int index_col_count) {
-        pybind11::gil_scoped_acquire gil;
+pybind11::object MessageMeta::cpp_to_py(cudf::io::table_with_metadata &&table, int index_col_count)
+{
+    pybind11::gil_scoped_acquire gil;
 
-        // Now convert to a python TableInfo object
-        auto converted_table = proxy_table_from_table_with_metadata(std::move(table), index_col_count);
+    // Now convert to a python TableInfo object
+    auto converted_table = proxy_table_from_table_with_metadata(std::move(table), index_col_count);
 
-        // VLOG(10) << "Table. Num Col: " << converted_table.attr("_num_columns").str().cast<std::string>()
-        //          << ", Num Ind: " << converted_table.attr("_num_columns").cast<std::string>()
-        //          << ", Rows: " << converted_table.attr("_num_rows").cast<std::string>();
-        // pybind11::print("Table Created. Num Rows: {}, Num Cols: {}, Num Ind: {}",
-        //           converted_table.attr("_num_rows"),
-        //           converted_table.attr("_num_columns"),
-        //           converted_table.attr("_num_indices"));
+    // VLOG(10) << "Table. Num Col: " << converted_table.attr("_num_columns").str().cast<std::string>()
+    //          << ", Num Ind: " << converted_table.attr("_num_columns").cast<std::string>()
+    //          << ", Rows: " << converted_table.attr("_num_rows").cast<std::string>();
+    // pybind11::print("Table Created. Num Rows: {}, Num Cols: {}, Num Ind: {}",
+    //           converted_table.attr("_num_rows"),
+    //           converted_table.attr("_num_columns"),
+    //           converted_table.attr("_num_indices"));
 
-        return converted_table;
-    }
+    return converted_table;
+}
 
 /********** MessageMetaInterfaceProxy **********/
-    std::shared_ptr<MessageMeta> MessageMetaInterfaceProxy::init_python(pybind11::object &&data_frame) {
-        return MessageMeta::create_from_python(std::move(data_frame));
-    }
+std::shared_ptr<MessageMeta> MessageMetaInterfaceProxy::init_python(pybind11::object &&data_frame)
+{
+    return MessageMeta::create_from_python(std::move(data_frame));
+}
 
-    cudf::size_type MessageMetaInterfaceProxy::count(MessageMeta &self) {
-        return self.count();
-    }
+cudf::size_type MessageMetaInterfaceProxy::count(MessageMeta &self)
+{
+    return self.count();
+}
 
-    pybind11::object MessageMetaInterfaceProxy::get_data_frame(MessageMeta &self) {
-        // // Get the column and convert to cudf
-        // auto py_table_struct = make_table_from_view_and_meta(self.m_pydf;.tbl->view(),
-        // self.m_pydf;.metadata); py::object py_table  =
-        // py::reinterpret_steal<py::object>((PyObject*)py_table_struct);
+pybind11::object MessageMetaInterfaceProxy::get_data_frame(MessageMeta &self)
+{
+    // // Get the column and convert to cudf
+    // auto py_table_struct = make_table_from_view_and_meta(self.m_pydf;.tbl->view(),
+    // self.m_pydf;.metadata); py::object py_table  =
+    // py::reinterpret_steal<py::object>((PyObject*)py_table_struct);
 
-        // // py_col.inc_ref();
+    // // py_col.inc_ref();
 
-        // return py_table;
-        return self.get_py_table();
-    }
+    // return py_table;
+    return self.get_py_table();
+}
 
-    std::shared_ptr<MessageMeta> MessageMetaInterfaceProxy::init_cpp(const std::string &filename) {
-        // Load the file
-        auto df_with_meta = CuDFTableUtil::load_table(filename);
+std::shared_ptr<MessageMeta> MessageMetaInterfaceProxy::init_cpp(const std::string &filename)
+{
+    // Load the file
+    auto df_with_meta = CuDFTableUtil::load_table(filename);
 
-        return MessageMeta::create_from_cpp(std::move(df_with_meta));
-    }
+    return MessageMeta::create_from_cpp(std::move(df_with_meta));
+}
 }  // namespace morpheus

--- a/morpheus/_lib/src/messages/multi.cpp
+++ b/morpheus/_lib/src/messages/multi.cpp
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-#include <morpheus/messages/multi.hpp>
+#include "morpheus/messages/multi.hpp"
 
-#include <morpheus/messages/meta.hpp>
-#include <morpheus/objects/table_info.hpp>
+#include "morpheus/messages/meta.hpp"
+#include "morpheus/objects/table_info.hpp"
 
 #include <cudf/types.hpp>
 

--- a/morpheus/_lib/src/messages/multi_inference.cpp
+++ b/morpheus/_lib/src/messages/multi_inference.cpp
@@ -15,16 +15,16 @@
  * limitations under the License.
  */
 
-#include <morpheus/messages/multi_inference.hpp>
+#include "morpheus/messages/multi_inference.hpp"
 
-#include <morpheus/messages/memory/inference_memory.hpp>
-#include <morpheus/messages/meta.hpp>
-#include <morpheus/messages/multi.hpp>
-#include <morpheus/objects/tensor.hpp>
-#include <morpheus/utilities/cupy_util.hpp>
+#include "morpheus/messages/memory/inference_memory.hpp"
+#include "morpheus/messages/meta.hpp"
+#include "morpheus/messages/multi.hpp"
+#include "morpheus/objects/tensor.hpp"
+#include "morpheus/utilities/cupy_util.hpp"
 
-#include <pybind11/pytypes.h>
 #include <cudf/types.hpp>
+#include <pybind11/pytypes.h>
 
 #include <memory>
 #include <string>

--- a/morpheus/_lib/src/messages/multi_inference_fil.cpp
+++ b/morpheus/_lib/src/messages/multi_inference_fil.cpp
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
-#include <morpheus/messages/multi_inference_fil.hpp>
+#include "morpheus/messages/multi_inference_fil.hpp"
 
-#include <morpheus/messages/memory/inference_memory.hpp>
-#include <morpheus/messages/meta.hpp>
-#include <morpheus/messages/multi_inference.hpp>
-#include <morpheus/objects/tensor.hpp>
+#include "morpheus/messages/memory/inference_memory.hpp"
+#include "morpheus/messages/meta.hpp"
+#include "morpheus/messages/multi_inference.hpp"
+#include "morpheus/objects/tensor.hpp"
 
 #include <cudf/types.hpp>
 

--- a/morpheus/_lib/src/messages/multi_inference_nlp.cpp
+++ b/morpheus/_lib/src/messages/multi_inference_nlp.cpp
@@ -15,16 +15,15 @@
  * limitations under the License.
  */
 
-#include <morpheus/messages/multi_inference_nlp.hpp>
+#include "morpheus/messages/multi_inference_nlp.hpp"
 
-#include <morpheus/messages/memory/inference_memory.hpp>
-#include <morpheus/messages/meta.hpp>
-#include <morpheus/messages/multi_inference.hpp>
-#include <morpheus/objects/tensor.hpp>
-#include <morpheus/utilities/cupy_util.hpp>
+#include "morpheus/messages/memory/inference_memory.hpp"
+#include "morpheus/messages/meta.hpp"
+#include "morpheus/messages/multi_inference.hpp"
+#include "morpheus/objects/tensor.hpp"
+#include "morpheus/utilities/cupy_util.hpp"
 
 #include <cudf/types.hpp>
-
 #include <pybind11/pytypes.h>
 
 #include <memory>

--- a/morpheus/_lib/src/messages/multi_response.cpp
+++ b/morpheus/_lib/src/messages/multi_response.cpp
@@ -15,16 +15,15 @@
  * limitations under the License.
  */
 
-#include <morpheus/messages/multi_response.hpp>
+#include "morpheus/messages/multi_response.hpp"
 
-#include <morpheus/messages/memory/response_memory.hpp>
-#include <morpheus/messages/meta.hpp>
-#include <morpheus/messages/multi.hpp>
-#include <morpheus/objects/tensor.hpp>
-#include <morpheus/utilities/cupy_util.hpp>
+#include "morpheus/messages/memory/response_memory.hpp"
+#include "morpheus/messages/meta.hpp"
+#include "morpheus/messages/multi.hpp"
+#include "morpheus/objects/tensor.hpp"
+#include "morpheus/utilities/cupy_util.hpp"
 
 #include <cudf/types.hpp>
-
 #include <pybind11/pytypes.h>
 
 #include <cstddef>

--- a/morpheus/_lib/src/messages/multi_response_probs.cpp
+++ b/morpheus/_lib/src/messages/multi_response_probs.cpp
@@ -15,14 +15,14 @@
  * limitations under the License.
  */
 
-#include <morpheus/messages/multi_response_probs.hpp>
+#include "morpheus/messages/multi_response_probs.hpp"
 
-#include <morpheus/messages/meta.hpp>
-#include <morpheus/objects/tensor.hpp>
-#include <morpheus/utilities/cupy_util.hpp>
+#include "morpheus/messages/meta.hpp"
+#include "morpheus/objects/tensor.hpp"
+#include "morpheus/utilities/cupy_util.hpp"
 
-#include <pybind11/pytypes.h>
 #include <cudf/types.hpp>
+#include <pybind11/pytypes.h>
 
 #include <memory>
 #include <utility>

--- a/morpheus/_lib/src/objects/dev_mem_info.cpp
+++ b/morpheus/_lib/src/objects/dev_mem_info.cpp
@@ -15,12 +15,13 @@
  * limitations under the License.
  */
 
-#include <morpheus/objects/dev_mem_info.hpp>
+#include "morpheus/objects/dev_mem_info.hpp"
 
 namespace morpheus {
-    // Component public implementations
-    // ************ DevMemInfo************************* //
-    void *DevMemInfo::data() const {
-        return static_cast<uint8_t *>(buffer->data()) + offset;
-    }
+// Component public implementations
+// ************ DevMemInfo************************* //
+void *DevMemInfo::data() const
+{
+    return static_cast<uint8_t *>(buffer->data()) + offset;
 }
+}  // namespace morpheus

--- a/morpheus/_lib/src/objects/fiber_queue.cpp
+++ b/morpheus/_lib/src/objects/fiber_queue.cpp
@@ -15,160 +15,175 @@
  * limitations under the License.
  */
 
-#include <morpheus/objects/fiber_queue.hpp>
+#include "morpheus/objects/fiber_queue.hpp"
 
 #include <boost/fiber/channel_op_status.hpp>
-
 #include <pybind11/pytypes.h>
 
 #include <chrono>
 #include <memory>
 #include <utility>
 
-
 namespace morpheus {
-    /****** Component public implementations *******************/
-    /****** FiberQueue****************************************/
-    FiberQueue::FiberQueue(size_t max_size)  : m_queue(max_size) {}
+/****** Component public implementations *******************/
+/****** FiberQueue****************************************/
+FiberQueue::FiberQueue(size_t max_size) : m_queue(max_size) {}
 
-    boost::fibers::channel_op_status FiberQueue::put(pybind11::object &&item, bool block, float timeout)  {
-        if (!block) {
-            return m_queue.try_push(std::move(item));
-        } else if (timeout > 0.0) {
-            return m_queue.push_wait_for(
-                    std::move(item),
-                    std::chrono::duration_cast<std::chrono::seconds>(std::chrono::duration<float>(timeout)));
-        } else {
-            // Blocking no timeout
-            return m_queue.push(std::move(item));
-        }
+boost::fibers::channel_op_status FiberQueue::put(pybind11::object &&item, bool block, float timeout)
+{
+    if (!block)
+    {
+        return m_queue.try_push(std::move(item));
     }
-
-    boost::fibers::channel_op_status FiberQueue::get(pybind11::object &item, bool block, float timeout)  {
-        if (!block) {
-            return m_queue.try_pop(std::ref(item));
-        } else if (timeout > 0.0) {
-            return m_queue.pop_wait_for(
-                    std::ref(item),
-                    std::chrono::duration_cast<std::chrono::seconds>(std::chrono::duration<float>(timeout)));
-        } else {
-            // Blocking no timeout
-            return m_queue.pop(std::ref(item));
-        }
+    else if (timeout > 0.0)
+    {
+        return m_queue.push_wait_for(
+            std::move(item), std::chrono::duration_cast<std::chrono::seconds>(std::chrono::duration<float>(timeout)));
     }
-
-    void FiberQueue::close()  {
-        m_queue.close();
-    }
-
-    bool FiberQueue::is_closed()  {
-        return m_queue.is_closed();
-    }
-
-    void FiberQueue::join()  {
-        // TODO(MDD): Not sure how to join a buffered channel
-    }
-
-    /****** FiberQueueInterfaceProxy *************************/
-    std::shared_ptr<morpheus::FiberQueue> FiberQueueInterfaceProxy::init(std::size_t max_size) {
-        if (max_size < 2 || ((max_size & (max_size - 1)) != 0)) {
-            throw std::invalid_argument("max_size must be greater than 1 and a power of 2.");
-        }
-
-        // Create a new shared_ptr
-        return std::make_shared<morpheus::FiberQueue>(max_size);
-    }
-
-    void FiberQueueInterfaceProxy::put(morpheus::FiberQueue &self, pybind11::object item, bool block, float timeout) {
-        boost::fibers::channel_op_status status;
-
-        // Release the GIL and try to move it
-        {
-            pybind11::gil_scoped_release nogil;
-
-            status = self.put(std::move(item), block, timeout);
-        }
-
-        switch (status) {
-            case boost::fibers::channel_op_status::success:
-                return;
-            case boost::fibers::channel_op_status::empty: {
-                // Raise queue.Empty
-                pybind11::object exc_class = pybind11::module_::import("queue").attr("Empty");
-
-                PyErr_SetNone(exc_class.ptr());
-
-                throw pybind11::error_already_set();
-            }
-            case boost::fibers::channel_op_status::full:
-            case boost::fibers::channel_op_status::timeout: {
-                // Raise queue.Full
-                pybind11::object exc_class = pybind11::module_::import("queue").attr("Empty");
-
-                PyErr_SetNone(exc_class.ptr());
-
-                throw pybind11::error_already_set();
-            }
-            case boost::fibers::channel_op_status::closed: {
-                // Raise queue.Full
-                pybind11::object exc_class = pybind11::module_::import(
-                        "morpheus.utils.producer_consumer_queue").attr("Closed");
-
-                PyErr_SetNone(exc_class.ptr());
-
-                throw pybind11::error_already_set();
-            }
-        }
-
-    }
-
-    pybind11::object FiberQueueInterfaceProxy::get(morpheus::FiberQueue &self, bool block, float timeout) {
-        boost::fibers::channel_op_status status;
-
-        pybind11::object item;
-
-        // Release the GIL and try to move it
-        {
-            pybind11::gil_scoped_release nogil;
-
-            status = self.get(std::ref(item), block, timeout);
-        }
-
-        switch (status) {
-            case boost::fibers::channel_op_status::success:
-                return item;
-            case boost::fibers::channel_op_status::empty: {
-                // Raise queue.Empty
-                pybind11::object exc_class = pybind11::module_::import("queue").attr("Empty");
-
-                PyErr_SetNone(exc_class.ptr());
-
-                throw pybind11::error_already_set();
-            }
-            case boost::fibers::channel_op_status::full:
-            case boost::fibers::channel_op_status::timeout: {
-                // Raise queue.Full
-                pybind11::object exc_class = pybind11::module_::import("queue").attr("Empty");
-
-                PyErr_SetNone(exc_class.ptr());
-
-                throw pybind11::error_already_set();
-            }
-            case boost::fibers::channel_op_status::closed: {
-                // Raise queue.Full
-                pybind11::object exc_class = pybind11::module_::import(
-                        "morpheus.utils.producer_consumer_queue").attr("Closed");
-
-                PyErr_SetNone(exc_class.ptr());
-
-                throw pybind11::error_already_set();
-            }
-            default:
-                throw std::runtime_error("Unknown channel status");
-        }
-    }
-
-    void FiberQueueInterfaceProxy::close(morpheus::FiberQueue &self) {
-        self.close();
+    else
+    {
+        // Blocking no timeout
+        return m_queue.push(std::move(item));
     }
 }
+
+boost::fibers::channel_op_status FiberQueue::get(pybind11::object &item, bool block, float timeout)
+{
+    if (!block)
+    {
+        return m_queue.try_pop(std::ref(item));
+    }
+    else if (timeout > 0.0)
+    {
+        return m_queue.pop_wait_for(
+            std::ref(item), std::chrono::duration_cast<std::chrono::seconds>(std::chrono::duration<float>(timeout)));
+    }
+    else
+    {
+        // Blocking no timeout
+        return m_queue.pop(std::ref(item));
+    }
+}
+
+void FiberQueue::close()
+{
+    m_queue.close();
+}
+
+bool FiberQueue::is_closed()
+{
+    return m_queue.is_closed();
+}
+
+void FiberQueue::join()
+{
+    // TODO(MDD): Not sure how to join a buffered channel
+}
+
+/****** FiberQueueInterfaceProxy *************************/
+std::shared_ptr<morpheus::FiberQueue> FiberQueueInterfaceProxy::init(std::size_t max_size)
+{
+    if (max_size < 2 || ((max_size & (max_size - 1)) != 0))
+    {
+        throw std::invalid_argument("max_size must be greater than 1 and a power of 2.");
+    }
+
+    // Create a new shared_ptr
+    return std::make_shared<morpheus::FiberQueue>(max_size);
+}
+
+void FiberQueueInterfaceProxy::put(morpheus::FiberQueue &self, pybind11::object item, bool block, float timeout)
+{
+    boost::fibers::channel_op_status status;
+
+    // Release the GIL and try to move it
+    {
+        pybind11::gil_scoped_release nogil;
+
+        status = self.put(std::move(item), block, timeout);
+    }
+
+    switch (status)
+    {
+    case boost::fibers::channel_op_status::success:
+        return;
+    case boost::fibers::channel_op_status::empty: {
+        // Raise queue.Empty
+        pybind11::object exc_class = pybind11::module_::import("queue").attr("Empty");
+
+        PyErr_SetNone(exc_class.ptr());
+
+        throw pybind11::error_already_set();
+    }
+    case boost::fibers::channel_op_status::full:
+    case boost::fibers::channel_op_status::timeout: {
+        // Raise queue.Full
+        pybind11::object exc_class = pybind11::module_::import("queue").attr("Empty");
+
+        PyErr_SetNone(exc_class.ptr());
+
+        throw pybind11::error_already_set();
+    }
+    case boost::fibers::channel_op_status::closed: {
+        // Raise queue.Full
+        pybind11::object exc_class = pybind11::module_::import("morpheus.utils.producer_consumer_queue").attr("Closed");
+
+        PyErr_SetNone(exc_class.ptr());
+
+        throw pybind11::error_already_set();
+    }
+    }
+}
+
+pybind11::object FiberQueueInterfaceProxy::get(morpheus::FiberQueue &self, bool block, float timeout)
+{
+    boost::fibers::channel_op_status status;
+
+    pybind11::object item;
+
+    // Release the GIL and try to move it
+    {
+        pybind11::gil_scoped_release nogil;
+
+        status = self.get(std::ref(item), block, timeout);
+    }
+
+    switch (status)
+    {
+    case boost::fibers::channel_op_status::success:
+        return item;
+    case boost::fibers::channel_op_status::empty: {
+        // Raise queue.Empty
+        pybind11::object exc_class = pybind11::module_::import("queue").attr("Empty");
+
+        PyErr_SetNone(exc_class.ptr());
+
+        throw pybind11::error_already_set();
+    }
+    case boost::fibers::channel_op_status::full:
+    case boost::fibers::channel_op_status::timeout: {
+        // Raise queue.Full
+        pybind11::object exc_class = pybind11::module_::import("queue").attr("Empty");
+
+        PyErr_SetNone(exc_class.ptr());
+
+        throw pybind11::error_already_set();
+    }
+    case boost::fibers::channel_op_status::closed: {
+        // Raise queue.Full
+        pybind11::object exc_class = pybind11::module_::import("morpheus.utils.producer_consumer_queue").attr("Closed");
+
+        PyErr_SetNone(exc_class.ptr());
+
+        throw pybind11::error_already_set();
+    }
+    default:
+        throw std::runtime_error("Unknown channel status");
+    }
+}
+
+void FiberQueueInterfaceProxy::close(morpheus::FiberQueue &self)
+{
+    self.close();
+}
+}  // namespace morpheus

--- a/morpheus/_lib/src/objects/file_types.cpp
+++ b/morpheus/_lib/src/objects/file_types.cpp
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-#include <morpheus/objects/file_types.hpp>
+#include "morpheus/objects/file_types.hpp"
 
-#include <morpheus/utilities/string_util.hpp>
+#include "morpheus/utilities/string_util.hpp"
 
 #include <filesystem>
 #include <stdexcept>

--- a/morpheus/_lib/src/objects/python_data_table.cpp
+++ b/morpheus/_lib/src/objects/python_data_table.cpp
@@ -15,13 +15,12 @@
  * limitations under the License.
  */
 
-#include <morpheus/objects/python_data_table.hpp>
+#include "morpheus/objects/python_data_table.hpp"
 
-#include <morpheus/objects/table_info.hpp>
-#include <morpheus/utilities/cudf_util.hpp>
+#include "morpheus/objects/table_info.hpp"
+#include "morpheus/utilities/cudf_util.hpp"
 
 #include <cudf/types.hpp>
-
 #include <pybind11/gil.h>
 #include <pybind11/pytypes.h>
 
@@ -30,32 +29,37 @@
 namespace morpheus {
 /****** Component public implementations *******************/
 /****** PyDataTable****************************************/
-    PyDataTable::PyDataTable(pybind11::object &&py_table) : m_py_table(std::move(py_table)) {}
+PyDataTable::PyDataTable(pybind11::object &&py_table) : m_py_table(std::move(py_table)) {}
 
-    PyDataTable::~PyDataTable() {
-        if (m_py_table) {
-            pybind11::gil_scoped_acquire gil;
-
-            // Clear out the python object
-            m_py_table = pybind11::object();
-        }
-    }
-
-    cudf::size_type PyDataTable::count() const {
-        pybind11::gil_scoped_acquire gil;
-        return m_py_table.attr("_num_rows").cast<cudf::size_type>();
-    }
-
-    TableInfo PyDataTable::get_info() const {
+PyDataTable::~PyDataTable()
+{
+    if (m_py_table)
+    {
         pybind11::gil_scoped_acquire gil;
 
-        // auto info = proxy_table_info_from_table((PyTable *) m_py_table.ptr(), this->shared_from_this());
-        auto info = proxy_table_info_from_table(m_py_table, this->shared_from_this());
-
-        return info;
+        // Clear out the python object
+        m_py_table = pybind11::object();
     }
+}
 
-    const pybind11::object &PyDataTable::get_py_object() const {
-        return m_py_table;
-    }
+cudf::size_type PyDataTable::count() const
+{
+    pybind11::gil_scoped_acquire gil;
+    return m_py_table.attr("_num_rows").cast<cudf::size_type>();
+}
+
+TableInfo PyDataTable::get_info() const
+{
+    pybind11::gil_scoped_acquire gil;
+
+    // auto info = proxy_table_info_from_table((PyTable *) m_py_table.ptr(), this->shared_from_this());
+    auto info = proxy_table_info_from_table(m_py_table, this->shared_from_this());
+
+    return info;
+}
+
+const pybind11::object &PyDataTable::get_py_object() const
+{
+    return m_py_table;
+}
 }  // namespace morpheus

--- a/morpheus/_lib/src/objects/rmm_tensor.cpp
+++ b/morpheus/_lib/src/objects/rmm_tensor.cpp
@@ -15,14 +15,14 @@
  * limitations under the License.
  */
 
-#include <morpheus/objects/rmm_tensor.hpp>
+#include "morpheus/objects/rmm_tensor.hpp"
 
-#include <morpheus/objects/tensor_object.hpp>
-#include <morpheus/utilities/matx_util.hpp>
-#include <morpheus/utilities/type_util.hpp>
+#include "morpheus/objects/tensor_object.hpp"
+#include "morpheus/utilities/matx_util.hpp"
+#include "morpheus/utilities/type_util.hpp"
 
-#include <pybind11/pybind11.h>
 #include <cudf/types.hpp>
+#include <pybind11/pybind11.h>
 #include <rmm/device_buffer.hpp>
 
 #include <cstdint>

--- a/morpheus/_lib/src/objects/table_info.cpp
+++ b/morpheus/_lib/src/objects/table_info.cpp
@@ -15,14 +15,13 @@
  * limitations under the License.
  */
 
-#include <morpheus/objects/table_info.hpp>
+#include "morpheus/objects/table_info.hpp"
 
-#include <morpheus/utilities/type_util_detail.hpp>
+#include "morpheus/utilities/type_util_detail.hpp"
 
 #include <cudf/copying.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
-
 #include <glog/logging.h>
 #include <pybind11/gil.h>
 #include <pybind11/pytypes.h>

--- a/morpheus/_lib/src/objects/tensor.cpp
+++ b/morpheus/_lib/src/objects/tensor.cpp
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 
-#include <morpheus/objects/tensor.hpp>
+#include "morpheus/objects/tensor.hpp"
 
-#include <morpheus/objects/rmm_tensor.hpp>
-#include <morpheus/objects/tensor_object.hpp>
-#include <morpheus/utilities/type_util.hpp>
+#include "morpheus/objects/rmm_tensor.hpp"
+#include "morpheus/objects/tensor_object.hpp"
+#include "morpheus/utilities/type_util.hpp"
 
 #include <rmm/device_buffer.hpp>
 

--- a/morpheus/_lib/src/objects/tensor_object.cpp
+++ b/morpheus/_lib/src/objects/tensor_object.cpp
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-#include <morpheus/objects/tensor_object.hpp>
+#include "morpheus/objects/tensor_object.hpp"
 
-#include <morpheus/utilities/tensor_util.hpp>
+#include "morpheus/utilities/tensor_util.hpp"
 
 #include <srf/memory/blob.hpp>       // for blob
 #include <srf/utils/type_utils.hpp>  // for DataType

--- a/morpheus/_lib/src/objects/wrapped_tensor.cpp
+++ b/morpheus/_lib/src/objects/wrapped_tensor.cpp
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-#include <morpheus/objects/wrapped_tensor.hpp>
+#include "morpheus/objects/wrapped_tensor.hpp"
 
-#include <morpheus/objects/tensor_object.hpp>
+#include "morpheus/objects/tensor_object.hpp"
 
 #include <pybind11/cast.h>
 #include <pybind11/pytypes.h>

--- a/morpheus/_lib/src/python_modules/common.cpp
+++ b/morpheus/_lib/src/python_modules/common.cpp
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-#include <morpheus/objects/fiber_queue.hpp>
-#include <morpheus/objects/wrapped_tensor.hpp>
-#include <morpheus/utilities/cudf_util.hpp>
+#include "morpheus/objects/fiber_queue.hpp"
+#include "morpheus/objects/wrapped_tensor.hpp"
+#include "morpheus/utilities/cudf_util.hpp"
 
 #include <pybind11/pybind11.h>
 

--- a/morpheus/_lib/src/python_modules/file_types.cpp
+++ b/morpheus/_lib/src/python_modules/file_types.cpp
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
-#include <morpheus/objects/file_types.hpp>
-#include <morpheus/utilities/cudf_util.hpp>
+#include "morpheus/objects/file_types.hpp"
+
+#include "morpheus/utilities/cudf_util.hpp"
 
 #include <pybind11/pybind11.h>
 

--- a/morpheus/_lib/src/python_modules/messages.cpp
+++ b/morpheus/_lib/src/python_modules/messages.cpp
@@ -15,28 +15,27 @@
  * limitations under the License.
  */
 
-#include <morpheus/messages/memory/inference_memory.hpp>
-#include <morpheus/messages/memory/inference_memory_fil.hpp>
-#include <morpheus/messages/memory/inference_memory_nlp.hpp>
-#include <morpheus/messages/memory/response_memory.hpp>
-#include <morpheus/messages/memory/response_memory_probs.hpp>
-#include <morpheus/messages/meta.hpp>
-#include <morpheus/messages/multi.hpp>
-#include <morpheus/messages/multi_inference.hpp>
-#include <morpheus/messages/multi_inference_fil.hpp>
-#include <morpheus/messages/multi_inference_nlp.hpp>
-#include <morpheus/messages/multi_response.hpp>
-#include <morpheus/messages/multi_response_probs.hpp>
-#include <morpheus/objects/tensor.hpp>
-#include <morpheus/utilities/cudf_util.hpp>
-
-#include <srf/node/edge_connector.hpp>
+#include "morpheus/messages/memory/inference_memory.hpp"
+#include "morpheus/messages/memory/inference_memory_fil.hpp"
+#include "morpheus/messages/memory/inference_memory_nlp.hpp"
+#include "morpheus/messages/memory/response_memory.hpp"
+#include "morpheus/messages/memory/response_memory_probs.hpp"
+#include "morpheus/messages/meta.hpp"
+#include "morpheus/messages/multi.hpp"
+#include "morpheus/messages/multi_inference.hpp"
+#include "morpheus/messages/multi_inference_fil.hpp"
+#include "morpheus/messages/multi_inference_nlp.hpp"
+#include "morpheus/messages/multi_response.hpp"
+#include "morpheus/messages/multi_response_probs.hpp"
+#include "morpheus/objects/tensor.hpp"
+#include "morpheus/utilities/cudf_util.hpp"
 
 #include <pybind11/cast.h>
 #include <pybind11/functional.h>  // IWYU pragma: keep
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
 #include <pybind11/stl.h>  // IWYU pragma: keep
+#include <srf/node/edge_connector.hpp>
 
 #include <cstddef>
 #include <memory>

--- a/morpheus/_lib/src/python_modules/stages.cpp
+++ b/morpheus/_lib/src/python_modules/stages.cpp
@@ -15,18 +15,18 @@
  * limitations under the License.
  */
 
-#include <morpheus/stages/add_classification.hpp>
-#include <morpheus/stages/add_scores.hpp>
-#include <morpheus/stages/deserialization.hpp>
-#include <morpheus/stages/file_source.hpp>
-#include <morpheus/stages/filter_detection.hpp>
-#include <morpheus/stages/kafka_source.hpp>
-#include <morpheus/stages/preprocess_fil.hpp>
-#include <morpheus/stages/preprocess_nlp.hpp>
-#include <morpheus/stages/serialize.hpp>
-#include <morpheus/stages/triton_inference.hpp>
-#include <morpheus/stages/write_to_file.hpp>
-#include <morpheus/utilities/cudf_util.hpp>
+#include "morpheus/stages/add_classification.hpp"
+#include "morpheus/stages/add_scores.hpp"
+#include "morpheus/stages/deserialization.hpp"
+#include "morpheus/stages/file_source.hpp"
+#include "morpheus/stages/filter_detection.hpp"
+#include "morpheus/stages/kafka_source.hpp"
+#include "morpheus/stages/preprocess_fil.hpp"
+#include "morpheus/stages/preprocess_nlp.hpp"
+#include "morpheus/stages/serialize.hpp"
+#include "morpheus/stages/triton_inference.hpp"
+#include "morpheus/stages/write_to_file.hpp"
+#include "morpheus/utilities/cudf_util.hpp"
 
 #include <srf/segment/object.hpp>
 

--- a/morpheus/_lib/src/stages/add_classification.cpp
+++ b/morpheus/_lib/src/stages/add_classification.cpp
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-#include <morpheus/stages/add_classification.hpp>
+#include "morpheus/stages/add_classification.hpp"
 
-#include <morpheus/utilities/matx_util.hpp>
+#include "morpheus/utilities/matx_util.hpp"
 
 #include <cstddef>
 #include <exception>

--- a/morpheus/_lib/src/stages/add_scores.cpp
+++ b/morpheus/_lib/src/stages/add_scores.cpp
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-#include <morpheus/stages/add_scores.hpp>
+#include "morpheus/stages/add_scores.hpp"
 
-#include <morpheus/utilities/matx_util.hpp>
+#include "morpheus/utilities/matx_util.hpp"
 
 #include <cstddef>
 #include <exception>

--- a/morpheus/_lib/src/stages/deserialize.cpp
+++ b/morpheus/_lib/src/stages/deserialize.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include <morpheus/stages/deserialization.hpp>
+#include "morpheus/stages/deserialization.hpp"
 
 #include <pysrf/node.hpp>
 #include <srf/segment/builder.hpp>

--- a/morpheus/_lib/src/stages/file_source.cpp
+++ b/morpheus/_lib/src/stages/file_source.cpp
@@ -15,20 +15,18 @@
  * limitations under the License.
  */
 
-#include <morpheus/stages/file_source.hpp>
-
-#include <srf/segment/builder.hpp>
+#include "morpheus/stages/file_source.hpp"
 
 #include <cudf/io/csv.hpp>
 #include <cudf/io/json.hpp>
 #include <cudf/strings/replace.hpp>
 #include <cudf/types.hpp>
-#include <nvtext/subword_tokenize.hpp>
-
 #include <glog/logging.h>
+#include <nlohmann/json.hpp>
+#include <nvtext/subword_tokenize.hpp>
 #include <pybind11/gil.h>
 #include <pybind11/pytypes.h>
-#include <nlohmann/json.hpp>
+#include <srf/segment/builder.hpp>
 
 #include <cstddef>
 #include <filesystem>

--- a/morpheus/_lib/src/stages/filter_detection.cpp
+++ b/morpheus/_lib/src/stages/filter_detection.cpp
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-#include <morpheus/stages/filter_detection.hpp>
+#include "morpheus/stages/filter_detection.hpp"
 
-#include <morpheus/utilities/matx_util.hpp>
+#include "morpheus/utilities/matx_util.hpp"
 
 #include <cstddef>
 #include <exception>

--- a/morpheus/_lib/src/stages/kafka_source.cpp
+++ b/morpheus/_lib/src/stages/kafka_source.cpp
@@ -15,25 +15,24 @@
  * limitations under the License.
  */
 
-#include <morpheus/stages/kafka_source.hpp>
+#include "morpheus/stages/kafka_source.hpp"
 
-#include <morpheus/messages/meta.hpp>
-#include <morpheus/utilities/stage_util.hpp>
-#include <morpheus/utilities/string_util.hpp>
+#include "morpheus/messages/meta.hpp"
+#include "morpheus/utilities/stage_util.hpp"
+#include "morpheus/utilities/string_util.hpp"
 
-#include <pysrf/node.hpp>
-#include <srf/runnable/context.hpp>
-#include <srf/segment/builder.hpp>
-
-#include <glog/logging.h>
-#include <http_client.h>
-#include <librdkafka/rdkafkacpp.h>
 #include <boost/fiber/recursive_mutex.hpp>
 #include <cudf/io/csv.hpp>
 #include <cudf/io/json.hpp>
 #include <cudf/strings/replace.hpp>
+#include <glog/logging.h>
+#include <http_client.h>
+#include <librdkafka/rdkafkacpp.h>
 #include <nlohmann/json.hpp>
 #include <nvtext/subword_tokenize.hpp>
+#include <pysrf/node.hpp>
+#include <srf/runnable/context.hpp>
+#include <srf/segment/builder.hpp>
 
 #include <chrono>
 #include <cstddef>

--- a/morpheus/_lib/src/stages/preprocess_fil.cpp
+++ b/morpheus/_lib/src/stages/preprocess_fil.cpp
@@ -15,25 +15,24 @@
  * limitations under the License.
  */
 
-#include <morpheus/stages/preprocess_fil.hpp>
+#include "morpheus/stages/preprocess_fil.hpp"
 
-#include <morpheus/messages/memory/inference_memory_fil.hpp>
-#include <morpheus/utilities/matx_util.hpp>
-#include <morpheus/utilities/type_util.hpp>
-#include <morpheus/utilities/type_util_detail.hpp>
+#include "morpheus/messages/memory/inference_memory_fil.hpp"
+#include "morpheus/utilities/matx_util.hpp"
+#include "morpheus/utilities/type_util.hpp"
+#include "morpheus/utilities/type_util_detail.hpp"
 
-#include <pysrf/node.hpp>
-#include <srf/segment/builder.hpp>
-
-#include <http_client.h>
-#include <librdkafka/rdkafkacpp.h>
-#include <pybind11/gil.h>
-#include <pybind11/pytypes.h>
 #include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/io/json.hpp>
 #include <cudf/types.hpp>
 #include <cudf/unary.hpp>
+#include <http_client.h>
+#include <librdkafka/rdkafkacpp.h>
+#include <pybind11/gil.h>
+#include <pybind11/pytypes.h>
+#include <pysrf/node.hpp>
 #include <rxcpp/rx-observable.hpp>
+#include <srf/segment/builder.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/morpheus/_lib/src/stages/preprocess_nlp.cpp
+++ b/morpheus/_lib/src/stages/preprocess_nlp.cpp
@@ -15,18 +15,17 @@
  * limitations under the License.
  */
 
-#include <morpheus/stages/preprocess_nlp.hpp>
+#include "morpheus/stages/preprocess_nlp.hpp"
 
-#include <morpheus/messages/multi_inference.hpp>
-#include <morpheus/utilities/type_util.hpp>
+#include "morpheus/messages/multi_inference.hpp"
+#include "morpheus/utilities/type_util.hpp"
 
-#include <pysrf/node.hpp>
-#include <srf/segment/builder.hpp>
-
-#include <librdkafka/rdkafkacpp.h>
 #include <cudf/types.hpp>
 #include <cudf/unary.hpp>
+#include <librdkafka/rdkafkacpp.h>
 #include <nvtext/subword_tokenize.hpp>
+#include <pysrf/node.hpp>
+#include <srf/segment/builder.hpp>
 
 #include <cstdint>
 #include <exception>

--- a/morpheus/_lib/src/stages/serialize.cpp
+++ b/morpheus/_lib/src/stages/serialize.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include <morpheus/stages/serialize.hpp>
+#include "morpheus/stages/serialize.hpp"
 
 #include <exception>
 #include <memory>

--- a/morpheus/_lib/src/stages/triton_inference.cpp
+++ b/morpheus/_lib/src/stages/triton_inference.cpp
@@ -15,19 +15,18 @@
  * limitations under the License.
  */
 
-#include <morpheus/stages/triton_inference.hpp>
+#include "morpheus/stages/triton_inference.hpp"
 
-#include <morpheus/messages/multi_response_probs.hpp>
-#include <morpheus/objects/triton_in_out.hpp>
-#include <morpheus/utilities/matx_util.hpp>
-#include <morpheus/utilities/stage_util.hpp>
-#include <morpheus/utilities/type_util.hpp>
-
-#include <pysrf/node.hpp>
+#include "morpheus/messages/multi_response_probs.hpp"
+#include "morpheus/objects/triton_in_out.hpp"
+#include "morpheus/utilities/matx_util.hpp"
+#include "morpheus/utilities/stage_util.hpp"
+#include "morpheus/utilities/type_util.hpp"
 
 #include <glog/logging.h>
 #include <http_client.h>
 #include <nlohmann/json.hpp>
+#include <pysrf/node.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/morpheus/_lib/src/stages/write_to_file.cpp
+++ b/morpheus/_lib/src/stages/write_to_file.cpp
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-#include <morpheus/stages/write_to_file.hpp>
+#include "morpheus/stages/write_to_file.hpp"
 
-#include <morpheus/utilities/matx_util.hpp>
+#include "morpheus/utilities/matx_util.hpp"
 
 #include <exception>
 #include <memory>

--- a/morpheus/_lib/src/utilities/cudf_util.cpp
+++ b/morpheus/_lib/src/utilities/cudf_util.cpp
@@ -15,13 +15,13 @@
  * limitations under the License.
  */
 
-#include <morpheus/utilities/cudf_util.hpp>
+#include "morpheus/utilities/cudf_util.hpp"
 
-#include <morpheus/objects/table_info.hpp>
+#include "morpheus/objects/table_info.hpp"
 
+#include <cudf/table/table.hpp>
 #include <glog/logging.h>
 #include <pybind11/gil.h>
-#include <cudf/table/table.hpp>
 
 /**
  * **************This needs to come last.********************

--- a/morpheus/_lib/src/utilities/cupy_util.cpp
+++ b/morpheus/_lib/src/utilities/cupy_util.cpp
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-#include <morpheus/utilities/cupy_util.hpp>
+#include "morpheus/utilities/cupy_util.hpp"
 
-#include <morpheus/objects/tensor.hpp>
+#include "morpheus/objects/tensor.hpp"
 
 #include <pybind11/cast.h>
 #include <pybind11/functional.h>  // IWYU pragma: keep

--- a/morpheus/_lib/src/utilities/matx_util.cu
+++ b/morpheus/_lib/src/utilities/matx_util.cu
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 
-#include <morpheus/utilities/matx_util.hpp>
+#include "morpheus/utilities/matx_util.hpp"
 
-#include <morpheus/objects/dev_mem_info.hpp>
-#include <morpheus/utilities/type_util.hpp>
-#include <morpheus/objects/tensor_object.hpp>
+#include "morpheus/objects/dev_mem_info.hpp"
+#include "morpheus/utilities/type_util.hpp"
+#include "morpheus/objects/tensor_object.hpp"
 
 #include <srf/cuda/sync.hpp>
 

--- a/morpheus/_lib/src/utilities/string_util.cpp
+++ b/morpheus/_lib/src/utilities/string_util.cpp
@@ -15,12 +15,11 @@
  * limitations under the License.
  */
 
-#include <morpheus/utilities/string_util.hpp>
+#include "morpheus/utilities/string_util.hpp"
 
 namespace morpheus {
-    bool StringUtil::str_contains(const std::string &str, const std::string &search_str)
-    {
-        return str.find(search_str) != std::string::npos;
-    }
+bool StringUtil::str_contains(const std::string &str, const std::string &search_str)
+{
+    return str.find(search_str) != std::string::npos;
 }
-
+}  // namespace morpheus

--- a/morpheus/_lib/src/utilities/table_util.cpp
+++ b/morpheus/_lib/src/utilities/table_util.cpp
@@ -15,11 +15,10 @@
  * limitations under the License.
  */
 
-#include <morpheus/utilities/table_util.hpp>
+#include "morpheus/utilities/table_util.hpp"
 
 #include <cudf/io/csv.hpp>
 #include <cudf/io/json.hpp>
-
 #include <glog/logging.h>
 
 #include <filesystem>
@@ -28,19 +27,25 @@
 namespace fs = std::filesystem;
 namespace py = pybind11;
 
-cudf::io::table_with_metadata morpheus::CuDFTableUtil::load_table(const std::string &filename) {
+cudf::io::table_with_metadata morpheus::CuDFTableUtil::load_table(const std::string &filename)
+{
     auto file_path = fs::path(filename);
 
-    if (file_path.extension() == ".json" || file_path.extension() == ".jsonlines") {
+    if (file_path.extension() == ".json" || file_path.extension() == ".jsonlines")
+    {
         // First, load the file into json
         auto options = cudf::io::json_reader_options::builder(cudf::io::source_info{filename}).lines(true);
 
         return cudf::io::read_json(options.build());
-    } else if (file_path.extension() == ".csv") {
+    }
+    else if (file_path.extension() == ".csv")
+    {
         auto options = cudf::io::csv_reader_options::builder(cudf::io::source_info{filename});
 
         return cudf::io::read_csv(options.build());
-    } else {
+    }
+    else
+    {
         LOG(FATAL) << "Unknown extension for file: " << filename;
         throw std::runtime_error("Unknown extension");
     }

--- a/morpheus/_lib/src/utilities/tensor_util.cpp
+++ b/morpheus/_lib/src/utilities/tensor_util.cpp
@@ -15,14 +15,13 @@
  * limitations under the License.
  */
 
-#include <morpheus/utilities/tensor_util.hpp>
+#include "morpheus/utilities/tensor_util.hpp"
 
+#include <experimental/iterator>
+#include <glog/logging.h>              // for DCHECK_EQ
 #include <srf/utils/sort_indexes.hpp>  // for sort_indexes
 
-#include <glog/logging.h>  // for DCHECK_EQ
-
-#include <algorithm>  // for copy
-#include <experimental/iterator>
+#include <algorithm>    // for copy
 #include <functional>   // for multiplies
 #include <iterator>     // for begin, end
 #include <numeric>      // for accumulate

--- a/morpheus/_lib/src/utilities/type_util.cu
+++ b/morpheus/_lib/src/utilities/type_util.cu
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include <morpheus/utilities/type_util.hpp>
+#include "morpheus/utilities/type_util.hpp"
 
 #include <stdexcept>
 #include <string>

--- a/morpheus/_lib/src/utilities/type_util_detail.cpp
+++ b/morpheus/_lib/src/utilities/type_util_detail.cpp
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-#include <morpheus/utilities/type_util_detail.hpp>
+#include "morpheus/utilities/type_util_detail.hpp"
 
-#include <morpheus/utilities/string_util.hpp>
+#include "morpheus/utilities/string_util.hpp"
 
 #include <glog/logging.h>
 

--- a/morpheus/_lib/tests/test_cuda.cu
+++ b/morpheus/_lib/tests/test_cuda.cu
@@ -17,7 +17,7 @@
 
 #include "test_morpheus.hpp"
 
-#include <morpheus/objects/tensor_object.hpp>
+#include "morpheus/objects/tensor_object.hpp"
 
 #include <srf/cuda/common.hpp> // for SRF_CHECK_CUDA
 #include <srf/cuda/sync.hpp> // for enqueue_stream_sync_event

--- a/morpheus/_lib/tests/test_type_util_detail.cpp
+++ b/morpheus/_lib/tests/test_type_util_detail.cpp
@@ -17,7 +17,7 @@
 
 #include "./test_morpheus.hpp"  // IWYU pragma: associated
 
-#include <morpheus/utilities/type_util_detail.hpp>
+#include "morpheus/utilities/type_util_detail.hpp"
 
 #include <gtest/gtest.h>  // for EXPECT_EQ
 


### PR DESCRIPTION
* Use quoted includes for morpheus headers
* Updates clang-format to re-order include blocks patterned after srf's
* Adds a check for `#pragma once` in headers (borrowed from srf)
* Add `cpp_checks.sh` to CI