### PR TITLE
Fix unittests

### DIFF
--- a/ci/scripts/github/common.sh
+++ b/ci/scripts/github/common.sh
@@ -51,7 +51,7 @@ export S3_URL="s3://rapids-downloads/ci/morpheus"
 export DISPLAY_URL="https://downloads.rapids.ai/ci/morpheus"
 export ARTIFACT_ENDPOINT="/pull-request/${PR_NUM}/${GIT_COMMIT}/${NVARCH}"
 export ARTIFACT_URL="${S3_URL}${ARTIFACT_ENDPOINT}"
-export DISPLAY_ARTIFACT_URL="${DISPLAY_URL}/pull-request/${PR_NUM}/${GIT_COMMIT}/${NVARCH}/"
+export DISPLAY_ARTIFACT_URL="${DISPLAY_URL}${ARTIFACT_ENDPOINT}/"
 
 # Set sccache env vars
 export SCCACHE_S3_KEY_PREFIX=morpheus-${NVARCH}

--- a/ci/scripts/github/test.sh
+++ b/ci/scripts/github/test.sh
@@ -64,7 +64,7 @@ cd ${MORPHEUS_ROOT}/tests
 
 set +e
 
-python -I -m pytest --run_slow --run_kafka \
+python -I -m pytest --run_slow --run_kafka --benchmark-disable \
        --junit-xml=${REPORTS_DIR}/report_pytest.xml \
        --cov=morpheus \
        --cov-report term-missing \

--- a/morpheus/_lib/src/stages/file_source.cpp
+++ b/morpheus/_lib/src/stages/file_source.cpp
@@ -57,34 +57,12 @@ FileSourceStage::FileSourceStage(std::string filename, int repeat) :
 FileSourceStage::subscriber_fn_t FileSourceStage::build()
 {
     return [this](rxcpp::subscriber<source_type_t> output) {
-        auto data_table     = load_table_from_file(m_filename);
-        int index_col_count = get_index_col_count(data_table);
-
-        // Next, create the message metadata. This gets reused for repeats
-        // When index_col_count is 0 this will cause a new range index to be created
-        auto meta = MessageMeta::create_from_cpp(std::move(data_table), index_col_count);
-
-        // Always push at least 1
-        output.on_next(meta);
-
-        for (cudf::size_type repeat_idx = 1; repeat_idx < m_repeat; ++repeat_idx)
+        for (cudf::size_type repeat_idx = 0; repeat_idx < m_repeat; ++repeat_idx)
         {
-            // Clone the previous meta object
-            {
-                pybind11::gil_scoped_acquire gil;
+            auto data_table     = load_table_from_file(m_filename);
+            int index_col_count = get_index_col_count(data_table);
 
-                // Use the copy function
-                auto df = meta->get_py_table().attr("copy")();
-
-                pybind11::int_ df_len = pybind11::len(df);
-
-                pybind11::object index = df.attr("index");
-
-                df.attr("index") = index + df_len;
-
-                meta = MessageMeta::create_from_python(std::move(df));
-            }
-
+            auto meta = MessageMeta::create_from_cpp(std::move(data_table), index_col_count);
             output.on_next(meta);
         }
 

--- a/morpheus/stages/input/file_source_stage.py
+++ b/morpheus/stages/input/file_source_stage.py
@@ -145,7 +145,7 @@ class FileSourceStage(SingleOutputSource):
 
         count = 0
 
-        for _ in range(self._repeat_count):
+        for itr in range(self._repeat_count):
 
             x = MessageMeta(df)
 
@@ -154,7 +154,7 @@ class FileSourceStage(SingleOutputSource):
             count += 1
 
             # If we are looping, copy and shift the index
-            if (self._repeat_count > 0):
+            if (itr + 1 < self._repeat_count):
                 prev_df = df
                 df = prev_df.copy()
 

--- a/morpheus/stages/input/file_source_stage.py
+++ b/morpheus/stages/input/file_source_stage.py
@@ -143,19 +143,13 @@ class FileSourceStage(SingleOutputSource):
             df_type="cudf",
         )
 
-        count = 0
-
-        for itr in range(self._repeat_count):
+        df_copy = None
+        for count in range(self._repeat_count):
+            if (count + 1 < self._repeat_count):
+                # If we are looping, copy and shift the index
+                df_copy = df.copy(deep=True)
+                df_copy.index += len(df_copy)
 
             x = MessageMeta(df)
-
+            df = df_copy
             yield x
-
-            count += 1
-
-            # If we are looping, copy and shift the index
-            if (itr + 1 < self._repeat_count):
-                prev_df = df
-                df = prev_df.copy()
-
-                df.index += len(df)


### PR DESCRIPTION
* Avoid unnecessary copies in file source stage
* When we do a copy, perform it before emitting and make a deep copy

fixes #443