### PR TITLE
Add unittest to ensure the kafka source is respecting the pipeline batch size

### DIFF
--- a/tests/test_kafka_source_stage_pipe.py
+++ b/tests/test_kafka_source_stage_pipe.py
@@ -33,6 +33,7 @@ from morpheus.stages.output.write_to_file_stage import WriteToFileStage
 from morpheus.stages.postprocess.serialize_stage import SerializeStage
 from morpheus.stages.preprocess.deserialize_stage import DeserializeStage
 from utils import TEST_DIRS
+from utils import DFPLengthChecker
 from utils import assert_path_exists
 from utils import write_file_to_kafka
 
@@ -172,6 +173,57 @@ def test_kafka_source_commit(num_records,
     pipe.add_stage(OffsetChecker(config, bootstrap_servers=kafka_bootstrap_servers, group_id='morpheus'))
     pipe.add_stage(TriggerStage(config))
 
+    pipe.add_stage(DeserializeStage(config))
+    pipe.add_stage(SerializeStage(config))
+    pipe.add_stage(WriteToFileStage(config, filename=out_file, overwrite=False))
+    pipe.run()
+
+    assert_path_exists(out_file)
+
+    input_data = read_file_to_df(input_file, file_type=FileTypes.Auto).values
+    output_data = read_file_to_df(out_file, file_type=FileTypes.Auto).values
+
+    assert len(input_data) == num_records
+    assert len(output_data) == num_records
+
+    # Somehow 0.7 ends up being 0.7000000000000001
+    input_data = np.around(input_data, 2)
+    output_data = np.around(output_data, 2)
+
+    assert output_data.tolist() == input_data.tolist()
+
+
+@pytest.mark.kafka
+@pytest.mark.slow
+@pytest.mark.parametrize('num_records', [1000])
+def test_kafka_source_batch_pipe(tmp_path,
+                                 config,
+                                 kafka_bootstrap_servers: str,
+                                 kafka_topics: typing.Tuple[str, str],
+                                 num_records: int) -> None:
+    input_file = os.path.join(tmp_path, "input_data.json")
+    with open(input_file, 'w') as fh:
+        for i in range(num_records):
+            fh.write("{}\n".format(json.dumps({'v': i})))
+
+    num_written = write_file_to_kafka(kafka_bootstrap_servers, kafka_topics.input_topic, input_file)
+    assert num_written == num_records
+
+    out_file = os.path.join(tmp_path, 'results.jsonlines')
+
+    expected_length = config.pipeline_batch_size
+    num_exact = num_records // expected_length
+
+    pipe = LinearPipeline(config)
+    pipe.set_source(
+        KafkaSourceStage(config,
+                         bootstrap_servers=kafka_bootstrap_servers,
+                         input_topic=kafka_topics.input_topic,
+                         auto_offset_reset="earliest",
+                         poll_interval="1seconds",
+                         client_id='morpheus_kafka_source_stage_pipe',
+                         stop_after=num_records))
+    pipe.add_stage(DFPLengthChecker(config, expected_length=expected_length, num_exact=num_exact))
     pipe.add_stage(DeserializeStage(config))
     pipe.add_stage(SerializeStage(config))
     pipe.add_stage(WriteToFileStage(config, filename=out_file, overwrite=False))


### PR DESCRIPTION
I thought this was a bug #700 so I wrote a test, and confirmed that this wasn't actually a bug, but don't want to waste a good unittest.