### PR TITLE
Update DFPMLFlowModelWriterStage to no longer save mean and std metrics

### DIFF
--- a/examples/digital_fingerprinting/production/morpheus/dfp/stages/dfp_mlflow_model_writer.py
+++ b/examples/digital_fingerprinting/production/morpheus/dfp/stages/dfp_mlflow_model_writer.py
@@ -181,12 +181,6 @@ class DFPMLFlowModelWriterStage(SinglePortStage):
                     metrics_dict[f"embedding-{k}-num_embeddings"] = embedding.num_embeddings
                     metrics_dict[f"embedding-{k}-embedding_dim"] = embedding.embedding_dim
 
-                # Add metrics for all of the loss stats
-                if (hasattr(model, "feature_loss_stats")):
-                    for k, v in model.feature_loss_stats.items():
-                        metrics_dict[f"loss-{k}-mean"] = v.get("mean", "unknown")
-                        metrics_dict[f"loss-{k}-std"] = v.get("std", "unknown")
-
                 mlflow.log_metrics(metrics_dict)
 
                 # Use the prepare_df function to setup the direct inputs to the model. Only include features returned by


### PR DESCRIPTION
`dfencoder` is being updated in this [PR](https://github.com/nv-morpheus/dfencoder/pull/6) to no longer store `mean` and `std` in the AutoEncoder model. This will cause an error in `DFPMLFlowModelWriterStage` where it tries to publish `mean` and `std` as metrics to MLflow. This PR updates `DFPMLFlowModelWriterStage` to no longer publish the metrics since they don't appear be used in Morpheus anymore.