### PR TITLE
fix incorrect line and byte count benchmarks

### DIFF
--- a/examples/digital_fingerprinting/production/morpheus/benchmarks/conftest.py
+++ b/examples/digital_fingerprinting/production/morpheus/benchmarks/conftest.py
@@ -45,10 +45,11 @@ def pytest_benchmark_update_json(config, benchmarks, output_json):
         output_json["machine_info"]["gpu_" + str(i)]["temperature"] = f"{gpu.temperature} C"
         output_json["machine_info"]["gpu_" + str(i)]["uuid"] = gpu.uuid
 
-    line_count = 0
-    byte_count = 0
-
     for bench in output_json['benchmarks']:
+
+        line_count = 0
+        byte_count = 0
+
         if "file_path" in PIPELINES_CONF[bench["name"]]:
             source_file = PIPELINES_CONF[bench["name"]]["file_path"]
             source_file = path.join(curr_dir, source_file)

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -35,9 +35,11 @@ def pytest_benchmark_update_json(config, benchmarks, output_json):
         output_json["machine_info"]["gpu_" + str(i)]["temperature"] = f"{gpu.temperature} C"
         output_json["machine_info"]["gpu_" + str(i)]["uuid"] = gpu.uuid
 
-    line_count = 0
-    byte_count = 0
     for bench in output_json['benchmarks']:
+
+        line_count = 0
+        byte_count = 0
+
         if "file_path" in E2E_TEST_CONFIGS[bench["name"]]:
             source_file = E2E_TEST_CONFIGS[bench["name"]]["file_path"]
             line_count = len(open(source_file).readlines())


### PR DESCRIPTION
Fixed incorrect line and byte count in  the benchmarks when using `globpath` in the configuration file.

closes #694 