### PR TITLE
Updates README.md to include instructions for launching Triton

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -304,22 +304,6 @@ Launching a full production Kafka cluster is outside the scope of this project. 
 
       **Note:** This will consume messages.
 
-### Launching Triton Server
-
-Many of the validation tests and example workflows require a Triton server to function. To launch Triton server, use the following command:
-
-```bash
-docker run --rm -ti --gpus=all -p8000:8000 -p8001:8001 -p8002:8002 -v $PWD/models:/models \
-  nvcr.io/nvidia/tritonserver:21.12-py3 \
-    tritonserver --model-repository=/models/triton-model-repo \
-                 --exit-on-error=false \
-                 --model-control-mode=explicit \
-                 --load-model abp-nvsmi-xgb \
-                 --load-model sid-minibert-onnx \
-                 --load-model phishing-bert-onnx
-```
-This will launch Triton using port 8001 for the GRPC server. This needs to match the Morpheus configuration.
-
 ### Pipeline Validation
 
 To verify that all pipelines are working correctly, validation scripts have been added at `${MORPHEUS_ROOT}/scripts/validation`. There are scripts for each of the main workflows: Anomalous Behavior Profiling (ABP), Humans-as-Machines-Machines-as-Humans (HAMMAH), Phishing Detection (Phishing), and Sensitive Information Detection (SID).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,11 +73,7 @@ This workflow utilizes a docker container to set up most dependencies ensuring a
 
 #### Prerequisites
 
-- Pascal architecture or better
-- NVIDIA driver `450.80.02` or higher
-- [Docker](https://docs.docker.com/get-docker/)
-- [The NVIDIA container toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
-
+1. Ensure all [requirements](README.md#requirements) from [README.md](README.md) are met.
 1. Build the development container
    ```bash
    ./docker/build_container_dev.sh
@@ -154,7 +150,7 @@ Note: These instructions assume the user is using `mamba` instead of `conda` sin
 
 - Pascal architecture or better
 - NVIDIA driver `450.80.02` or higher
-- [CUDA 11.0+](https://developer.nvidia.com/cuda-downloads)
+- [Cuda 11.5](https://developer.nvidia.com/cuda-11-5-2-download-archive)
 - `conda` and `mamba`
   - See the [Getting Started Guide](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) if `conda` is not already installed
   - Install `mamba`:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,9 +148,9 @@ Note: These instructions assume the user is using `mamba` instead of `conda` sin
 
 #### Prerequisites
 
-- Pascal architecture or better
+- Pascal architecture GPU or better
 - NVIDIA driver `450.80.02` or higher
-- [Cuda 11.5](https://developer.nvidia.com/cuda-11-5-2-download-archive)
+- [CUDA 11.5](https://developer.nvidia.com/cuda-11-5-2-download-archive)
 - `conda` and `mamba`
   - See the [Getting Started Guide](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) if `conda` is not already installed
   - Install `mamba`:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,32 +65,7 @@ cd $MORPHEUS_ROOT
 ```
 The large model and data files in this repo are stored using [Git Large File Storage (LFS)](https://git-lfs.github.com/). These files will be required for running the training/validation scripts and example pipelines for the Morpheus pre-trained models.
 
-By default only those files stored in LFS strictly needed for running Morpheus are included when the Morpheus repository is cloned. Additional datasets can be downloaded using the `scripts/fetch_data.py` script. Usage of the script is as follows:
-```bash
-scripts/fetch_data.py fetch <dataset> [<dataset>...]
-```
-
-At time of writing the defined datasets are:
-* all - Metaset includes all others
-* examples - Data needed by scripts in the `examples` subdir
-* models - Morpheus models (largest dataset)
-* tests - Data used by unittests
-* validation - Subset of the models dataset needed by some unittests
-
-To download just the examples and models:
-```bash
-scripts/fetch_data.py fetch examples models
-```
-
-To download the data needed for unittests:
-```bash
-scripts/fetch_data.py fetch tests validation
-```
-
-If `Git LFS` is not installed before cloning the repository, the large files will not be pulled. If this is the case, follow the instructions for installing `Git LFS` from [here](https://git-lfs.github.com/), and then run the following command.
-```bash
-scripts/fetch_data.py fetch all
-```
+By default only those files stored in LFS strictly needed for running Morpheus are included when the Morpheus repository is cloned. Additional datasets can be downloaded using the `scripts/fetch_data.py` script. See the section [Git LFS](README.md#git-lfs) of the [README.md](README.md) file for details on this.
 
 ### Build in Docker Container
 

--- a/README.md
+++ b/README.md
@@ -27,14 +27,6 @@ The following sections must be followed prior to building the Morpheus container
 - [The NVIDIA container toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
 - [Git LFS](https://git-lfs.github.com/)
 
-#### Git LFS
-
-The large model and data files in this repo are stored using [Git Large File Storage (LFS)](https://git-lfs.github.com/). These files will be required for running the training/validation scripts and example pipelines for the Morpheus pre-trained models.
-
-If `Git LFS` is not installed before cloning the repository, the large files will not be pulled. If this is the case, follow the instructions for installing `Git LFS` from [here](https://git-lfs.github.com/), and then run the following command:
-```bash
-git lfs install
-```
 
 #### Clone the Repository
 
@@ -44,10 +36,37 @@ git clone https://github.com/NVIDIA/Morpheus.git $MORPHEUS_ROOT
 cd $MORPHEUS_ROOT
 ```
 
-**Note:** If the repository was cloned before `Git LFS` was installed, you can ensure you have downloaded the LFS files with the command:
+#### Git LFS
 
+The large model and data files in this repo are stored using [Git Large File Storage (LFS)](https://git-lfs.github.com/). Only those files which are strictly needed to run Morpheus are downloaded by default when the repository is cloned.
+
+The `scripts/fetch_data.py` script can be used to fetch the Morpheus pre-trained models, and other files required for running the training/validation scripts and example pipelines.
+
+Usage of the script is as follows:
 ```bash
-git lfs pull
+scripts/fetch_data.py fetch <dataset> [<dataset>...]
+```
+
+At time of writing the defined datasets are:
+* all - Metaset includes all others
+* examples - Data needed by scripts in the `examples` subdir
+* models - Morpheus models (largest dataset)
+* tests - Data used by unittests
+* validation - Subset of the models dataset needed by some unittests
+
+To download just the examples and models:
+```bash
+scripts/fetch_data.py fetch examples models
+```
+
+To download the data needed for unittests:
+```bash
+scripts/fetch_data.py fetch tests validation
+```
+
+If `Git LFS` is not installed the before cloning the repository, the `scripts/fetch_data.py` script will fail. If this is the case follow the instructions for installing `Git LFS` from [here](https://git-lfs.github.com/), and then run the following command:
+```bash
+git lfs install
 ```
 
 ### Build Morpheus Container

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ More advanced users, or those who are interested in using the latest pre-release
 The following sections must be followed prior to building the Morpheus container or building Morpheus from source.
 
 #### Requirements
-- Pascal architecture or better
+- Pascal architecture GPU or better
 - NVIDIA driver `450.80.02` or higher
 - [Docker](https://docs.docker.com/get-docker/)
 - [The NVIDIA container toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The following sections must be followed prior to building the Morpheus container
 - NVIDIA driver `450.80.02` or higher
 - [Docker](https://docs.docker.com/get-docker/)
 - [The NVIDIA container toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
+- [NVIDIA Triton Inference Server](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tritonserver) `22.02` or higher
 - [Git LFS](https://git-lfs.github.com/)
 
 
@@ -94,6 +95,22 @@ DOCKER_IMAGE_TAG="v22.06.00a-runtime" ./docker/run_container_release.sh
 ### Build from Source
 
 It's possible to build from source outside of a container. However, due to the large number of dependencies, this can be complex and is only necessary for developers. Instructions for developers and contributors can be found in [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+## Launching Triton Server
+
+Many of the validation tests and example workflows require a Triton server to function.
+Use the following command to launch a Docker container for Triton loading all of the included pre-trained models:
+
+```bash
+docker run --rm -ti --gpus=all -p8000:8000 -p8001:8001 -p8002:8002 \
+	-v $PWD/models:/models \
+	nvcr.io/nvidia/tritonserver:22.02-py3 \
+	tritonserver --model-repository=/models/triton-model-repo \
+		--exit-on-error=false \
+		--log-info=true \
+		--strict-readiness=false
+```
+This will launch Triton using the default network ports (8000 for HTTP, 8001 for GRPC, and 8002 for metrics).
 
 ## Running Morpheus
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The following sections must be followed prior to building the Morpheus container
 - NVIDIA driver `450.80.02` or higher
 - [Docker](https://docs.docker.com/get-docker/)
 - [The NVIDIA container toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
-- [NVIDIA Triton Inference Server](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tritonserver) `22.02` or higher
+- [NVIDIA Triton Inference Server](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tritonserver) `22.06` or higher
 - [Git LFS](https://git-lfs.github.com/)
 
 
@@ -104,7 +104,7 @@ Use the following command to launch a Docker container for Triton loading all of
 ```bash
 docker run --rm -ti --gpus=all -p8000:8000 -p8001:8001 -p8002:8002 \
 	-v $PWD/models:/models \
-	nvcr.io/nvidia/tritonserver:22.02-py3 \
+	nvcr.io/nvidia/tritonserver:22.06-py3 \
 	tritonserver --model-repository=/models/triton-model-repo \
 		--exit-on-error=false \
 		--log-info=true \

--- a/scripts/validation/val-globals.sh
+++ b/scripts/validation/val-globals.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/validation/val-globals.sh
+++ b/scripts/validation/val-globals.sh
@@ -26,7 +26,7 @@ export e="\033[0;90m"
 export y="\033[0;33m"
 export x="\033[0m"
 
-export TRITON_IMAGE=${TRITON_IMAGE:-"nvcr.io/nvidia/tritonserver:22.02-py3"}
+export TRITON_IMAGE=${TRITON_IMAGE:-"nvcr.io/nvidia/tritonserver:22.06-py3"}
 
 # TRITON_GRPC_PORT is only used when TRITON_URL is undefined
 export TRITON_GRPC_PORT=${TRITON_GRPC_PORT:-"8001"}

--- a/scripts/validation/val-utils.sh
+++ b/scripts/validation/val-utils.sh
@@ -68,7 +68,7 @@ function wait_for_triton {
 
 function ensure_triton_running {
 
-   TRITON_IMAGE=${TRITON_IMAGE:-"nvcr.io/nvidia/tritonserver:22.02-py3"}
+   TRITON_IMAGE=${TRITON_IMAGE:-"nvcr.io/nvidia/tritonserver:22.06-py3"}
 
    IS_RUNNING=$(is_triton_running)
 

--- a/scripts/validation/val-utils.sh
+++ b/scripts/validation/val-utils.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Also updates:
* Git LFS instructions
* Software requirements
* Specifics that apply to all users were moved from `CONTRIBUTING.md` to `README.md`
* Default version of Triton used by Validation scripts updated to 22.06 

Fixes #288