### PR TITLE
Fix bug where the model's max batch size would split inference inputs

### DIFF
--- a/morpheus/_lib/src/stages/triton_inference.cpp
+++ b/morpheus/_lib/src/stages/triton_inference.cpp
@@ -161,30 +161,44 @@ InferenceClientStage::subscribe_fn_t InferenceClientStage::build_operator()
                                                 cudaMemcpyDeviceToHost));
                 }
 
-                for (size_t i = 0; i < x->count; i += m_max_batch_size)
+                for (size_t i = 0; i < x->count;)
                 {
                     triton::client::InferInput* input1;
 
                     size_t start = i;
                     size_t stop  = std::min(i + m_max_batch_size, x->count);
 
-                    sink_type_t mini_batch_input = x->get_slice(start, stop);
-
-                    size_t out_start = start;
-                    size_t out_stop  = stop;
+                    size_t out_start;
+                    size_t out_stop;
                     if (needs_seq_ids)
                     {
-                        out_start = (*host_seq_ids)[out_start];
-                        if (out_stop < host_seq_ids->size())
+                        out_start = (*host_seq_ids)[start];
+                        if (stop < host_seq_ids->size())
                         {
-                            out_stop = (*host_seq_ids)[out_stop];
+                            // make sure we aren't performing a batch split between rows for the same input
+                            // this assumes that we don't have input that couldn't fit in a single mini-batch
+                            while (stop > start && (*host_seq_ids)[stop - 1] == (*host_seq_ids)[stop])
+                            {
+                                --stop;
+                            }
+
+                            out_stop = (*host_seq_ids)[stop];
+                            i += (stop - start);
                         }
                         else
                         {
                             out_stop = x->mess_count;
+                            i += m_max_batch_size;
                         }
                     }
+                    else
+                    {
+                        out_start = start;
+                        out_stop  = stop;
+                        i += m_max_batch_size;
+                    }
 
+                    sink_type_t mini_batch_input    = x->get_slice(start, stop);
                     source_type_t mini_batch_output = response->get_slice(out_start, out_stop);
 
                     // Iterate on the model inputs in case the model takes less than what tensors are available
@@ -265,7 +279,7 @@ InferenceClientStage::subscribe_fn_t InferenceClientStage::build_operator()
                         {
                             // Since we are working with slices of both the input and the output, the seq_ids have
                             // already been applied to the output's start & stop, so we only need to reduce the
-                            // response tensort when the size doesn't match our output
+                            // response tensor when the size doesn't match our output
                             std::vector<int64_t> mapped_output_shape{output_shape};
                             mapped_output_shape[0] = mini_batch_output->count;
 

--- a/morpheus/_lib/src/utilities/matx_util.cu
+++ b/morpheus/_lib/src/utilities/matx_util.cu
@@ -397,11 +397,12 @@ namespace morpheus {
 
         std::size_t start = 0;
         auto output_offset = seq_ids[seq_id_offset];
-        for (std::size_t i=0; i < num_input_rows; ++i)
+        for (std::size_t i=1; i < num_input_rows; ++i)
         {
             auto idx = seq_ids[i+seq_id_offset];
             if (idx != seq_ids[start+seq_id_offset])
             {
+                DCHECK(seq_ids[start+seq_id_offset]-output_offset < output_shape[0]);
                 cudf::type_dispatcher(cudf_type,
                                       matx_reduce_max,
                                       start,
@@ -411,6 +412,7 @@ namespace morpheus {
             }
         }
 
+        DCHECK(seq_ids[start+seq_id_offset]-output_offset < output_shape[0]);
         cudf::type_dispatcher(cudf_type,
                               matx_reduce_max,
                               start,


### PR DESCRIPTION
Fix bug where the model's max batch size would split inference inputs mapping back to the same source row in the dataframe.

ex:
```
model_max_batch_size = 4
seq_ids = [0, 0, 0, 1, 1, 2, 3, 3]
```

Would cause the inference inputs for dataframe row 1 to occur in two non-adjacent batches.

This is a non-ideal fix as this doesn't handle the case where the inference input is so large that it spans more rows than the model's max batch size. 

A better solution would be to always split on `model_max_batch_size` and then take the max of both results, the problem is as-written the two results would appear in two separate slices of `ResponseMemoryProbs`