### PR TITLE
Update DFPRollingWindowStage to emit correct window

### DIFF
--- a/examples/digital_fingerprinting/production/morpheus/dfp/stages/dfp_rolling_window_stage.py
+++ b/examples/digital_fingerprinting/production/morpheus/dfp/stages/dfp_rolling_window_stage.py
@@ -158,12 +158,10 @@ class DFPRollingWindowStage(SinglePortStage):
                 raise RuntimeError(("Overlapping rolling history detected. "
                                     "Rolling history can only be used with non-overlapping batches"))
 
-            train_offset = train_df.index.get_loc(first_row_idx)
-
             # Otherwise return a new message
             return MultiDFPMessage(meta=DFPMessageMeta(df=train_df, user_id=user_id),
-                                   mess_offset=train_offset,
-                                   mess_count=found_count)
+                                   mess_offset=0,
+                                   mess_count=len(train_df))
 
     def on_data(self, message: DFPMessageMeta):
 


### PR DESCRIPTION
DFPRollingWindowStage was only emitting last batch once `min_history` was met. This PR updates the stage to emit all accumulated rows meeting configured window history requirements.

Fixes #674