### PR TITLE
Set channels and versions to ensure we get a good version of tensorflow

### DIFF
--- a/examples/gnn_fraud_detection_pipeline/README.md
+++ b/examples/gnn_fraud_detection_pipeline/README.md
@@ -21,7 +21,7 @@ limitations under the License.
 Prior to running the gnn fruad detection pipeline, additional requirements must be installed in to your conda environment. A supplemental requirements file has been provided in this example directory.
 
 ```bash
-mamba install -c rapidsai -c nvidia -c stellargraph -c conda-forge chardet cuml stellargraph tensorflow
+mamba env update -n ${CONDA_DEFAULT_ENV} -f examples/gnn_fraud_detection_pipeline/requirements.yml
 ```
 
 ## Running

--- a/examples/gnn_fraud_detection_pipeline/requirements.yml
+++ b/examples/gnn_fraud_detection_pipeline/requirements.yml
@@ -16,9 +16,12 @@
 channels:
     - rapidsai
     - nvidia
+    - nvidia/label/dev # For pre-releases of SRF. Should still default to full releases if available
+    - nvidia/label/cuda-11.5.2 # For cuda-nvml-dev=11.5, which is not published under nvidia channel yet.
     - stellargraph
     - conda-forge
 dependencies:
-    - cuml
-    - stellargraph
-    - tensorflow
+    - chardet=5.0.0
+    - cuml=22.08
+    - stellargraph=1.2.1
+    - tensorflow=2.9.1


### PR DESCRIPTION
Fixes an issue where without specifying the `nvidia/label/dev` channel conda/mamba will install an old version of tensorflow (2.4.1) which is unable to load the model file.

fixes #324