### PR TITLE
Silence build warnings when building rabbitmq example

### DIFF
--- a/examples/developer_guide/4_rabbitmq_cpp_stage/cmake/Configure_SimpleAmqpClient.cmake
+++ b/examples/developer_guide/4_rabbitmq_cpp_stage/cmake/Configure_SimpleAmqpClient.cmake
@@ -32,11 +32,14 @@ function(find_and_configure_SimpleAmqpClient version)
       GIT_REPOSITORY  https://github.com/alanxz/SimpleAmqpClient
       GIT_TAG         "v${version}"
       GIT_SHALLOW     TRUE
-      OPTIONS         "Rabbitmqc_INCLUDE_DIR ${rabbitmq_SOURCE_DIR}/librabbitmq"
+      OPTIONS         "Rabbitmqc_INCLUDE_DIR ${rabbitmq_SOURCE_DIR}/include"
                       "Rabbitmqc_LIBRARY ${rabbitmq_BINARY_DIR}/librabbitmq/librabbitmq.so"
                       "BUILD_API_DOCS OFF"
                       "BUILD_SHARED_LIBS OFF"
   )
+
+  # Needed to pick up the generated export.h
+  target_include_directories(SimpleAmqpClient PUBLIC "${rabbitmq_BINARY_DIR}/include")
 
 endfunction()
 

--- a/examples/developer_guide/4_rabbitmq_cpp_stage/cmake/Configure_SimpleAmqpClient.cmake
+++ b/examples/developer_guide/4_rabbitmq_cpp_stage/cmake/Configure_SimpleAmqpClient.cmake
@@ -41,6 +41,9 @@ function(find_and_configure_SimpleAmqpClient version)
   # Needed to pick up the generated export.h
   target_include_directories(SimpleAmqpClient PUBLIC "${rabbitmq_BINARY_DIR}/include")
 
+  # Suppress #warning deprecation messages from rabbitmq
+  target_compile_options(SimpleAmqpClient PRIVATE -Wno-cpp)
+
 endfunction()
 
 find_and_configure_SimpleAmqpClient(${SIMPLE_AMQP_CLIENT_VERSION})

--- a/examples/developer_guide/4_rabbitmq_cpp_stage/cmake/Configure_rabbitmq.cmake
+++ b/examples/developer_guide/4_rabbitmq_cpp_stage/cmake/Configure_rabbitmq.cmake
@@ -19,10 +19,10 @@ function(find_and_configure_rabbitmq version)
 
   list(APPEND CMAKE_MESSAGE_CONTEXT "rabbitmq")
 
-  # Supress warnings coming from rabbitmq's cmake project.
-  set(CMAKE_POLICY_DEFAULT_CMP0048 NEW)
+  # Commit 7fa7b0b contains unreleased cmake fixes which currently only exist in the master branch of the repo.
+  # https://github.com/alanxz/rabbitmq-c/issues/740
 
-  rapids_cpm_find(rabbitmq 633d5fd10a2782968783c0bb58b3e88b8978c567
+  rapids_cpm_find(rabbitmq ${version}
     GLOBAL_TARGETS
       rabbitmq rabbitmq::rabbitmq
     BUILD_EXPORT_SET
@@ -31,8 +31,7 @@ function(find_and_configure_rabbitmq version)
       ${PROJECT_NAME}-exports
     CPM_ARGS
       GIT_REPOSITORY  https://github.com/alanxz/rabbitmq-c
-      GIT_TAG 633d5fd10a2782968783c0bb58b3e88b8978c567
-      GIT_SHALLOW     TRUE
+      GIT_TAG         7fa7b0b
       OPTIONS         "BUILD_EXAMPLES OFF"
                       "BUILD_TESTING OFF"
                       "BUILD_TOOLS OFF"

--- a/examples/developer_guide/4_rabbitmq_cpp_stage/cmake/Configure_rabbitmq.cmake
+++ b/examples/developer_guide/4_rabbitmq_cpp_stage/cmake/Configure_rabbitmq.cmake
@@ -19,7 +19,10 @@ function(find_and_configure_rabbitmq version)
 
   list(APPEND CMAKE_MESSAGE_CONTEXT "rabbitmq")
 
-  rapids_cpm_find(rabbitmq ${version}
+  # Supress warnings coming from rabbitmq's cmake project.
+  set(CMAKE_POLICY_DEFAULT_CMP0048 NEW)
+
+  rapids_cpm_find(rabbitmq 633d5fd10a2782968783c0bb58b3e88b8978c567
     GLOBAL_TARGETS
       rabbitmq rabbitmq::rabbitmq
     BUILD_EXPORT_SET
@@ -28,7 +31,7 @@ function(find_and_configure_rabbitmq version)
       ${PROJECT_NAME}-exports
     CPM_ARGS
       GIT_REPOSITORY  https://github.com/alanxz/rabbitmq-c
-      GIT_TAG         "v${version}"
+      GIT_TAG 633d5fd10a2782968783c0bb58b3e88b8978c567
       GIT_SHALLOW     TRUE
       OPTIONS         "BUILD_EXAMPLES OFF"
                       "BUILD_TESTING OFF"


### PR DESCRIPTION
* Track recent commit for rabbitmq, which resolved warnings coming from cmake. Unfortunately these fixes are unreleased (https://github.com/alanxz/rabbitmq-c/issues/740) 
* Silence warnings coming from SimpleAmqpClient

fixes #471
