### PR TITLE
add nvidia-tensorrt dependency in requirements.txt. Examples where a BERT model needed to be optimized failed within the container due to tensorrt module missing.

### DIFF
--- a/docker/conda/environments/requirements.txt
+++ b/docker/conda/environments/requirements.txt
@@ -11,6 +11,7 @@ git+https://github.com/efajardo-nv/dfencoder.git@nv-updates#egg=dfencoder
 grpcio-channelz
 networkx
 nvidia-pyindex
+nvidia-tensorrt
 pybind11-stubgen==0.10.5
 torch==1.10.2+cu113
 tqdm


### PR DESCRIPTION
Signed-off-by: Brandon Tuttle <btuttle@nvidia.com>

While running through the examples and attempting to deploy models to Triton, I wanted to use TensorRT, as explained in models/triton-model-repo/sid-minibert-trt/1/README.md, the script-built container does not have the tensorrt modules installed to optimize. 