### PR TITLE
Updating CI runner image for MRC and C++20

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -31,8 +31,8 @@ jobs:
     uses: ./.github/workflows/ci_pipe.yml
     with:
       run_check: ${{ startsWith(github.ref_name, 'pull-request/') }}
-      container: nvcr.io/ea-nvidia-morpheus/morpheus:morpheus-ci-driver-221102
-      test_container: nvcr.io/ea-nvidia-morpheus/morpheus:morpheus-ci-test-221102
+      container: nvcr.io/ea-nvidia-morpheus/morpheus:morpheus-ci-driver-221216
+      test_container: nvcr.io/ea-nvidia-morpheus/morpheus:morpheus-ci-test-221216
     secrets:
       GHA_AWS_ACCESS_KEY_ID: ${{ secrets.GHA_AWS_ACCESS_KEY_ID }}
       GHA_AWS_SECRET_ACCESS_KEY: ${{ secrets.GHA_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
With the updated compilers and dependencies, a new CI image is needed.