### PR TITLE
Fix CLI parsing of C++ enum values

### DIFF
--- a/morpheus.code-workspace
+++ b/morpheus.code-workspace
@@ -61,7 +61,7 @@
 				"name": "Python: Run Pipeline (NLP)",
 				"type": "python",
 				"request": "launch",
-				"program": "${workspaceFolder}/morpheus/cli.py",
+				"program": "${workspaceFolder}/morpheus/cli/run.py",
 				"console": "integratedTerminal",
 				"justMyCode": false,
 				"subProcess": true,
@@ -118,7 +118,7 @@
 				"name": "Python: Run Pipeline (FIL)",
 				"type": "python",
 				"request": "launch",
-				"program": "${workspaceFolder}/morpheus/cli.py",
+				"program": "${workspaceFolder}/morpheus/cli/run.py",
 				"console": "integratedTerminal",
 				"justMyCode": false,
 				"subProcess": true,
@@ -174,7 +174,7 @@
 				"name": "Python: Run Pipeline (AE)",
 				"type": "python",
 				"request": "launch",
-				"program": "${workspaceFolder}/morpheus/cli.py",
+				"program": "${workspaceFolder}/morpheus/cli/run.py",
 				"console": "integratedTerminal",
 				"justMyCode": false,
 				"subProcess": true,
@@ -233,7 +233,7 @@
 				"name": "Python: Run Pipeline (NLP-Phishing)",
 				"type": "python",
 				"request": "launch",
-				"program": "${workspaceFolder}/morpheus/cli.py",
+				"program": "${workspaceFolder}/morpheus/cli/run.py",
 				"console": "integratedTerminal",
 				"justMyCode": false,
 				"subProcess": true,
@@ -330,7 +330,7 @@
 				"justMyCode": false
 			},
 			{
-				"name": "Debug SRF from Python (Morpheus-NLP)",
+				"name": "Debug MRC from Python (Morpheus-NLP)",
 				"type": "cppdbg",
 				"request": "launch",
 				"program": "python",
@@ -415,7 +415,7 @@
 				],
 				"symbolLoadInfo": {
 					"loadAll": false,
-					"exceptionList": "libsrf*.so;cudf_helpers.*;executor.*;morpheus.*;node.*;options.*;pipeline.*;segment.*;subscriber.*;stages.*;messages.*;common*.so"
+					"exceptionList": "libmrc*.so;cudf_helpers.*;executor.*;morpheus.*;node.*;options.*;pipeline.*;segment.*;subscriber.*;stages.*;messages.*;common*.so"
 				},
 				"miDebuggerPath": "gdb",
 				"sourceFileMap": {
@@ -426,7 +426,7 @@
 				},
 			},
 			{
-				"name": "Debug SRF from Python (Morpheus-FIL)",
+				"name": "Debug MRC from Python (Morpheus-FIL)",
 				"type": "cppdbg",
 				"request": "launch",
 				"program": "python",
@@ -508,7 +508,7 @@
 				],
 				"symbolLoadInfo": {
 					"loadAll": false,
-					"exceptionList": "libsrf*.so;cudf_helpers.*;executor.*;morpheus.*;node.*;options.*;pipeline.*;segment.*;subscriber.*;stages.*;messages.*;common*.so"
+					"exceptionList": "libmrc*.so;cudf_helpers.*;executor.*;morpheus.*;node.*;options.*;pipeline.*;segment.*;subscriber.*;stages.*;messages.*;common*.so"
 				},
 				"miDebuggerPath": "gdb",
 				"sourceFileMap": {
@@ -519,7 +519,7 @@
 				},
 			},
 			{
-				"name": "Debug SRF from Python (Morpheus-AE)",
+				"name": "Debug MRC from Python (Morpheus-AE)",
 				"type": "cppdbg",
 				"request": "launch",
 				"program": "python",
@@ -599,7 +599,7 @@
 				],
 				"symbolLoadInfo": {
 					"loadAll": false,
-					"exceptionList": "libsrf*.so;cudf_helpers.*;executor.*;morpheus.*;node.*;options.*;pipeline.*;segment.*;subscriber.*;stages.*;messages.*;common*.so"
+					"exceptionList": "libmrc*.so;cudf_helpers.*;executor.*;morpheus.*;node.*;options.*;pipeline.*;segment.*;subscriber.*;stages.*;messages.*;common*.so"
 				},
 				"miDebuggerPath": "gdb",
 				"sourceFileMap": {

--- a/morpheus/cli/commands.py
+++ b/morpheus/cli/commands.py
@@ -24,7 +24,7 @@ from morpheus.cli.stage_registry import GlobalStageRegistry
 from morpheus.cli.stage_registry import LazyStageInfo
 from morpheus.cli.utils import MorpheusRelativePath
 from morpheus.cli.utils import get_config_from_ctx
-from morpheus.cli.utils import get_enum_values
+from morpheus.cli.utils import get_enum_keys
 from morpheus.cli.utils import get_log_levels
 from morpheus.cli.utils import get_pipeline_from_ctx
 from morpheus.cli.utils import load_labels_file
@@ -450,8 +450,8 @@ def pipeline_fil(ctx: click.Context, **kwargs):
               help=("Specifying this value will filter all incoming data to only use rows with matching User IDs. "
                     "Which column is used for the User ID is specified by `userid_column_name`"))
 @click.option('--feature_scaler',
-              type=click.Choice(get_enum_values(AEFeatureScalar), case_sensitive=False),
-              default=AEFeatureScalar.STANDARD.value,
+              type=click.Choice(get_enum_keys(AEFeatureScalar), case_sensitive=False),
+              default=AEFeatureScalar.STANDARD.name,
               callback=functools.partial(parse_enum, enum_class=AEFeatureScalar, case_sensitive=False),
               help=("Autoencoder feature scaler"))
 @click.option('--use_generic_model',

--- a/morpheus/cli/utils.py
+++ b/morpheus/cli/utils.py
@@ -168,7 +168,7 @@ def get_enum_map(enum_class: typing.Type):
     assert (issubclass(enum_class, Enum) or is_pybind_enum(enum_class)), \
             "Must pass a class that derives from Enum or a C++ enum exposed to Python"
 
-    return dict(enum_class.__members__)
+    return {x.name: x.value for x in enum_class.__members__.values()}
 
 
 def get_enum_inv_map(enum_class: typing.Type):

--- a/morpheus/cli/utils.py
+++ b/morpheus/cli/utils.py
@@ -22,7 +22,6 @@ from functools import update_wrapper
 
 import click
 import click.globals
-from typing_utils import issubtype
 
 import morpheus
 from morpheus.config import Config

--- a/morpheus/cli/utils.py
+++ b/morpheus/cli/utils.py
@@ -48,7 +48,7 @@ def _without_empty_args(passed_args):
     return {k: v for k, v in passed_args.items() if v is not None}
 
 
-def is_pybind_enum(cls):
+def is_pybind_enum(cls: typing.Any):
     """
     Determines if the given `cls` is an enum.
     C++ enums exposed via pybind11 do not inherit from Enum, but do expose the `__members__` convention.
@@ -162,48 +162,28 @@ def parse_log_level(ctx, param, value):
     return x
 
 
-def get_enum_map(enum_class: typing.Type):
+def is_enum(enum_class: typing.Type):
+    return issubclass(enum_class, Enum) or is_pybind_enum(enum_class)
 
-    assert (issubclass(enum_class, Enum) or is_pybind_enum(enum_class)), \
+
+def get_enum_members(enum_class: typing.Type):
+
+    assert is_enum(enum_class), \
             "Must pass a class that derives from Enum or a C++ enum exposed to Python"
 
-    return {x.name: x.value for x in enum_class.__members__.values()}
+    return dict(enum_class.__members__)
 
 
-def get_enum_inv_map(enum_class: typing.Type):
+def get_enum_keys(enum_class: typing.Type):
 
-    assert (issubclass(enum_class, Enum) or is_pybind_enum(enum_class)), \
-        "Must pass a class that derives from Enum or a C++ enum exposed to Python"
+    enum_map = get_enum_members(enum_class)
 
-    enum_map = {x.value: x.name for x in enum_class.__members__.values()}
-
-    return enum_map
-
-
-def get_enum_values(enum_class: typing.Type):
-
-    enum_map = get_enum_map(enum_class)
-
-    return list(enum_map.values())
+    return list(enum_map.keys())
 
 
 def parse_enum(_: click.Context, _2: click.Parameter, value: str, enum_class: typing.Type, case_sensitive=True):
 
-    enum_map = get_enum_inv_map(enum_class)
-
-    if case_sensitive:
-        enum_key = enum_map[value]
-    else:
-        # Make the keys lowercase
-        enum_map = {key.lower(): value for key, value in enum_map.items()}
-        enum_key = enum_map[value.lower()]
-
-    result = enum_class[enum_key]
-    return result
-
-
-def parse_pybind_enum(_: click.Context, _2: click.Parameter, value: str, enum_class: typing.Type, case_sensitive=True):
-    enum_map = get_enum_map(enum_class)
+    enum_map = get_enum_members(enum_class)
 
     if not case_sensitive:
         # Make the keys lowercase
@@ -211,6 +191,7 @@ def parse_pybind_enum(_: click.Context, _2: click.Parameter, value: str, enum_cl
         value = value.lower()
 
     result = enum_map[value]
+
     return result
 
 

--- a/morpheus/stages/input/file_source_stage.py
+++ b/morpheus/stages/input/file_source_stage.py
@@ -49,9 +49,9 @@ class FileSourceStage(SingleOutputSource):
     iterative : boolean, default = False, is_flag = True
         Iterative mode will emit dataframes one at a time. Otherwise a list of dataframes is emitted. Iterative mode is
         good for interleaving source stages.
-    file_type : `morpheus._lib.common.FileTypes`, default = 'auto'
+    file_type : `morpheus._lib.common.FileTypes`, optional, case_sensitive = False
         Indicates what type of file to read. Specifying 'auto' will determine the file type from the extension.
-        Supported extensions: 'json', 'csv'
+        Supported extensions: 'csv', 'json' and 'jsonlines'
     repeat : int, default = 1, min = 1
         Repeats the input dataset multiple times. Useful to extend small datasets for debugging.
     filter_null : bool, default = True

--- a/morpheus/stages/input/kafka_source_stage.py
+++ b/morpheus/stages/input/kafka_source_stage.py
@@ -67,7 +67,7 @@ class KafkaSourceStage(SingleOutputSource):
     disable_pre_filtering : bool, default = False
         Enabling this option will skip pre-filtering of json messages. This is only useful when inputs are known to be
         valid json.
-    auto_offset_reset : `AutoOffsetReset`, default = AutoOffsetReset.LATEST, case_sensitive = False
+    auto_offset_reset : `AutoOffsetReset`, case_sensitive = False
         Sets the value for the configuration option 'auto.offset.reset'. See the kafka documentation for more
         information on the effects of each value."
     stop_after: int, default = 0
@@ -85,7 +85,7 @@ class KafkaSourceStage(SingleOutputSource):
                  poll_interval: str = "10millis",
                  disable_commit: bool = False,
                  disable_pre_filtering: bool = False,
-                 auto_offset_reset: AutoOffsetReset = "latest",
+                 auto_offset_reset: AutoOffsetReset = AutoOffsetReset.LATEST,
                  stop_after: int = 0,
                  async_commits: bool = True):
         super().__init__(c)

--- a/morpheus/stages/output/write_to_file_stage.py
+++ b/morpheus/stages/output/write_to_file_stage.py
@@ -48,8 +48,9 @@ class WriteToFileStage(SinglePortStage):
         Name of the file to which the messages will be written.
     overwrite : boolean, default = False, is_flag = True
         Overwrite file if exists. Will generate an error otherwise.
-    file_type : `morpheus._lib.common.FileTypes`, optional
-        File type of output (FileTypes.JSON, FileTypes.CSV, FileTypes.Auto), by default FileTypes.Auto.
+    file_type : `morpheus._lib.common.FileTypes`, optional, case_sensitive = False
+        Indicates what type of file to write. Specifying 'auto' will determine the file type from the extension.
+        Supported extensions: 'csv', 'json' and 'jsonlines'
     include_index_col : bool, default = True
         Write out the index as a column, by default True.
     """

--- a/morpheus/stages/postprocess/filter_detections_stage.py
+++ b/morpheus/stages/postprocess/filter_detections_stage.py
@@ -69,7 +69,7 @@ class FilterDetectionsStage(SinglePortStage):
         Threshold to classify, default is 0.5.
     copy : bool
         Whether or not to perform a copy.
-    filter_source : `from morpheus._lib.common.FilterSource`, default = 'auto'
+    filter_source : `from morpheus._lib.common.FilterSource`, case_sensitive = False
         Indicate if we are operating on is an output tensor or a field in the DataFrame.
         Choosing `Auto` will default to `TENSOR` when the incoming message contains output tensorts and `DATAFRAME`
         otherwise.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,6 +24,7 @@ from click.testing import CliRunner
 from mlflow.tracking import fluent
 
 import morpheus
+from morpheus._lib.common import FileTypes
 from morpheus.cli import commands
 from morpheus.config import Config
 from morpheus.config import ConfigAutoEncoder
@@ -537,6 +538,143 @@ class TestCLI:
 
         assert isinstance(to_file, WriteToFileStage)
         assert to_file._output_file == 'out.csv'
+
+        assert isinstance(to_kafka, WriteToKafkaStage)
+        assert to_kafka._kafka_conf['bootstrap.servers'] == 'kserv1:123,kserv2:321'
+        assert to_kafka._output_topic == 'test_topic'
+
+    @pytest.mark.replace_callback('pipeline_fil')
+    def test_issue_675(self, config, callback_values, tmp_path, mlflow_uri):
+        """
+        Test parsing of CLI flags for C++ enum values
+        """
+        tmp_model = os.path.join(tmp_path, 'fake-model.file')
+        with open(tmp_model, 'w'):
+            pass
+
+        file_src_args = FILE_SRC_ARGS[:]
+        file_src_args.append('--file_type=json')
+
+        from_kafka_args = FROM_KAFKA_ARGS[:]
+        from_kafka_args.append('--auto_offset_reset=earliest')
+
+        to_file_args = TO_FILE_ARGS[:]
+        to_file_args.append('--file_type=csv')
+
+        args = (GENERAL_ARGS + ['pipeline-other'] + file_src_args + from_kafka_args + [
+            'deserialize',
+            'filter',
+            '--filter_source=tensor',
+            'dropna',
+            '--column',
+            'xyz',
+            'preprocess',
+            'add-scores',
+            'unittest-conv-msg',
+            'inf-identity',
+            'inf-pytorch',
+            '--model_filename',
+            tmp_model,
+            'mlflow-drift',
+            '--tracking_uri',
+            mlflow_uri
+        ] + INF_TRITON_ARGS + MONITOR_ARGS + ['add-class'] + VALIDATE_ARGS + ['serialize'] + to_file_args +
+                TO_KAFKA_ARGS)
+
+        obj = {}
+        runner = CliRunner()
+        result = runner.invoke(commands.cli, args, obj=obj)
+        assert result.exit_code == 47, result.output
+
+        # Ensure our config is populated correctly
+
+        config = obj["config"]
+        assert config.mode == PipelineModes.FIL
+        assert config.class_labels == ['frogs', 'lizards', 'toads']
+
+        assert config.ae is None
+
+        pipe = callback_values['pipe']
+        assert pipe is not None
+
+        stages = callback_values['stages']
+        # Verify the stages are as we expect them, if there is a size-mismatch python will raise a Value error
+        [
+            file_source,
+            from_kafka,
+            deserialize,
+            filter_stage,
+            dropna,
+            process_fil,
+            add_scores,
+            conv_msg,
+            inf_ident,
+            inf_pytorch,
+            mlflow_drift,
+            triton_inf,
+            monitor,
+            add_class,
+            validation,
+            serialize,
+            to_file,
+            to_kafka
+        ] = stages
+
+        assert isinstance(file_source, FileSourceStage)
+        assert file_source._filename == os.path.join(TEST_DIRS.validation_data_dir, 'abp-validation-data.jsonlines')
+        assert not file_source._iterative
+        assert file_source._file_type == FileTypes.JSON
+
+        assert isinstance(from_kafka, KafkaSourceStage)
+        assert from_kafka._consumer_params['bootstrap.servers'] == 'kserv1:123,kserv2:321'
+        assert from_kafka._topic == 'test_topic'
+        assert from_kafka._consumer_params['auto.offset.reset'] == 'earliest'
+
+        assert isinstance(deserialize, DeserializeStage)
+        assert isinstance(filter_stage, FilterDetectionsStage)
+
+        assert isinstance(dropna, DropNullStage)
+        assert dropna._column == 'xyz'
+
+        assert isinstance(process_fil, PreprocessFILStage)
+
+        assert isinstance(add_scores, AddScoresStage)
+        assert isinstance(conv_msg, ConvMsg)
+        assert isinstance(inf_ident, IdentityInferenceStage)
+
+        assert isinstance(inf_pytorch, PyTorchInferenceStage)
+        assert inf_pytorch._model_filename == tmp_model
+
+        assert isinstance(mlflow_drift, MLFlowDriftStage)
+        assert mlflow_drift._tracking_uri == mlflow_uri
+
+        assert isinstance(triton_inf, TritonInferenceStage)
+        assert triton_inf._kwargs['model_name'] == 'test-model'
+        assert triton_inf._kwargs['server_url'] == 'test:123'
+        assert triton_inf._kwargs['force_convert_inputs']
+
+        assert isinstance(monitor, MonitorStage)
+        assert monitor._description == 'Unittest'
+        assert monitor._smoothing == 0.001
+        assert monitor._unit == 'inf'
+
+        assert isinstance(add_class, AddClassificationsStage)
+
+        assert isinstance(validation, ValidationStage)
+        assert validation._val_file_name == os.path.join(TEST_DIRS.validation_data_dir,
+                                                         'dfp-cloudtrail-role-g-validation-data-output.csv')
+        assert validation._results_file_name == 'results.json'
+        assert validation._index_col == '_index_'
+
+        # Click appears to be converting this into a tuple
+        assert list(validation._exclude_columns) == ['event_dt']
+        assert validation._rel_tol == 0.1
+
+        assert isinstance(serialize, SerializeStage)
+
+        assert isinstance(to_file, WriteToFileStage)
+        assert to_file._output_file == 'out.csv'
+        assert file_source._file_type == FileTypes.CSV
 
         assert isinstance(to_kafka, WriteToKafkaStage)
         assert to_kafka._kafka_conf['bootstrap.servers'] == 'kserv1:123,kserv2:321'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,6 +25,7 @@ from mlflow.tracking import fluent
 
 import morpheus
 from morpheus._lib.common import FileTypes
+from morpheus._lib.common import FilterSource
 from morpheus.cli import commands
 from morpheus.config import Config
 from morpheus.config import ConfigAutoEncoder
@@ -633,6 +634,7 @@ class TestCLI:
 
         assert isinstance(deserialize, DeserializeStage)
         assert isinstance(filter_stage, FilterDetectionsStage)
+        assert filter_stage._filter_source == FilterSource.TENSOR.value
 
         assert isinstance(dropna, DropNullStage)
         assert dropna._column == 'xyz'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -625,7 +625,7 @@ class TestCLI:
         assert isinstance(file_source, FileSourceStage)
         assert file_source._filename == os.path.join(TEST_DIRS.validation_data_dir, 'abp-validation-data.jsonlines')
         assert not file_source._iterative
-        assert file_source._file_type == FileTypes.JSON.value
+        assert file_source._file_type == FileTypes.JSON
 
         assert isinstance(from_kafka, KafkaSourceStage)
         assert from_kafka._consumer_params['bootstrap.servers'] == 'kserv1:123,kserv2:321'
@@ -634,7 +634,7 @@ class TestCLI:
 
         assert isinstance(deserialize, DeserializeStage)
         assert isinstance(filter_stage, FilterDetectionsStage)
-        assert filter_stage._filter_source == FilterSource.TENSOR.value
+        assert filter_stage._filter_source == FilterSource.TENSOR
 
         assert isinstance(dropna, DropNullStage)
         assert dropna._column == 'xyz'
@@ -675,7 +675,7 @@ class TestCLI:
 
         assert isinstance(to_file, WriteToFileStage)
         assert to_file._output_file == 'out.csv'
-        assert to_file._file_type == FileTypes.CSV.value
+        assert to_file._file_type == FileTypes.CSV
 
         assert isinstance(to_kafka, WriteToKafkaStage)
         assert to_kafka._kafka_conf['bootstrap.servers'] == 'kserv1:123,kserv2:321'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -544,9 +544,9 @@ class TestCLI:
         assert to_kafka._output_topic == 'test_topic'
 
     @pytest.mark.replace_callback('pipeline_fil')
-    def test_issue_675(self, config, callback_values, tmp_path, mlflow_uri):
+    def test_enum_parsing(self, config, callback_values, tmp_path, mlflow_uri):
         """
-        Test parsing of CLI flags for C++ enum values
+        Test parsing of CLI flags for C++ enum values issue #675
         """
         tmp_model = os.path.join(tmp_path, 'fake-model.file')
         with open(tmp_model, 'w'):


### PR DESCRIPTION
C++ enums exposed to Python via pybind11 are not subclasses of `enum.Enum` causing them to not be parsed properly by the CLI.

Hot-patching this into 23.01

fixes #675 