### PR TITLE
Updating the CUDA libraries to use Conda packages

### DIFF
--- a/docker/conda/environments/cuda11.5_dev.yml
+++ b/docker/conda/environments/cuda11.5_dev.yml
@@ -27,7 +27,7 @@ dependencies:
     - boost-cpp=1.74
     - cachetools=5.0.0
     - ccache>=3.7
-    - clangdev=15
+    - clangdev=14
     - click >=8
     - cmake=3.24
     - configargparse=1.5
@@ -54,7 +54,7 @@ dependencies:
     - grpcio
     - gtest=1.10
     - gxx_linux-64=11.2
-    - include-what-you-use=0.19
+    - include-what-you-use=0.18
     - isort
     - libcublas-dev
     - libcufft-dev

--- a/docker/conda/environments/cuda11.5_dev.yml
+++ b/docker/conda/environments/cuda11.5_dev.yml
@@ -16,9 +16,9 @@
 name: morpheus
 channels:
     - rapidsai
+    - nvidia/label/cuda-11.5.2 # Choose the 11.5 versions before the general nvidia channel
     - nvidia
     - nvidia/label/dev # For pre-releases of MRC. Should still default to full releases if available
-    - nvidia/label/cuda-11.5.2 # For cuda-nvml-dev=11.5, which is not published under nvidia channel yet.
     - conda-forge
 dependencies:
     ####### Morpheus Dependencies (keep sorted!) #######
@@ -27,7 +27,7 @@ dependencies:
     - boost-cpp=1.74
     - cachetools=5.0.0
     - ccache>=3.7
-    - clangdev=14
+    - clangdev=15
     - click >=8
     - cmake=3.24
     - configargparse=1.5
@@ -54,8 +54,12 @@ dependencies:
     - grpcio
     - gtest=1.10
     - gxx_linux-64=11.2
-    - include-what-you-use=0.18
+    - include-what-you-use=0.19
     - isort
+    - libcublas-dev
+    - libcufft-dev
+    - libcurand-dev
+    - libcusolver-dev
     - librdkafka=1.7.0
     - mlflow>1.29,<2
     - mrc=23.01


### PR DESCRIPTION
With the new devcontainer, if the default image doesnt have all of the CUDA libraries installed (cuFFT, cuRand, cuBlas, cuSolver), the build will fail. This changes the build to pull those packages in from Conda instead of assuming they are already installed.