### PR TITLE
Pin camouflage to v0.9 and ensure pytest-benchmark>=4

### DIFF
--- a/ci/scripts/github/test.sh
+++ b/ci/scripts/github/test.sh
@@ -30,7 +30,7 @@ pip install ${MORPHEUS_ROOT}/build/wheel
 CPP_TESTS=($(find ${MORPHEUS_ROOT}/build/wheel -name "*.x"))
 
 rapids-logger "Installing test dependencies"
-npm install --silent -g camouflage-server
+npm install --silent -g camouflage-server@0.9
 
 # Kafka tests need Java, since this stage is the only one that needs it, installing it here rather than adding it to
 # the ci.yaml file

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -172,7 +172,7 @@ FROM conda_env_dev as development
 # COPY . ./
 
 # Install camouflage needed for unittests to mock a triton server
-RUN npm install -g camouflage-server
+RUN npm install -g camouflage-server@0.9
 
 # Setup git to allow other users to access /workspace. Requires git 2.35.3 or
 # greater. See https://marc.info/?l=git&m=164989570902912&w=2. Only enable for

--- a/docker/conda/environments/cuda11.5_dev.yml
+++ b/docker/conda/environments/cuda11.5_dev.yml
@@ -71,7 +71,6 @@ dependencies:
     - pybind11-stubgen=0.10.5
     - pydot
     - pytest
-    - pytest-benchmark
     - pytest-cov
     - python-graphviz
     - python=3.8

--- a/docker/conda/environments/cuda11.5_dev.yml
+++ b/docker/conda/environments/cuda11.5_dev.yml
@@ -71,6 +71,7 @@ dependencies:
     - pybind11-stubgen=0.10.5
     - pydot
     - pytest
+    - pytest-benchmark>=4.0
     - pytest-cov
     - python-graphviz
     - python=3.8

--- a/docker/conda/environments/requirements.txt
+++ b/docker/conda/environments/requirements.txt
@@ -6,6 +6,7 @@
 # Packages listed here should also be listed in setup.py
 git+https://github.com/nv-morpheus/dfencoder.git@branch-22.09#egg=dfencoder
 nvidia-pyindex
+pytest-benchmark>=4.0
 torch==1.10.2+cu113
 tritonclient[all]==2.17.*
 websockets

--- a/docker/conda/environments/requirements.txt
+++ b/docker/conda/environments/requirements.txt
@@ -6,7 +6,6 @@
 # Packages listed here should also be listed in setup.py
 git+https://github.com/nv-morpheus/dfencoder.git@branch-22.09#egg=dfencoder
 nvidia-pyindex
-pytest-benchmark>=4.0
 torch==1.10.2+cu113
 tritonclient[all]==2.17.*
 websockets

--- a/tests/mock_triton_server/config.yml
+++ b/tests/mock_triton_server/config.yml
@@ -35,3 +35,5 @@ protocols:
     grpc_tls: false
 injection:
   enable: true
+validation:
+  enable: false


### PR DESCRIPTION
v0.10 was released on 2022-10-25 and completely breaks our tests which depends on it.
pytest-benchmark 4.0 fixes an incompatibility with pytest 7.2