### PR TITLE
Update External Repo to Single Directory

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
-[submodule "examples/sid_visualization/viz"]
-	path = examples/sid_visualization/viz
+[submodule "external/morpheus-visualizations"]
+	path = external/morpheus-visualizations
 	url = https://github.com/nv-morpheus/morpheus-visualizations.git
 	branch = branch-22.09

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "external/morpheus-visualizations"]
 	path = external/morpheus-visualizations
 	url = https://github.com/nv-morpheus/morpheus-visualizations.git
-	branch = branch-22.09
+	branch = branch-22.11

--- a/examples/sid_visualization/viz
+++ b/examples/sid_visualization/viz
@@ -1,0 +1,1 @@
+../../external/morpheus-visualizations/GraphVis


### PR DESCRIPTION
With the addition of multiple visualizations in the morpheus-visualizations repo, we now can have multiple examples that need the submodule.

To fix this, the submodule has been moved into `external/morpheus-visualizations` and symlinks created back to the examples folder.