### PR TITLE
WriteToFileStage optionally emit a flush on each message received

### DIFF
--- a/morpheus/_lib/include/morpheus/io/serializers.hpp
+++ b/morpheus/_lib/include/morpheus/io/serializers.hpp
@@ -47,8 +47,13 @@ std::string df_to_csv(const TableInfo& tbl, bool include_header, bool include_in
  * @param out_stream : Output stream to write the results to a destination
  * @param include_header : Determines whether or not to include the header
  * @param include_index_col : Determines whether or not to include the dataframe index
+ * @param flush : When `true` flush `out_stream`.
  */
-void df_to_csv(const TableInfo& tbl, std::ostream& out_stream, bool include_header, bool include_index_col = true);
+void df_to_csv(const TableInfo& tbl,
+               std::ostream& out_stream,
+               bool include_header,
+               bool include_index_col = true,
+               bool flush             = false);
 
 /**
  * @brief Serialize a dataframe into a JSON formatted string
@@ -65,8 +70,9 @@ std::string df_to_json(const TableInfo& tbl, bool include_index_col = true);
  * @param tbl : A wrapper around data in the dataframe
  * @param out_stream : Output stream to write the results to a destination
  * @param include_index_col : Determines whether or not to include the dataframe index
+ * @param flush : When `true` flush `out_stream`.
  */
-void df_to_json(const TableInfo& tbl, std::ostream& out_stream, bool include_index_col = true);
+void df_to_json(const TableInfo& tbl, std::ostream& out_stream, bool include_index_col = true, bool flush = false);
 
 /** @} */  // end of group
 }  // namespace morpheus

--- a/morpheus/_lib/include/morpheus/stages/write_to_file.hpp
+++ b/morpheus/_lib/include/morpheus/stages/write_to_file.hpp
@@ -64,11 +64,13 @@ class WriteToFileStage : public mrc::pymrc::PythonNode<std::shared_ptr<MessageMe
      * @param mode : Reference to the mode for opening a file
      * @param file_type : FileTypes
      * @param include_index_col : Write out the index as a column, by default true
+     * @param flush : When `true` flush the output buffer to disk on each message.
      */
-    WriteToFileStage(const std::string &filename,
+    WriteToFileStage(const std::string& filename,
                      std::ios::openmode mode = std::ios::out,
                      FileTypes file_type     = FileTypes::Auto,
-                     bool include_index_col  = true);
+                     bool include_index_col  = true,
+                     bool flush              = false);
 
   private:
     /**
@@ -81,21 +83,22 @@ class WriteToFileStage : public mrc::pymrc::PythonNode<std::shared_ptr<MessageMe
      *
      * @param msg
      */
-    void write_json(sink_type_t &msg);
+    void write_json(sink_type_t& msg);
 
     /**
      * @brief Write messages (rows in a DataFrame) to a CSV format
      *
      * @param msg
      */
-    void write_csv(sink_type_t &msg);
+    void write_csv(sink_type_t& msg);
 
     subscribe_fn_t build_operator();
 
     bool m_is_first{};
     bool m_include_index_col;
+    bool m_flush;
     std::ofstream m_fstream;
-    std::function<void(sink_type_t &)> m_write_func;
+    std::function<void(sink_type_t&)> m_write_func;
 };
 
 /****** WriteToFileStageInterfaceProxy******************/
@@ -113,6 +116,7 @@ struct WriteToFileStageInterfaceProxy
      * @param mode : Reference to the mode for opening a file
      * @param file_type : FileTypes
      * @param include_index_col : Write out the index as a column, by default true
+     * @param flush : When `true` flush the output buffer to disk on each message.
      * @return std::shared_ptr<mrc::segment::Object<WriteToFileStage>>
      */
     static std::shared_ptr<mrc::segment::Object<WriteToFileStage>> init(mrc::segment::Builder& builder,
@@ -120,7 +124,8 @@ struct WriteToFileStageInterfaceProxy
                                                                         const std::string& filename,
                                                                         const std::string& mode = "w",
                                                                         FileTypes file_type     = FileTypes::Auto,
-                                                                        bool include_index_col  = true);
+                                                                        bool include_index_col  = true,
+                                                                        bool flush              = false);
 };
 
 #pragma GCC visibility pop

--- a/morpheus/_lib/src/io/serializers.cpp
+++ b/morpheus/_lib/src/io/serializers.cpp
@@ -93,7 +93,7 @@ std::string df_to_csv(const TableInfo& tbl, bool include_header, bool include_in
     return out_stream.str();
 }
 
-void df_to_csv(const TableInfo& tbl, std::ostream& out_stream, bool include_header, bool include_index_col)
+void df_to_csv(const TableInfo& tbl, std::ostream& out_stream, bool include_header, bool include_index_col, bool flush)
 {
     auto column_names         = tbl.get_column_names();
     cudf::size_type start_col = 1;
@@ -132,6 +132,11 @@ void df_to_csv(const TableInfo& tbl, std::ostream& out_stream, bool include_head
     }
 
     cudf::io::write_csv(options_builder.build(), rmm::mr::get_current_device_resource());
+
+    if (flush)
+    {
+        sink.flush();
+    }
 }
 
 std::string df_to_json(const TableInfo& tbl, bool include_index_col)
@@ -155,7 +160,7 @@ std::string df_to_json(const TableInfo& tbl, bool include_index_col)
     return results;
 }
 
-void df_to_json(const TableInfo& tbl, std::ostream& out_stream, bool include_index_col)
+void df_to_json(const TableInfo& tbl, std::ostream& out_stream, bool include_index_col, bool flush)
 {
     // Unlike df_to_csv, we use the ostream overload to call the string overload because there is no C++
     // implementation of to_json
@@ -163,7 +168,11 @@ void df_to_json(const TableInfo& tbl, std::ostream& out_stream, bool include_ind
 
     // Now write the contents to the stream
     out_stream.write(output.data(), output.size());
-    out_stream.flush();
+
+    if (flush)
+    {
+        out_stream.flush();
+    }
 }
 
 }  // namespace morpheus

--- a/morpheus/_lib/src/python_modules/stages.cpp
+++ b/morpheus/_lib/src/python_modules/stages.cpp
@@ -179,7 +179,8 @@ PYBIND11_MODULE(stages, m)
              py::arg("filename"),
              py::arg("mode")              = "w",
              py::arg("file_type")         = 0,  // Setting this to FileTypes::AUTO throws a conversion error at runtime
-             py::arg("include_index_col") = true);
+             py::arg("include_index_col") = true,
+             py::arg("flush")             = false);
 
 #ifdef VERSION_INFO
     m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);

--- a/morpheus/_lib/src/stages/write_to_file.cpp
+++ b/morpheus/_lib/src/stages/write_to_file.cpp
@@ -33,13 +33,12 @@ namespace morpheus {
 
 // Component public implementations
 // ************ WriteToFileStage **************************** //
-WriteToFileStage::WriteToFileStage(const std::string &filename,
-                                   std::ios::openmode mode,
-                                   FileTypes file_type,
-                                   bool include_index_col) :
+WriteToFileStage::WriteToFileStage(
+    const std::string& filename, std::ios::openmode mode, FileTypes file_type, bool include_index_col, bool flush) :
   PythonNode(base_t::op_factory_from_sub_fn(build_operator())),
   m_is_first(true),
-  m_include_index_col(include_index_col)
+  m_include_index_col(include_index_col),
+  m_flush(flush)
 {
     if (file_type == FileTypes::Auto)
     {
@@ -48,11 +47,11 @@ WriteToFileStage::WriteToFileStage(const std::string &filename,
 
     if (file_type == FileTypes::CSV)
     {
-        m_write_func = [this](auto &&PH1) { write_csv(std::forward<decltype(PH1)>(PH1)); };
+        m_write_func = [this](auto&& PH1) { write_csv(std::forward<decltype(PH1)>(PH1)); };
     }
     else if (file_type == FileTypes::JSON)
     {
-        m_write_func = [this](auto &&PH1) { write_json(std::forward<decltype(PH1)>(PH1)); };
+        m_write_func = [this](auto&& PH1) { write_json(std::forward<decltype(PH1)>(PH1)); };
     }
     else  // FileTypes::AUTO
     {
@@ -66,16 +65,16 @@ WriteToFileStage::WriteToFileStage(const std::string &filename,
     m_fstream.open(filename, mode);
 }
 
-void WriteToFileStage::write_json(WriteToFileStage::sink_type_t &msg)
+void WriteToFileStage::write_json(WriteToFileStage::sink_type_t& msg)
 {
     // Call df_to_json passing our fstream
-    df_to_json(msg->get_info(), m_fstream, m_include_index_col);
+    df_to_json(msg->get_info(), m_fstream, m_include_index_col, m_flush);
 }
 
-void WriteToFileStage::write_csv(WriteToFileStage::sink_type_t &msg)
+void WriteToFileStage::write_csv(WriteToFileStage::sink_type_t& msg)
 {
     // Call df_to_csv passing our fstream
-    df_to_csv(msg->get_info(), m_fstream, m_is_first, m_include_index_col);
+    df_to_csv(msg->get_info(), m_fstream, m_is_first, m_include_index_col, m_flush);
 }
 
 void WriteToFileStage::close()
@@ -113,7 +112,8 @@ std::shared_ptr<mrc::segment::Object<WriteToFileStage>> WriteToFileStageInterfac
     const std::string& filename,
     const std::string& mode,
     FileTypes file_type,
-    bool include_index_col)
+    bool include_index_col,
+    bool flush)
 {
     std::ios::openmode fsmode = std::ios::out;
 
@@ -149,7 +149,8 @@ std::shared_ptr<mrc::segment::Object<WriteToFileStage>> WriteToFileStageInterfac
         throw std::runtime_error(std::string("Unsupported file mode. Must choose either 'w' or 'a'. Mode: ") + mode);
     }
 
-    auto stage = builder.construct_object<WriteToFileStage>(name, filename, fsmode, file_type, include_index_col);
+    auto stage =
+        builder.construct_object<WriteToFileStage>(name, filename, fsmode, file_type, include_index_col, flush);
 
     return stage;
 }

--- a/morpheus/_lib/tests/CMakeLists.txt
+++ b/morpheus/_lib/tests/CMakeLists.txt
@@ -22,7 +22,6 @@ add_executable(test_libmorpheus
   test_matx_util.cpp
   test_morpheus.cpp
   test_multi_slices.cpp
-  test_serializers.cpp
   test_tensor.cpp
   test_type_util_detail.cpp
 )

--- a/morpheus/_lib/tests/CMakeLists.txt
+++ b/morpheus/_lib/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(test_libmorpheus
   test_matx_util.cpp
   test_morpheus.cpp
   test_multi_slices.cpp
+  test_serializers.cpp
   test_tensor.cpp
   test_type_util_detail.cpp
 )

--- a/morpheus/stages/output/write_to_file_stage.py
+++ b/morpheus/stages/output/write_to_file_stage.py
@@ -51,7 +51,7 @@ class WriteToFileStage(SinglePortStage):
         File type of output (FileTypes.JSON, FileTypes.CSV, FileTypes.Auto), by default FileTypes.Auto.
     include_index_col : bool, default = True
         Write out the index as a column, by default True.
-    flush : bool, default = False
+    flush : bool, default = False, is_flag = True
         When `True` flush the output buffer to disk on each message.
     """
 

--- a/morpheus/stages/output/write_to_file_stage.py
+++ b/morpheus/stages/output/write_to_file_stage.py
@@ -37,8 +37,7 @@ class WriteToFileStage(SinglePortStage):
     """
     Write all messages to a file.
 
-    This class writes messages to a file. This class does not buffer or keep the file open between messages.
-    It should not be used in production code.
+    This class writes messages to a file.
 
     Parameters
     ----------
@@ -52,6 +51,8 @@ class WriteToFileStage(SinglePortStage):
         File type of output (FileTypes.JSON, FileTypes.CSV, FileTypes.Auto), by default FileTypes.Auto.
     include_index_col : bool, default = True
         Write out the index as a column, by default True.
+    flush : bool, default = False
+        When `True` flush the output buffer to disk on each message.
     """
 
     def __init__(self,
@@ -59,7 +60,8 @@ class WriteToFileStage(SinglePortStage):
                  filename: str,
                  overwrite: bool = False,
                  file_type: FileTypes = FileTypes.Auto,
-                 include_index_col: bool = True):
+                 include_index_col: bool = True,
+                 flush: bool = False):
 
         super().__init__(c)
 
@@ -80,6 +82,7 @@ class WriteToFileStage(SinglePortStage):
 
         self._is_first = True
         self._include_index_col = include_index_col
+        self._flush = flush
 
     @property
     def name(self) -> str:
@@ -128,7 +131,8 @@ class WriteToFileStage(SinglePortStage):
                                                self._output_file,
                                                "w",
                                                self._file_type,
-                                               self._include_index_col)
+                                               self._include_index_col,
+                                               self._flush)
         else:
 
             def node_fn(obs: mrc.Observable, sub: mrc.Subscriber):
@@ -144,6 +148,9 @@ class WriteToFileStage(SinglePortStage):
                         lines = self._convert_to_strings(x.df)
 
                         out_file.writelines(lines)
+
+                        if self._flush:
+                            out_file.flush()
 
                         return x
 

--- a/tests/test_file_in_out_stage_pipe.py
+++ b/tests/test_file_in_out_stage_pipe.py
@@ -29,14 +29,15 @@ from utils import TEST_DIRS
 from utils import assert_path_exists
 
 
+@pytest.mark.parametrize("flush", [False, True])
 @pytest.mark.parametrize("output_type", ["csv", "json", "jsonlines"])
-def test_file_rw_pipe(tmp_path, config, output_type):
+def test_file_rw_pipe(tmp_path, config, output_type, flush):
     input_file = os.path.join(TEST_DIRS.tests_data_dir, "filter_probs.csv")
     out_file = os.path.join(tmp_path, 'results.{}'.format(output_type))
 
     pipe = LinearPipeline(config)
     pipe.set_source(FileSourceStage(config, filename=input_file))
-    pipe.add_stage(WriteToFileStage(config, filename=out_file, overwrite=False))
+    pipe.add_stage(WriteToFileStage(config, filename=out_file, overwrite=False, flush=flush))
     pipe.run()
 
     assert_path_exists(out_file)

--- a/tests/test_write_to_file_stage.py
+++ b/tests/test_write_to_file_stage.py
@@ -23,7 +23,6 @@ from morpheus.pipeline import LinearPipeline
 from morpheus.stages.input.file_source_stage import FileSourceStage
 from morpheus.stages.output.write_to_file_stage import WriteToFileStage
 from utils import TEST_DIRS
-from utils import assert_path_exists
 
 
 @pytest.mark.use_python

--- a/tests/test_write_to_file_stage.py
+++ b/tests/test_write_to_file_stage.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from unittest import mock
+
+import pytest
+
+from morpheus.pipeline import LinearPipeline
+from morpheus.stages.input.file_source_stage import FileSourceStage
+from morpheus.stages.output.write_to_file_stage import WriteToFileStage
+from utils import TEST_DIRS
+from utils import assert_path_exists
+
+
+@pytest.mark.use_python
+@pytest.mark.parametrize("flush", [False, True])
+@pytest.mark.parametrize("output_type", ["csv", "json", "jsonlines"])
+def test_file_rw_pipe(tmp_path, config, output_type, flush):
+    """
+    Test the flush functionality of the WriteToFileStage.
+    """
+    input_file = os.path.join(TEST_DIRS.tests_data_dir, "filter_probs.csv")
+    out_file = os.path.join(tmp_path, 'results.{}'.format(output_type))
+
+    # This currently works because the FileSourceStage doesn't use the builtin open function, but WriteToFileStage does
+    mock_open = mock.mock_open()
+    with mock.patch('builtins.open', mock_open):
+        pipe = LinearPipeline(config)
+        pipe.set_source(FileSourceStage(config, filename=input_file))
+        pipe.add_stage(WriteToFileStage(config, filename=out_file, overwrite=False, flush=flush))
+        pipe.run()
+
+    assert not os.path.exists(out_file)
+    assert mock_open().flush.called == flush


### PR DESCRIPTION
Currently we don't flush to disk for each message. However for some sources like Kafka, there may be long periods of time between incoming messages which might be small.

* Adds new `flush` constructor argument to `WriteToFileStage`
* Ensures that we are consistent on when we flush and don't. Specifically the Python impl never flushed, but the C++ impl flushed always for json but not for csv.

fixes #558 