### PR TITLE
update for numpy array results on ABP notebook

### DIFF
--- a/models/training-tuning-scripts/abp-models/abp-nvsmi-xgb-20210310.ipynb
+++ b/models/training-tuning-scripts/abp-models/abp-nvsmi-xgb-20210310.ipynb
@@ -348,8 +348,8 @@
    ],
    "source": [
     "\n",
-    "y_pred = fil_preds_gpu.to_array()\n",
-    "y_true = y_test.to_array()\n",
+    "y_pred = fil_preds_gpu\n",
+    "y_true = y_test\n",
     "accuracy_score(y_true, y_pred)"
    ]
   },


### PR DESCRIPTION
removing `to_array` to avoid this error
----> 1 y_pred = fil_preds_gpu.to_array()
      2 y_true = y_test.to_array()
      3 accuracy_score(y_true, y_pred)

AttributeError: 'numpy.ndarray' object has no attribute 'to_array

Closes #469 