### PR TITLE
Minor fixes/updates to abp_pcap_detection example

### DIFF
--- a/examples/abp_pcap_detection/README.md
+++ b/examples/abp_pcap_detection/README.md
@@ -30,12 +30,12 @@ docker pull nvcr.io/nvidia/tritonserver:22.08-py3
 
 Bind the provided `abp-pcap-xgb` directory to the docker container model repo at `/models`.
 
+From the root of the Morpheus repo, navigate to the anomalous behavior profiling example directory:
 ```bash
-# Change directory to the anomalous behavior profiling example folder
-cd <MORPHEUS_ROOT>/examples/abp_pcap_detection
+cd examples/abp_pcap_detection
 
 # Launch the container
-docker run --rm --gpus=all -p 8000:8000 -p 8001:8001 -p 8002:8002 -v $PWD/abp-pcap-xgb:/models/abp-pcap-xgb --name tritonserver nvcr.io/nvidia/tritonserver:22.08-py3 tritonserver --model-repository=/models --exit-on-error=false --model-control-mode=poll --repository-poll-secs=30
+docker run --rm --gpus=all -p 8000:8000 -p 8001:8001 -p 8002:8002 -v $PWD/abp-pcap-xgb:/models/abp-pcap-xgb --name tritonserver nvcr.io/nvidia/tritonserver:22.08-py3 tritonserver --model-repository=/models --exit-on-error=false
 ```
 
 ##### Verify Model Deployment
@@ -52,8 +52,14 @@ Once Triton server finishes starting up, it will display the status of all loade
 ## ABP Detection Pipeline
 Use Morpheus to run the Anomalous Behavior Profiling Detection Pipeline with the pcap data. A pipeline has been configured in `run.py` with several command line options:
 
+From the root of the Morpheus repo run:
 ```bash
-$ python run.py --help
+cd examples/abp_pcap_detection
+python run.py --help
+```
+
+Output:
+```
 Usage: run.py [OPTIONS]
 
 Options:
@@ -83,7 +89,7 @@ Options:
   --help                          Show this message and exit.
 ```
 
-To launch the configured Morpheus pipeline with the sample data that is provided at `<MORPHEUS_ROOT>/examples/data`, from the `examples/abp_pcap_detection` directory run the following:
+To launch the configured Morpheus pipeline with the sample data that is provided in `examples/data`, from the `examples/abp_pcap_detection` directory run the following:
 
 ```bash
 python run.py \


### PR DESCRIPTION
* Remove `<MORPHEUS_ROOT>` making all bash commands copy/past-able 
* Remove polling flags from Triton command