### PR TITLE
Update cmake minimum version based on rapids-cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 
-cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
 
 
 list(APPEND CMAKE_MESSAGE_CONTEXT "morpheus")

--- a/ci/conda/recipes/morpheus/meta.yaml
+++ b/ci/conda/recipes/morpheus/meta.yaml
@@ -51,7 +51,7 @@ outputs:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
         - {{ compiler("cuda") }}
-        - cmake 3.22
+        - cmake >=3.23.1
         - ccache
         - ninja
       host:

--- a/docker/conda/environments/cuda11.5_dev.yml
+++ b/docker/conda/environments/cuda11.5_dev.yml
@@ -29,7 +29,7 @@ dependencies:
     - ccache>=3.7
     - clangdev=14
     - click >=8
-    - cmake=3.22
+    - cmake >=3.23.1
     - configargparse=1.5
     - cuda-nvml-dev=11.5
     - cuda-python<=11.7.0 # Remove when Issue #251 is closed


### PR DESCRIPTION
Per rapidsai/rapids-cmake#227

Note that this must be manually installed for focal (20.04). The snap version appears to have issues resolving RDKAFKA