### PR TITLE
Remove buildx from docker command causes issues with docker 20.10.5

### DIFF
--- a/docker/build_container.sh
+++ b/docker/build_container.sh
@@ -45,7 +45,7 @@ DOCKER_ARGS="${DOCKER_ARGS} --network=host"
 DOCKER_ARGS="${DOCKER_ARGS} ${DOCKER_EXTRA_ARGS}"
 
 # Export buildkit variable
-export DOCKER_BUILDKIT
+export DOCKER_BUILDKIT=1
 
 echo "Building morpheus:${DOCKER_TAG}..."
 echo "   FROM_IMAGE      : ${FROM_IMAGE}"
@@ -56,7 +56,7 @@ echo "   RAPIDS_VER      : ${RAPIDS_VER}"
 echo "   PYTHON_VER      : ${PYTHON_VER}"
 echo "   TENSORRT_VERSION: ${TENSORRT_VERSION}"
 echo ""
-echo "   COMMAND: docker buildx build ${DOCKER_ARGS} -f docker/Dockerfile ."
+echo "   COMMAND: docker build ${DOCKER_ARGS} -f docker/Dockerfile ."
 echo "   Note: add '--progress plain' to DOCKER_ARGS to show all container build output"
 
-docker buildx build ${DOCKER_ARGS} -f docker/Dockerfile .
+docker build ${DOCKER_ARGS} -f docker/Dockerfile .


### PR DESCRIPTION
On my system using `docker buildx build` gives this error:
```
$ ./docker/build_container_dev.sh 
Building morpheus:...
   FROM_IMAGE      : gpuci/miniforge-cuda
   CUDA_VER        : 11.5
   LINUX_DISTRO    : ubuntu
   LINUX_VER       : 20.04
   RAPIDS_VER      : 22.04
   PYTHON_VER      : 3.8
   TENSORRT_VERSION: 8.2.1.3

   COMMAND: docker buildx build -t morpheus:dev-221025 --target development --build-arg FROM_IMAGE=gpuci/miniforge-cuda --build-arg CUDA_VER=11.5 --build-arg LINUX_DISTRO=ubuntu --build-arg LINUX_VER=20.04 --build-arg RAPIDS_VER=22.04 --build-arg PYTHON_VER=3.8 --build-arg TENSORRT_VERSION=8.2.1.3 --network=host  -f docker/Dockerfile .
   Note: add '--progress plain' to DOCKER_ARGS to show all container build output
unknown shorthand flag: 't' in -t
See 'docker --help'.

Usage:  docker [OPTIONS] COMMAND
...
```