### PR TITLE
Updating the CI image to use Driver 520

### DIFF
--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -104,7 +104,7 @@ jobs:
   test:
     name: Test
     needs: [build]
-    runs-on: [self-hosted, linux, amd64, gpu-v100-495-1]
+    runs-on: [self-hosted, linux, amd64, gpu-v100-520-1]
     timeout-minutes: 60
     container:
       credentials:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -31,8 +31,8 @@ jobs:
     uses: ./.github/workflows/ci_pipe.yml
     with:
       run_check: ${{ startsWith(github.ref_name, 'pull-request/') }}
-      container: nvcr.io/ea-nvidia-morpheus/morpheus:morpheus-ci-driver-221216
-      test_container: nvcr.io/ea-nvidia-morpheus/morpheus:morpheus-ci-test-221216
+      container: nvcr.io/ea-nvidia-morpheus/morpheus:morpheus-ci-driver-230125
+      test_container: nvcr.io/ea-nvidia-morpheus/morpheus:morpheus-ci-test-230125
     secrets:
       GHA_AWS_ACCESS_KEY_ID: ${{ secrets.GHA_AWS_ACCESS_KEY_ID }}
       GHA_AWS_SECRET_ACCESS_KEY: ${{ secrets.GHA_AWS_SECRET_ACCESS_KEY }}

--- a/ci/runner/Dockerfile
+++ b/ci/runner/Dockerfile
@@ -62,7 +62,7 @@ RUN apt update && \
     libcufft-dev-${CUDA_PKG_VER} \
     libcurand-dev-${CUDA_PKG_VER} \
     libcusolver-dev-${CUDA_PKG_VER} \
-    libnvidia-compute-495 && \
+    libnvidia-compute-520 && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/ci/runner/README.md
+++ b/ci/runner/README.md
@@ -1,0 +1,24 @@
+<!--
+ SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+The CI Runner documentation is located in the external Utilities repo. Ensure all submodules are up to date:
+
+```
+git submodule update --init --recursive
+```
+
+The documentation is then located [here](../../external/utilities/ci/runner/README.md).


### PR DESCRIPTION
This is part 1 of 2 for updates needed by #618. For now, we are explicitly specifying 520 in the driver but plan on using `latest` in the future.