### PR TITLE
Ensure Camouflage is shutdown after every test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -314,7 +314,7 @@ def wait_for_camouflage(host="localhost", port=8000, timeout=5):
 
 def _set_pdeathsig(sig=signal.SIGTERM):
     """
-    Helper function to ensure once parent process exits, its childrent processes will automatically die
+    Helper function to ensure once parent process exits, its child processes will automatically die
     """
 
     def prctl_fn():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -296,9 +296,9 @@ def wait_for_camouflage(host="localhost", port=8000, timeout=5):
                 if (r.json()['message'] == 'I am alive.'):
                     return True
                 else:
-                    warnings.warn(
-                        "Camoflage returned status 200 but had incorrect response JSON. Continuing to wait. Response JSON:\n{}"
-                        .format(r.json()))
+                    warnings.warn(("Camoflage returned status 200 but had incorrect response JSON. "
+                                   "Continuing to wait. Response JSON:\n%s"),
+                                  r.json())
 
         except Exception:
             pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -364,16 +364,16 @@ def _camouflage_is_running():
 
         logging.info("Launched camouflage in %s with pid: %s", root_dir, popen.pid)
 
-        if startup_timeout > 0:
-            if not wait_for_camouflage(timeout=startup_timeout):
+        if not wait_for_camouflage(timeout=startup_timeout):
 
-                if popen.poll() is not None:
-                    raise RuntimeError("camouflage server exited with status code={} details in: {}".format(
-                        popen.poll(), os.path.join(root_dir, 'camouflage.log')))
+            if popen.poll() is not None:
+                raise RuntimeError("camouflage server exited with status code={} details in: {}".format(
+                    popen.poll(), os.path.join(root_dir, 'camouflage.log')))
 
-                raise RuntimeError("Failed to launch camouflage server")
+            raise RuntimeError("Failed to launch camouflage server")
 
-        yield is_running
+        # Must have been started by this point
+        yield True
 
         logging.info("Killing pid {}".format(popen.pid))
 

--- a/tests/mock_triton_server/mocks/reset/POST.mock
+++ b/tests/mock_triton_server/mocks/reset/POST.mock
@@ -3,14 +3,29 @@ Content-Type: application/json
 
 {{#code}}
 (()=>{
-    if(!this.counter) {
-        this.counter=0;
-    }
 
-    logger.log(`Resetting counter from ${this.counter} to 0`);
+    // Create a new shared state object.
+    let counters = new Map();
 
-    // Just reset the counter value to 0
-    this.counter=0;
+    // Save it on the Handlebars object since that is shared by all functions
+    this.Handlebars._nv_morpheus = {
+        counters: counters,
+        get_and_increment: (method_name) => {
+            if (!counters.has(method_name)){
+                counters.set(method_name, 0);
+            }
+
+            // Get the current value
+            const curr_counter = counters.get(method_name) + 1;
+
+            // Set the incremented value
+            counters.set(method_name, curr_counter);
+
+            return curr_counter;
+        }
+    };
+
+    logger.info(`Resetting the counter object.`);
 
     return {
         status: 200,

--- a/tests/mock_triton_server/mocks/reset/POST.mock
+++ b/tests/mock_triton_server/mocks/reset/POST.mock
@@ -1,0 +1,20 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{{#code}}
+(()=>{
+    if(!this.counter) {
+        this.counter=0;
+    }
+
+    logger.log(`Resetting counter from ${this.counter} to 0`);
+
+    // Just reset the counter value to 0
+    this.counter=0;
+
+    return {
+        status: 200,
+        body: `{}`
+    };
+})();
+{{/code}}

--- a/tests/mock_triton_server/mocks/v2/models/abp-nvsmi-xgb/infer/POST.mock
+++ b/tests/mock_triton_server/mocks/v2/models/abp-nvsmi-xgb/infer/POST.mock
@@ -1,21 +1,27 @@
 HTTP/1.1 200 OK
 Content-Type: application/octet-stream
 {{#inject}}(()=>{
-    if(!this.counter) {
-        this.counter=0;
+
+    // Check for the shared state object
+    if (!this.Handlebars._nv_morpheus === undefined){
+        throw "Must call `POST /reset` endpoint before calling other methods!";
     }
 
-    this.counter+=1;
-    this.filename = "payloads/abp/abp_infer_resp." + this.counter + ".body"
+    const counter = this.Handlebars._nv_morpheus.get_and_increment();
+    const filename = "payloads/abp/abp_infer_resp." + counter + ".body"
+
+    logger.info(`Returning payload for counter: ${counter}, and filename: ${filename}`);
 
     let inf_header_content_length = 155;
-    if (this.counter > 1) {
+    if (counter > 1) {
         inf_header_content_length = 153;
     }
 
     // This seems like the only way to pass a variable to the file helper
-    request._nv_morpheus_params = {counter: this.counter, filename: this.filename};
-
+    request._nv_morpheus_params = {
+        counter,
+        filename
+    };
 
     return "Inference-Header-Content-Length: " + inf_header_content_length;
 })();{{/inject}}

--- a/tests/mock_triton_server/mocks/v2/models/phishing-bert-onnx/infer/POST.mock
+++ b/tests/mock_triton_server/mocks/v2/models/phishing-bert-onnx/infer/POST.mock
@@ -2,15 +2,24 @@ HTTP/1.1 200 OK
 Content-Type: application/octet-stream
 Inference-Header-Content-Length: 156
 {{#inject}}(()=>{
-    if(!this.counter) {
-        this.counter=0;
+
+    // Check for the shared state object
+    if (!this.Handlebars._nv_morpheus === undefined){
+        throw "Must call `POST /reset` endpoint before calling other methods!";
     }
 
-    this.counter+=1;
-    this.filename = "payloads/phishing/phishing_infer_resp." + this.counter + ".body"
+    const counter = this.Handlebars._nv_morpheus.get_and_increment();
+    const filename = "payloads/phishing/phishing_infer_resp." + counter + ".body"
+
+    logger.info(`Returning payload for counter: ${counter}, and filename: ${filename}`);
 
     // This seems like the only way to pass a variable to the file helper
-    request._nv_morpheus_params = {counter: this.counter, filename: this.filename};
+    request._nv_morpheus_params = {
+        counter,
+        filename
+    };
+
+    return "";
 })();{{/inject}}
 
 {{file path=request._nv_morpheus_params.filename}}

--- a/tests/mock_triton_server/mocks/v2/models/sid-minibert-onnx-no-trunc/infer/POST.mock
+++ b/tests/mock_triton_server/mocks/v2/models/sid-minibert-onnx-no-trunc/infer/POST.mock
@@ -1,22 +1,29 @@
 HTTP/1.1 200 OK
 Content-Type: application/octet-stream
 {{#inject}}(()=>{
-    if(!this.counter) {
-        this.counter=0;
+
+    // Check for the shared state object
+    if (!this.Handlebars._nv_morpheus === undefined){
+        throw "Must call `POST /reset` endpoint before calling other methods!";
     }
 
-    this.counter+=1;
-    this.filename = "payloads/sid-no-trunc/sid_infer_resp." + this.counter + ".body"
+    const counter = this.Handlebars._nv_morpheus.get_and_increment();
+    const filename = "payloads/sid-no-trunc/sid_infer_resp." + counter + ".body"
+
+    logger.info(`Returning payload for counter: ${counter}, and filename: ${filename}`);
 
     let inf_header_content_length = 157;
-    if (this.counter === 33) {
+    if (counter === 33) {
         inf_header_content_length = 156;
-    } else if (this.counter === 65) {
+    } else if (counter === 65) {
         inf_header_content_length = 155;
     }
 
     // This seems like the only way to pass a variable to the file helper
-    request._nv_morpheus_params = {counter: this.counter, filename: this.filename};
+    request._nv_morpheus_params = {
+        counter,
+        filename
+    };
 
     return "Inference-Header-Content-Length: " + inf_header_content_length;
 })();{{/inject}}

--- a/tests/mock_triton_server/mocks/v2/models/sid-minibert-onnx/infer/POST.mock
+++ b/tests/mock_triton_server/mocks/v2/models/sid-minibert-onnx/infer/POST.mock
@@ -1,20 +1,27 @@
 HTTP/1.1 200 OK
 Content-Type: application/octet-stream
 {{#inject}}(()=>{
-    if(!this.counter) {
-        this.counter=0;
+
+    // Check for the shared state object
+    if (!this.Handlebars._nv_morpheus === undefined){
+        throw "Must call `POST /reset` endpoint before calling other methods!";
     }
 
-    this.counter+=1;
-    this.filename = "payloads/sid/sid_infer_resp." + this.counter + ".body"
+    const counter = this.Handlebars._nv_morpheus.get_and_increment();
+    const filename = "payloads/sid/sid_infer_resp." + counter + ".body"
+
+    logger.info(`Returning payload for counter: ${counter}, and filename: ${filename}`);
 
     let inf_header_content_length = 157;
-    if (this.counter === 63) {
+    if (counter === 63) {
         inf_header_content_length = 156;
     }
 
     // This seems like the only way to pass a variable to the file helper
-    request._nv_morpheus_params = {counter: this.counter, filename: this.filename};
+    request._nv_morpheus_params = {
+        counter,
+        filename
+    };
 
     return "Inference-Header-Content-Length: " + inf_header_content_length;
 })();{{/inject}}


### PR DESCRIPTION
If a test crashes or a developer stops a test in the middle of debugging, Camouflage will be left open. Any subsequent runs of pytest will fail to start.

This fixes the issue by binding the child process to the pytest process, ensuring that it will always be closed. Also added support for using already running Camouflage servers.

Closes #329 