### PR TITLE
Removing `grpcio-channelz`

### DIFF
--- a/ci/conda/recipes/morpheus/meta.yaml
+++ b/ci/conda/recipes/morpheus/meta.yaml
@@ -61,27 +61,33 @@ outputs:
         - libcudf {{ rapids_version }}
         - librdkafka 1.7
         - pip
-        - pybind11-stubgen
+        - pybind11-stubgen 0.10.5
         - python {{ python }}
         - rapidjson 1.1
         - scikit-build >=0.12
         - srf {{ minor_version }}
         - versioneer-518
       run:
+        # Runtime only requirements. This + setup.y is the definitive runtime requirement list
         - click >=8
+        - configargparse 1.5
         - cuda-python <=11.7.0 # Remove when Issue #251 is closed
         - cudf {{ rapids_version }}
         - cudf_kafka {{ rapids_version }}
         - cupy # Version determined from cudf
+        - datacompy 0.8
         - distributed
+        - docker-py 5.0
         - grpcio # Version determined from cudf
         - mlflow >=1.23
-        - networkx
+        - networkx 2.8
+        - numpydoc 1.4
         - pandas 1.3
-        - pluggy
+        - pluggy 1.0
         - python
-        - tqdm
-        - typing_utils
+        - tqdm 4
+        - typing_utils 0.1
+        - watchdog 2.1
 
     test:
       requires:

--- a/docker/conda/environments/cuda11.5_dev.yml
+++ b/docker/conda/environments/cuda11.5_dev.yml
@@ -28,7 +28,9 @@ dependencies:
     - cachetools=5.0.0
     - ccache>=3.7
     - clangdev=14
+    - click >=8
     - cmake=3.22
+    - configargparse=1.5
     - cuda-nvml-dev=11.5
     - cuda-python<=11.7.0 # Remove when Issue #251 is closed
     - cudatoolkit=11.5
@@ -36,8 +38,9 @@ dependencies:
     - cudf_kafka 22.08.*
     - cupy=9.5.0
     - cython=0.29.24
+    - datacompy=0.8
     - docker-compose=1.29.2
-    - docker-py=5.0.3
+    - docker-py=5.0
     - faker=12.3.0
     - flake8
     - flatbuffers=2.0
@@ -55,13 +58,16 @@ dependencies:
     - isort
     - mlflow>=1.23
     - myst-parser==0.17
+    - networkx=2.8
     - ninja=1.10
     - nodejs=17.4.0
+    - numpydoc=1.4
     - pandas=1.3
     - pip
     - pkg-config # for srf cmake
+    - pluggy=1.0
     - protobuf=3.20
-    - pybind11-stubgen
+    - pybind11-stubgen=0.10.5
     - pydot
     - pytest
     - pytest-benchmark
@@ -74,7 +80,9 @@ dependencies:
     - sphinx_rtd_theme
     - srf 22.08.*
     - sysroot_linux-64=2.17
-    - tqdm
+    - tqdm=4
+    - typing_utils=0.1
+    - watchdog=2.1
     - yapf=0.32.0
     ####### Morpheus Pip Dependencies (keep sorted!) #######
     - pip:

--- a/docker/conda/environments/cuda11.5_dev.yml
+++ b/docker/conda/environments/cuda11.5_dev.yml
@@ -48,6 +48,7 @@ dependencies:
     - gmock=1.10
     - gputil
     - grpc-cpp>=1.43
+    - grpcio
     - gtest=1.10
     - gxx_linux-64=9.4
     - include-what-you-use=0.18

--- a/docker/conda/environments/requirements.txt
+++ b/docker/conda/environments/requirements.txt
@@ -3,17 +3,8 @@
 --find-links https://download.pytorch.org/whl/cu113/torch_stable.html
 
 ####### Pip-only runtime dependencies (keep sorted!) #######
-click>=8
-configargparse
-datacompy
-docker
+# Packages listed here should also be listed in setup.py
 git+https://github.com/nv-morpheus/dfencoder.git@branch-22.09#egg=dfencoder
-networkx
-numpydoc
 nvidia-pyindex
-pybind11-stubgen==0.10.5
 torch==1.10.2+cu113
-tqdm
-tritonclient[all]
-typing-utils
-watchdog==2.1.8
+tritonclient[all]==2.17.*

--- a/docker/conda/environments/requirements.txt
+++ b/docker/conda/environments/requirements.txt
@@ -8,7 +8,6 @@ configargparse
 datacompy
 docker
 git+https://github.com/nv-morpheus/dfencoder.git@branch-22.09#egg=dfencoder
-grpcio-channelz
 networkx
 numpydoc
 nvidia-pyindex

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         "pluggy",
         "torch==1.10.2+cu113",
         "tqdm",
-        "tritonclient[all]",
+        "tritonclient[all]==2.17",  # Force to 2.17 since they require grpcio==1.41 for newer versions
         "typing-utils",
     ],
     license="Apache",

--- a/setup.py
+++ b/setup.py
@@ -40,18 +40,11 @@ setup(
     include_package_data=True,
     packages=find_packages(include=["morpheus", "morpheus.*"], exclude=['tests']),
     install_requires=[
-        "click>=8",
-        "datacompy",
-        "docker",
+        # Only list the packages which cannot be installed via conda here. Should mach the requirements in
+        # docker/conda/environments/requirements.txt
         "dfencoder @ git+https://github.com/nv-morpheus/dfencoder.git@branch-22.09#egg=dfencoder",
-        "mlflow>=1.23",
-        "networkx",
-        "pandas>=1.3",
-        "pluggy",
         "torch==1.10.2+cu113",
-        "tqdm",
-        "tritonclient[all]==2.17",  # Force to 2.17 since they require grpcio==1.41 for newer versions
-        "typing-utils",
+        "tritonclient[all]==2.17.*",  # Force to 2.17 since they require grpcio==1.41 for newer versions
     ],
     license="Apache",
     python_requires='>=3.8, <4',

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
         "datacompy",
         "docker",
         "dfencoder @ git+https://github.com/nv-morpheus/dfencoder.git@branch-22.09#egg=dfencoder",
-        "grpcio-channelz",
         "mlflow>=1.23",
         "networkx",
         "pandas>=1.3",


### PR DESCRIPTION
Looks like the `grpcio-channelz` package has been breaking CI. Since this package isnt even used anywhere since the `streamz` days, we should remove it.