### PR TITLE
Remove hard-coded keys from production DFP

### DIFF
--- a/examples/digital_fingerprinting/production/morpheus/dfp/stages/dfp_file_to_df.py
+++ b/examples/digital_fingerprinting/production/morpheus/dfp/stages/dfp_file_to_df.py
@@ -205,7 +205,7 @@ class DFPFileToDataFrameStage(SinglePortStage):
         output_df: pd.DataFrame = pd.concat(dfs)
 
         # Finally sort by timestamp and then reset the index
-        output_df.sort_values(by=["timestamp"], inplace=True)
+        output_df.sort_values(by=[self._config.ae.timestamp_column_name], inplace=True)
 
         output_df.reset_index(drop=True, inplace=True)
 

--- a/examples/digital_fingerprinting/production/morpheus/dfp/stages/dfp_mlflow_model_writer.py
+++ b/examples/digital_fingerprinting/production/morpheus/dfp/stages/dfp_mlflow_model_writer.py
@@ -164,8 +164,8 @@ class DFPMLFlowModelWriterStage(SinglePortStage):
                     "Epochs": model.lr_decay.state_dict().get("last_epoch", "unknown"),
                     "Learning rate": model.lr,
                     "Batch size": model.batch_size,
-                    "Start Epoch": message.get_meta("timestamp").min(),
-                    "End Epoch": message.get_meta("timestamp").max(),
+                    "Start Epoch": message.get_meta(self._config.ae.timestamp_column_name).min(),
+                    "End Epoch": message.get_meta(self._config.ae.timestamp_column_name).max(),
                     "Log Count": message.mess_count,
                 })
 

--- a/examples/digital_fingerprinting/production/morpheus/dfp/stages/dfp_rolling_window_stage.py
+++ b/examples/digital_fingerprinting/production/morpheus/dfp/stages/dfp_rolling_window_stage.py
@@ -69,11 +69,11 @@ class CachedUserWindow:
         # row_hashes = pd.util.hash_pandas_object(incoming_df)
 
         # Filter the incoming df by epochs later than the current max_epoch
-        filtered_df = incoming_df[incoming_df["timestamp"] > self.max_epoch]
+        filtered_df = incoming_df[incoming_df[self.timestamp_column] > self.max_epoch]
 
         if (len(filtered_df) == 0):
             # We have nothing new to add. Double check that we fit within the window
-            before_history = incoming_df[incoming_df["timestamp"] < self.min_epoch]
+            before_history = incoming_df[incoming_df[self.timestamp_column] < self.min_epoch]
 
             return len(before_history) == 0
 

--- a/examples/digital_fingerprinting/production/morpheus/dfp/stages/dfp_split_users_stage.py
+++ b/examples/digital_fingerprinting/production/morpheus/dfp/stages/dfp_split_users_stage.py
@@ -86,7 +86,7 @@ class DFPSplitUsersStage(SinglePortStage):
 
                 split_dataframes.update(
                     {username: user_df
-                     for username, user_df in message.groupby("username", sort=False)})
+                     for username, user_df in message.groupby(self._config.ae.userid_column_name, sort=False)})
 
             output_messages: typing.List[DFPMessageMeta] = []
 

--- a/examples/digital_fingerprinting/production/morpheus/dfp_azure_pipeline.py
+++ b/examples/digital_fingerprinting/production/morpheus/dfp_azure_pipeline.py
@@ -228,10 +228,16 @@ def run_pipeline(train_users,
                         groupby_column=config.ae.userid_column_name),
         CustomColumn(name="locincrement",
                      dtype=int,
-                     process_column_fn=partial(create_increment_col, column_name="location")),
+                     process_column_fn=partial(create_increment_col,
+                     column_name="location",
+                     groupby_column=config.ae.userid_column_name,
+                     timestamp_column=config.ae.timestamp_column_name)),
         CustomColumn(name="appincrement",
                      dtype=int,
-                     process_column_fn=partial(create_increment_col, column_name="appDisplayName")),
+                     process_column_fn=partial(create_increment_col,
+                     column_name="appDisplayName",
+                     groupby_column=config.ae.userid_column_name,
+                     timestamp_column=config.ae.timestamp_column_name))
     ]
 
     preprocess_schema = DataFrameInputSchema(column_info=preprocess_column_info, preserve_columns=["_batch_id"])

--- a/examples/digital_fingerprinting/production/morpheus/dfp_duo_pipeline.py
+++ b/examples/digital_fingerprinting/production/morpheus/dfp_duo_pipeline.py
@@ -229,7 +229,10 @@ def run_pipeline(train_users,
                         groupby_column=config.ae.userid_column_name),
         CustomColumn(name="locincrement",
                      dtype=int,
-                     process_column_fn=partial(create_increment_col, column_name="location")),
+                     process_column_fn=partial(create_increment_col,
+                     column_name="location",
+                     groupby_column=config.ae.userid_column_name,
+                     timestamp_column=config.ae.timestamp_column_name))
     ]
 
     preprocess_schema = DataFrameInputSchema(column_info=preprocess_column_info, preserve_columns=["_batch_id"])


### PR DESCRIPTION
Remove hard-coded keys `username` and `timestamp` keys from production DFP stages. Allows source dataframe column names to be configured with `config.ae.userid_column_name` and `config.ae.timestamp_column_name`.

Closes #606 