### PR TITLE
[Draft] Optionally override feature length on a per-stage level

### DIFF
--- a/morpheus/stages/inference/triton_inference_stage.py
+++ b/morpheus/stages/inference/triton_inference_stage.py
@@ -798,7 +798,6 @@ class TritonInferenceAE(_TritonInferenceWorker):
         # Save the autoencoder path
         with open(c.ae.autoencoder_path, 'rb') as in_strm:
             self._autoencoder = dill.load(in_strm)
-            #self._autoencoder.load_state_dict(torch.load(in_strm))
 
             # Ensure that there is a label_smoothing property on cce. Necessary if pytorch version is different
             if (not hasattr(self._autoencoder.cce, "label_smoothing")):

--- a/morpheus/stages/inference/triton_inference_stage.py
+++ b/morpheus/stages/inference/triton_inference_stage.py
@@ -814,13 +814,14 @@ class TritonInferenceAE(_TritonInferenceWorker):
         import torch
 
         output = {output.mapped_name: result.as_numpy(output.name) for output in self._outputs.values()}
+        #print(f"*********\nself._outputs={self._outputs}\noutput={sorted(output.keys())}")
 
         data = self._autoencoder.prepare_df(batch.get_meta())
         num_target, bin_target, codes = self._autoencoder.compute_targets(data)
         mse_loss = self._autoencoder.mse(torch.as_tensor(output["num"], device='cuda'), num_target)
         net_loss = [mse_loss.data]
-        bce_loss = self._autoencoder.bce(torch.as_tensor(output["bin"], device='cuda'), bin_target)
-        net_loss += [bce_loss.data]
+        #bce_loss = self._autoencoder.bce(torch.as_tensor(output["bin"], device='cuda'), bin_target)
+        #net_loss += [bce_loss.data]
         cce_loss = []
         for i, ft in enumerate(self._autoencoder.categorical_fts):
             loss = self._autoencoder.cce(torch.as_tensor(output[ft], device='cuda'), codes[i])

--- a/morpheus/stages/preprocess/preprocess_ae_stage.py
+++ b/morpheus/stages/preprocess/preprocess_ae_stage.py
@@ -44,10 +44,13 @@ class PreprocessAEStage(PreprocessBaseStage):
 
     """
 
-    def __init__(self, c: Config):
+    def __init__(self, c: Config, fea_length=None):
         super().__init__(c)
+        if fea_length is None:
+            self._fea_length = c.feature_length
+        else:
+            self._fea_length = fea_length
 
-        self._fea_length = c.feature_length
         self._feature_columns = c.ae.feature_columns
 
     @property


### PR DESCRIPTION
- Optionally override feature length on a per-stage level, this allows using multiple models in the same pipeline. I didn't implement this across the board, if others agree with this direction, I can add it to the other places where `feature_length` is used.
- Use dill to load saved model. Not really sure here, the previous method wasn't working but dill worked.
- Ensure that the `bin` tensor exists in the output before using it.