### PR TITLE
DFPFileBatcherStage: Sort only by timestamp

### DIFF
--- a/examples/digital_fingerprinting/production/morpheus/dfp/stages/dfp_file_batcher_stage.py
+++ b/examples/digital_fingerprinting/production/morpheus/dfp/stages/dfp_file_batcher_stage.py
@@ -16,7 +16,6 @@ import logging
 import typing
 from collections import namedtuple
 from datetime import datetime
-from operator import itemgetter
 
 import fsspec
 import pandas as pd
@@ -74,7 +73,7 @@ class DFPFileBatcherStage(SinglePortStage):
             ts_and_files.append(TimestampFileObj(ts, file_object))
 
         # sort the incoming data by date
-        ts_and_files.sort(key=itemgetter(0))
+        ts_and_files.sort(key=lambda x: x.timestamp)
 
         # Create a dataframe with the incoming metadata
         if ((len(ts_and_files) > 1) and (self._sampling_rate_s > 0)):

--- a/examples/digital_fingerprinting/production/morpheus/dfp/stages/dfp_file_batcher_stage.py
+++ b/examples/digital_fingerprinting/production/morpheus/dfp/stages/dfp_file_batcher_stage.py
@@ -16,6 +16,7 @@ import logging
 import typing
 from collections import namedtuple
 from datetime import datetime
+from operator import itemgetter
 
 import fsspec
 import pandas as pd
@@ -73,7 +74,7 @@ class DFPFileBatcherStage(SinglePortStage):
             ts_and_files.append(TimestampFileObj(ts, file_object))
 
         # sort the incoming data by date
-        ts_and_files.sort()
+        ts_and_files.sort(key=itemgetter(0))
 
         # Create a dataframe with the incoming metadata
         if ((len(ts_and_files) > 1) and (self._sampling_rate_s > 0)):


### PR DESCRIPTION
Fixes bug when two files have the same timestamp.
This tends to happen when receiving data from someone else via a tar file and the filenames don't contain a timestamp, causing the stage to use the filesystem's modified time.

fixes #449