### PR TITLE
Fill in missing pieces for DFP documentation

### DIFF
--- a/docs/source/developer_guide/guides/5_digital_fingerprinting.md
+++ b/docs/source/developer_guide/guides/5_digital_fingerprinting.md
@@ -15,18 +15,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<!--
-The Sphinx theme we are using applies an upper-case to all h4 headings. In this document we are uding H4 headings
-for our class names and did not want to lose any of our camel-casing. We dind't want to apply this change globally as
-we wanted to retain this in other documents, this it appears here as an in-line override.
--->
-<style>
-    h4
-    {
-        text-transform: none;
-    }
-</style>
-
 # 5. Digital Fingerprinting (DFP)
 
 ## Overview
@@ -116,6 +104,7 @@ DFP in Morpheus is accomplished via two independent pipelines: training and infe
 * Detected anomilies are published to an S3 bucket, directory or a Kafka topic.
 * Output can be integrated with a monitoring tool.
 
+
 ## Runtune Environment Setup
 ![Runtune Environment Setup](img/dfp_runtime_env.png)
 
@@ -153,6 +142,7 @@ The reference architecture is composed of the following services:​
 The stages in both the Training and Inference pipelines can be mixed and matched with little impact​, i.e., the `MultiFileSource` can be configured to pull from S3 or from local files and can be replaced altogether with any other Morpheus input stage. similarly the S3 writer can be replaced with any Morpheus output stage.  Regardless of the inputs & outputs the core pipeline should renmain unchanged.  While stages in the core of the pipeline (inside the blue areas in the above diagram) perform common actions that should be configured not exchanged.
 
 ### Morpheus Config
+
 For both inference and training pipeline the Morpheus config object should be constructed with the same values, and should look like:
 ```python
 import os
@@ -453,6 +443,7 @@ For any user without an associated model in MLflow, the model for the generic us
 | -------- | ---- | ----------- |
 | `c` | `morpheus.config.Config` | Morpheus config object |
 | `model_name_formatter` | `str` | Format string to control the name of models fetched from MLflow.  Currently available field names are: `user_id`. |
+
 
 #### DFPPostprocessingStage
 The `DFPPostprocessingStage` [examples/digital_fingerprinting/production/morpheus/dfp/stages/dfp_postprocessing_stage.py](/examples/digital_fingerprinting/production/morpheus/dfp/stages/dfp_postprocessing_stage.py) stage filters records contained in the `DataFrame` emits a new `dfp.messages.DFPMessageMeta` message containing all records with a z score greater than `z_score_threshold` or `None` if no records are greater than `z_score_threshold`.

--- a/docs/source/developer_guide/guides/5_digital_fingerprinting.md
+++ b/docs/source/developer_guide/guides/5_digital_fingerprinting.md
@@ -410,6 +410,11 @@ After training the generic model, individual user models can be trained​.  Ind
 #### DFPTraining
 The `DFPTraining` [examples/digital_fingerprinting/production/morpheus/dfp/stages/dfp_training.py](/examples/digital_fingerprinting/production/morpheus/dfp/stages/dfp_training.py) trains a model for each incoming `DataFrame` and emits an instance of `morpheus.messages.multi_ae_message.MultiAEMessage` containing the trained model.
 
+| Argument | Type | Descirption |
+| -------- | ---- | ----------- |
+| `c` | `morpheus.config.Config` | Morpheus config object |
+| `model_kwargs` | `dict` or `None` | Optional dictionary of keyword arguments to be used when constructing the model. | 
+
 #### DFPMLFlowModelWriterStage
 The `DFPMLFlowModelWriterStage` [examples/digital_fingerprinting/production/morpheus/dfp/stages/dfp_mlflow_model_writer.py](/examples/digital_fingerprinting/production/morpheus/dfp/stages/dfp_mlflow_model_writer.py) stage publishes trained models into MLflow, skipping any model which lacked sufficient training data (current required minimum is 300 log records).
 
@@ -442,7 +447,8 @@ For any user without an associated model in MLflow, the model for the generic us
 | Argument | Type | Descirption |
 | -------- | ---- | ----------- |
 | `c` | `morpheus.config.Config` | Morpheus config object |
-| `model_name_formatter` | `str` | Format string to control the name of models fetched from MLflow.  Currently available field names are: `user_id`. |
+| `model_name_formatter` | `str` | Format string to control the name of models fetched from MLflow.  Currently available field names are: `user_id` and `user_md5` which is an md5 hexadecimal digest as returned by [`hash.hexdigest`](https://docs.python.org/3.8/library/hashlib.html?highlight=hexdigest#hashlib.hash.hexdigest). |
+
 
 
 #### DFPPostprocessingStage

--- a/docs/source/developer_guide/guides/5_digital_fingerprinting.md
+++ b/docs/source/developer_guide/guides/5_digital_fingerprinting.md
@@ -239,12 +239,9 @@ from dfp.utils.column_info import DataFrameInputSchema
 from dfp.utils.column_info import DateTimeColumn
 ```
 ```python
-schema = DataFrameInputSchema(json_columns=['event'],
-                                column_info=[
-                                    DateTimeColumn(name=config.ae.timestamp_column_name,
-                                                   dtype=datetime,
-                                                   input_name='event.timestamp')
-                                ])
+schema = DataFrameInputSchema(
+    json_columns=['event'],
+    column_info=[DateTimeColumn(name=config.ae.timestamp_column_name, dtype=datetime, input_name='event.timestamp')])
 ```
 
 In the above examples three opperations were performed:
@@ -261,6 +258,47 @@ The `DFPFileToDataFrameStage` is executed first and is responsible for flattenin
 | `preserve_columns` | `List[str]` or `str` | Optional regular expression string or list of regular expression strings that define columns in the input data which should be preserved in the output `DataFrame`. By default this is an empty `list`. |
 | `row_filter` | `function` or `None` | Optional function to be called after all other processing has been performed. This function receives the `DataFrame` as it's only argument returning a `DataFrame`. |
 
+#### ColumnInfo Classes
+The `ColumnInfo` class and subclasses define a single column.
+
+##### ColumnInfo
+Defines a single column and type-cast.
+| Argument | Type | Descirption |
+| -------- | ---- | ----------- |
+| `name` | `str` | Name of the column |
+| `dtype` | `str` or Python type | Any type string or Python class recognized by [Pandas](https://pandas.pydata.org/docs/user_guide/basics.html#dtypes) |
+
+##### CustomColumn
+Defines a column to be computed by a user-defined function `process_column_fn`.
+
+| Argument | Type | Descirption |
+| -------- | ---- | ----------- |
+| `name` | `str` | Name of the column |
+| `dtype` | `str` or Python type | Any type string or Python class recognized by [Pandas](https://pandas.pydata.org/docs/user_guide/basics.html#dtypes) |
+| `process_column_fn` | `function` | Function which receives the entire `DataFrame` as it's only input, returning a new [`pandas.Series`](https://pandas.pydata.org/docs/reference/api/pandas.Series.html) object to be stored in column `name`. |
+
+##### RenameColumn
+Similar to `ColumnInfo` but adds the ability to also perform a rename.
+| Argument | Type | Descirption |
+| -------- | ---- | ----------- |
+| `name` | `str` | Name of the destination column |
+| `dtype` | `str` or Python type | Any type string or Python class recognized by [Pandas](https://pandas.pydata.org/docs/user_guide/basics.html#dtypes) |
+| `input_name` | `str` | Original column name |
+
+##### BoolColumn
+Subclass of `RenameColumn` adds the ability to map a set custom values as boolean values. For example say we had a string input field containing one of 5 possible enum values: `OK`, `SUCCESS`, `DENIED`, `CANCELED` and `EXPIRED` we could map these values into a single boolean field as:
+```python
+from dfp.utils.column_info import BoolColumn
+```
+```python
+field = BoolColumn(name="result",
+                   dtype=bool,
+                   input_name="result",
+                   true_values=["OK", "SUCCESS"],
+                   false_values=["DENIED", "CANCELED", "EXPIRED"])
+```
+
+We used strings in this example, however we also could have just as easily mapped integer status codes.
 
 ### Output Stages
 ![Output Stages](img/dfp_output_config.png)

--- a/docs/source/developer_guide/guides/5_digital_fingerprinting.md
+++ b/docs/source/developer_guide/guides/5_digital_fingerprinting.md
@@ -298,7 +298,57 @@ field = BoolColumn(name="result",
                    false_values=["DENIED", "CANCELED", "EXPIRED"])
 ```
 
-We used strings in this example, however we also could have just as easily mapped integer status codes.
+We used strings in this example, however we also could have just as easily mapped integer status codes.  We also have the ability to map on to types other than boolean by providing custom values for true and false  (eg. `1`/`0`, `yes`/`no`) .
+
+| Argument | Type | Descirption |
+| -------- | ---- | ----------- |
+| `name` | `str` | Name of the destination column |
+| `dtype` | `str` or Python type | Typically this should be `bool` however it could potentially be another type if `true_value` and `false_value` are specified. |
+| `input_name` | `str` | Original column name |
+| `true_value` | Any | Optional value to store for true values, should be of a type `dtype`. Defaults to `True`. |
+| `false_value` | Any | Optional value to store for false values, should be of a type `dtype`. Defaults to `False`. |
+| `true_values` | `List[str]` | List of string values to be interpreted as true. |
+| `false_values` | `List[str]` | List of string values to be interpreted as false. |
+
+##### DateTimeColumn
+Subclass of `RenameColumn` specific to casting UTC localized datetime values. When incoming values contain a time-zone offset string the values are converted to UTC, while values without a time-zone are assumed to be UTC.
+
+| Argument | Type | Descirption |
+| -------- | ---- | ----------- |
+| `name` | `str` | Name of the destination column |
+| `dtype` | `str` or Python type | Any type string or Python class recognized by [Pandas](https://pandas.pydata.org/docs/user_guide/basics.html#dtypes) |
+| `input_name` | `str` | Original column name |
+
+##### StringJoinColumn
+Subclass of `RenameColumn`, converts incoming `list` values to string by joining by `sep`.
+
+| Argument | Type | Descirption |
+| -------- | ---- | ----------- |
+| `name` | `str` | Name of the destination column |
+| `dtype` | `str` or Python type | Any type string or Python class recognized by [Pandas](https://pandas.pydata.org/docs/user_guide/basics.html#dtypes) |
+| `input_name` | `str` | Original column name |
+| `sep` | `str` | Separator string to use for the join |
+
+##### StringCatColumn
+Concatinate values from multiple columns into a new string column separated by `sep`.
+
+| Argument | Type | Descirption |
+| -------- | ---- | ----------- |
+| `name` | `str` | Name of the destination column |
+| `dtype` | `str` or Python type | Any type string or Python class recognized by [Pandas](https://pandas.pydata.org/docs/user_guide/basics.html#dtypes) |
+| `input_columns` | `List[str]` | List of columns to concatinate |
+| `sep` | `str` | Separator string |
+
+##### IncrementColumn
+Subclass of `DateTimeColumn`, counts the unique occurrences of a value in `groupby_column` over a specific time window `period` based on dates in the `input_name` field.
+
+| Argument | Type | Descirption |
+| -------- | ---- | ----------- |
+| `name` | `str` | Name of the destination column |
+| `dtype` | `str` or Python type | Should be `int` or other integer class |
+| `input_name` | `str` | Original column name containing timestamp values |
+| `groupby_column` | `str` | Column name to group by |
+| `period` | `str` | Optional time period to peform the calculation over, value must be [one of pandas' offset strings](https://pandas.pydata.org/docs/user_guide/timeseries.html#timeseries-offset-aliases). Defaults to `D` one day |
 
 ### Output Stages
 ![Output Stages](img/dfp_output_config.png)

--- a/docs/source/developer_guide/guides/5_digital_fingerprinting.md
+++ b/docs/source/developer_guide/guides/5_digital_fingerprinting.md
@@ -15,6 +15,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+<!--
+The Sphinx theme we are using applies an upper-case to all h4 headings. In this document we are uding H4 headings
+for our class names and did not want to lose any of our camel-casing. We dind't want to apply this change globally as
+we wanted to retain this in other documents, this it appears here as an in-line override.
+-->
+<style>
+    h4
+    {
+        text-transform: none;
+    }
+</style>
+
 # 5. Digital Fingerprinting (DFP)
 
 ## Overview
@@ -104,7 +116,6 @@ DFP in Morpheus is accomplished via two independent pipelines: training and infe
 * Detected anomilies are published to an S3 bucket, directory or a Kafka topic.
 * Output can be integrated with a monitoring tool.
 
-
 ## Runtune Environment Setup
 ![Runtune Environment Setup](img/dfp_runtime_env.png)
 
@@ -142,7 +153,6 @@ The reference architecture is composed of the following services:​
 The stages in both the Training and Inference pipelines can be mixed and matched with little impact​, i.e., the `MultiFileSource` can be configured to pull from S3 or from local files and can be replaced altogether with any other Morpheus input stage. similarly the S3 writer can be replaced with any Morpheus output stage.  Regardless of the inputs & outputs the core pipeline should renmain unchanged.  While stages in the core of the pipeline (inside the blue areas in the above diagram) perform common actions that should be configured not exchanged.
 
 ### Morpheus Config
-
 For both inference and training pipeline the Morpheus config object should be constructed with the same values, and should look like:
 ```python
 import os
@@ -443,7 +453,6 @@ For any user without an associated model in MLflow, the model for the generic us
 | -------- | ---- | ----------- |
 | `c` | `morpheus.config.Config` | Morpheus config object |
 | `model_name_formatter` | `str` | Format string to control the name of models fetched from MLflow.  Currently available field names are: `user_id`. |
-
 
 #### DFPPostprocessingStage
 The `DFPPostprocessingStage` [examples/digital_fingerprinting/production/morpheus/dfp/stages/dfp_postprocessing_stage.py](/examples/digital_fingerprinting/production/morpheus/dfp/stages/dfp_postprocessing_stage.py) stage filters records contained in the `DataFrame` emits a new `dfp.messages.DFPMessageMeta` message containing all records with a z score greater than `z_score_threshold` or `None` if no records are greater than `z_score_threshold`.

--- a/examples/digital_fingerprinting/production/morpheus/dfp/utils/column_info.py
+++ b/examples/digital_fingerprinting/production/morpheus/dfp/utils/column_info.py
@@ -159,10 +159,10 @@ class IncrementColumn(DateTimeColumn):
     period: str = "D"
 
     def process_column(self, df: pd.DataFrame) -> pd.Series:
-        per_day = super().process_column(df).dt.to_period(self.period)
+        period = super().process_column(df).dt.to_period(self.period)
 
-        # Create the per-user, per-day log count
-        return df.groupby([self.groupby_column, per_day]).cumcount()
+        # Create the `groupby_column`, per-period log count
+        return df.groupby([self.groupby_column, period]).cumcount()
 
 
 @dataclasses.dataclass

--- a/examples/digital_fingerprinting/production/morpheus/dfp/utils/column_info.py
+++ b/examples/digital_fingerprinting/production/morpheus/dfp/utils/column_info.py
@@ -169,7 +169,7 @@ class IncrementColumn(DateTimeColumn):
 class DataFrameInputSchema:
     json_columns: typing.List[str] = dataclasses.field(default_factory=list)
     column_info: typing.List[ColumnInfo] = dataclasses.field(default_factory=list)
-    preserve_columns: re.Pattern = dataclasses.field(default_factory=list)
+    preserve_columns: typing.List[str] = dataclasses.field(default_factory=list)
     row_filter: typing.Callable[[pd.DataFrame], pd.DataFrame] = None
 
     def __post_init__(self):


### PR DESCRIPTION
* Docs for `DataFrameInputSchema`
* Docs for `ColumnInfo` & subclasses
* Docs for `DFPTraining` constructor args
* Update docs for `DFPInferenceStage` to reflect recent fixes to `model_name_formatter`
* Minor type-hint, comment & variable name fixes for `column_info.py`