### PR TITLE
Create types.hpp 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,7 +202,6 @@ mlruns/*
 # Ignore generated pyi files for pybind and cython modules
 morpheus/_lib/**/*.pyi
 
-# Explicitly ignore .vscode/settings.json and .vscode/launch.json. Shared settings should go in morpheus.code-workspace
-# and user settings will go in .vscode/launch.json and .vscode/settings.json
-.vscode/settings.json
-.vscode/launch.json
+# Explicitly ignore .vscode/. Shared settings should go in morpheus.code-workspace
+# and user settings will go in .vscode/
+.vscode/

--- a/morpheus/_lib/include/morpheus/messages/memory/inference_memory.hpp
+++ b/morpheus/_lib/include/morpheus/messages/memory/inference_memory.hpp
@@ -18,7 +18,7 @@
 #pragma once
 
 #include "morpheus/messages/memory/tensor_memory.hpp"
-#include "morpheus/types.hpp"  // for tensor_map_t
+#include "morpheus/types.hpp"  // for TensorMapType
 
 #include <cstddef>
 #include <string>
@@ -51,7 +51,7 @@ class InferenceMemory : public TensorMemory
      * @param count
      * @param tensors
      */
-    InferenceMemory(size_t count, tensor_map_t&& tensors);
+    InferenceMemory(size_t count, TensorMapType&& tensors);
 
     /**
      * @brief Checks if a tensor named `name` exists in `tensors`

--- a/morpheus/_lib/include/morpheus/messages/memory/inference_memory.hpp
+++ b/morpheus/_lib/include/morpheus/messages/memory/inference_memory.hpp
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "morpheus/messages/memory/tensor_memory.hpp"
+#include "morpheus/types.hpp"  // for tensor_map_t
 
 #include <cstddef>
 #include <string>

--- a/morpheus/_lib/include/morpheus/messages/memory/inference_memory.hpp
+++ b/morpheus/_lib/include/morpheus/messages/memory/inference_memory.hpp
@@ -18,7 +18,7 @@
 #pragma once
 
 #include "morpheus/messages/memory/tensor_memory.hpp"
-#include "morpheus/types.hpp"  // for TensorMapType
+#include "morpheus/types.hpp"  // for TensorMap
 
 #include <cstddef>
 #include <string>
@@ -51,7 +51,7 @@ class InferenceMemory : public TensorMemory
      * @param count
      * @param tensors
      */
-    InferenceMemory(size_t count, TensorMapType&& tensors);
+    InferenceMemory(size_t count, TensorMap&& tensors);
 
     /**
      * @brief Checks if a tensor named `name` exists in `tensors`

--- a/morpheus/_lib/include/morpheus/messages/memory/response_memory.hpp
+++ b/morpheus/_lib/include/morpheus/messages/memory/response_memory.hpp
@@ -19,7 +19,7 @@
 
 #include "morpheus/messages/memory/tensor_memory.hpp"
 #include "morpheus/objects/tensor_object.hpp"  // for TensorObject
-#include "morpheus/types.hpp"                  // for TensorMapType
+#include "morpheus/types.hpp"                  // for TensorMap
 
 #include <pybind11/pytypes.h>
 
@@ -54,7 +54,7 @@ class ResponseMemory : public TensorMemory
      * @param count
      * @param tensors
      */
-    ResponseMemory(size_t count, TensorMapType&& tensors);
+    ResponseMemory(size_t count, TensorMap&& tensors);
 
     /**
      * @brief Checks if a tensor named `name` exists in `tensors`

--- a/morpheus/_lib/include/morpheus/messages/memory/response_memory.hpp
+++ b/morpheus/_lib/include/morpheus/messages/memory/response_memory.hpp
@@ -19,7 +19,7 @@
 
 #include "morpheus/messages/memory/tensor_memory.hpp"
 #include "morpheus/objects/tensor_object.hpp"  // for TensorObject
-#include "morpheus/types.hpp"                  // for tensor_map_t
+#include "morpheus/types.hpp"                  // for TensorMapType
 
 #include <pybind11/pytypes.h>
 
@@ -54,7 +54,7 @@ class ResponseMemory : public TensorMemory
      * @param count
      * @param tensors
      */
-    ResponseMemory(size_t count, tensor_map_t&& tensors);
+    ResponseMemory(size_t count, TensorMapType&& tensors);
 
     /**
      * @brief Checks if a tensor named `name` exists in `tensors`

--- a/morpheus/_lib/include/morpheus/messages/memory/response_memory.hpp
+++ b/morpheus/_lib/include/morpheus/messages/memory/response_memory.hpp
@@ -19,6 +19,7 @@
 
 #include "morpheus/messages/memory/tensor_memory.hpp"
 #include "morpheus/objects/tensor_object.hpp"  // for TensorObject
+#include "morpheus/types.hpp"                  // for tensor_map_t
 
 #include <pybind11/pytypes.h>
 

--- a/morpheus/_lib/include/morpheus/messages/memory/response_memory_probs.hpp
+++ b/morpheus/_lib/include/morpheus/messages/memory/response_memory_probs.hpp
@@ -18,7 +18,6 @@
 #pragma once
 
 #include "morpheus/messages/memory/response_memory.hpp"
-#include "morpheus/messages/memory/tensor_memory.hpp"
 #include "morpheus/objects/tensor_object.hpp"
 #include "morpheus/types.hpp"  // for tensor_map_t
 

--- a/morpheus/_lib/include/morpheus/messages/memory/response_memory_probs.hpp
+++ b/morpheus/_lib/include/morpheus/messages/memory/response_memory_probs.hpp
@@ -19,7 +19,7 @@
 
 #include "morpheus/messages/memory/response_memory.hpp"
 #include "morpheus/objects/tensor_object.hpp"
-#include "morpheus/types.hpp"  // for TensorMapType
+#include "morpheus/types.hpp"  // for TensorMap
 
 #include <cudf/types.hpp>
 #include <pybind11/pytypes.h>
@@ -57,7 +57,7 @@ class ResponseMemoryProbs : public ResponseMemory
      * @param count
      * @param tensors
      */
-    ResponseMemoryProbs(size_t count, TensorMapType&& tensors);
+    ResponseMemoryProbs(size_t count, TensorMap&& tensors);
 
     /**
      * @brief Returns the tensor named 'probs', throws a `std::runtime_error` if it does not exist

--- a/morpheus/_lib/include/morpheus/messages/memory/response_memory_probs.hpp
+++ b/morpheus/_lib/include/morpheus/messages/memory/response_memory_probs.hpp
@@ -20,6 +20,7 @@
 #include "morpheus/messages/memory/response_memory.hpp"
 #include "morpheus/messages/memory/tensor_memory.hpp"
 #include "morpheus/objects/tensor_object.hpp"
+#include "morpheus/types.hpp"  // for tensor_map_t
 
 #include <cudf/types.hpp>
 #include <pybind11/pytypes.h>

--- a/morpheus/_lib/include/morpheus/messages/memory/response_memory_probs.hpp
+++ b/morpheus/_lib/include/morpheus/messages/memory/response_memory_probs.hpp
@@ -19,7 +19,7 @@
 
 #include "morpheus/messages/memory/response_memory.hpp"
 #include "morpheus/objects/tensor_object.hpp"
-#include "morpheus/types.hpp"  // for tensor_map_t
+#include "morpheus/types.hpp"  // for TensorMapType
 
 #include <cudf/types.hpp>
 #include <pybind11/pytypes.h>
@@ -57,7 +57,7 @@ class ResponseMemoryProbs : public ResponseMemory
      * @param count
      * @param tensors
      */
-    ResponseMemoryProbs(size_t count, tensor_map_t&& tensors);
+    ResponseMemoryProbs(size_t count, TensorMapType&& tensors);
 
     /**
      * @brief Returns the tensor named 'probs', throws a `std::runtime_error` if it does not exist

--- a/morpheus/_lib/include/morpheus/messages/memory/tensor_memory.hpp
+++ b/morpheus/_lib/include/morpheus/messages/memory/tensor_memory.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "morpheus/types.hpp"  // for TensorMapType, TensorIndex
+#include "morpheus/types.hpp"  // for TensorMap, TensorIndex
 
 #include <cstddef>  // for size_t
 #include <string>
@@ -55,11 +55,11 @@ class TensorMemory
      * @param count
      * @param tensors
      */
-    TensorMemory(size_t count, TensorMapType&& tensors);
+    TensorMemory(size_t count, TensorMap&& tensors);
     virtual ~TensorMemory() = default;
 
     size_t count{0};
-    TensorMapType tensors;
+    TensorMap tensors;
 
     /**
      * @brief Verify whether the specified tensor name is present in the tensor memory
@@ -75,10 +75,10 @@ class TensorMemory
      *
      * @param ranges
      * @param num_selected_rows
-     * @return TensorMapType
+     * @return TensorMap
      */
-    TensorMapType copy_tensor_ranges(const std::vector<std::pair<TensorIndex, TensorIndex>>& ranges,
-                                     size_t num_selected_rows) const;
+    TensorMap copy_tensor_ranges(const std::vector<std::pair<TensorIndex, TensorIndex>>& ranges,
+                                 size_t num_selected_rows) const;
 };
 
 /** @} */  // end of group

--- a/morpheus/_lib/include/morpheus/messages/memory/tensor_memory.hpp
+++ b/morpheus/_lib/include/morpheus/messages/memory/tensor_memory.hpp
@@ -17,11 +17,9 @@
 
 #pragma once
 
-#include "morpheus/objects/tensor_object.hpp"  // for TensorObject
-#include "morpheus/types.hpp"                  // for tensor_map_t, TensorIndex
+#include "morpheus/types.hpp"  // for tensor_map_t, TensorIndex
 
 #include <cstddef>  // for size_t
-#include <map>
 #include <string>
 #include <utility>  // for pair
 #include <vector>

--- a/morpheus/_lib/include/morpheus/messages/memory/tensor_memory.hpp
+++ b/morpheus/_lib/include/morpheus/messages/memory/tensor_memory.hpp
@@ -17,7 +17,8 @@
 
 #pragma once
 
-#include "morpheus/objects/tensor_object.hpp"  // for TensorIndex, TensorObject
+#include "morpheus/objects/tensor_object.hpp"  // for TensorObject
+#include "morpheus/types.hpp"                  // for tensor_map_t, TensorIndex
 
 #include <cstddef>  // for size_t
 #include <map>
@@ -43,8 +44,6 @@ namespace morpheus {
 class TensorMemory
 {
   public:
-    using tensor_map_t = std::map<std::string, TensorObject>;
-
     /**
      * @brief Construct a new Tensor Memory object
      *

--- a/morpheus/_lib/include/morpheus/messages/memory/tensor_memory.hpp
+++ b/morpheus/_lib/include/morpheus/messages/memory/tensor_memory.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "morpheus/types.hpp"  // for tensor_map_t, TensorIndex
+#include "morpheus/types.hpp"  // for TensorMapType, TensorIndex
 
 #include <cstddef>  // for size_t
 #include <string>
@@ -55,11 +55,11 @@ class TensorMemory
      * @param count
      * @param tensors
      */
-    TensorMemory(size_t count, tensor_map_t&& tensors);
+    TensorMemory(size_t count, TensorMapType&& tensors);
     virtual ~TensorMemory() = default;
 
     size_t count{0};
-    tensor_map_t tensors;
+    TensorMapType tensors;
 
     /**
      * @brief Verify whether the specified tensor name is present in the tensor memory
@@ -75,10 +75,10 @@ class TensorMemory
      *
      * @param ranges
      * @param num_selected_rows
-     * @return tensor_map_t
+     * @return TensorMapType
      */
-    tensor_map_t copy_tensor_ranges(const std::vector<std::pair<TensorIndex, TensorIndex>>& ranges,
-                                    size_t num_selected_rows) const;
+    TensorMapType copy_tensor_ranges(const std::vector<std::pair<TensorIndex, TensorIndex>>& ranges,
+                                     size_t num_selected_rows) const;
 };
 
 /** @} */  // end of group

--- a/morpheus/_lib/include/morpheus/messages/multi.hpp
+++ b/morpheus/_lib/include/morpheus/messages/multi.hpp
@@ -20,6 +20,7 @@
 #include "morpheus/messages/meta.hpp"
 #include "morpheus/objects/table_info.hpp"
 #include "morpheus/objects/tensor_object.hpp"
+#include "morpheus/types.hpp"  // for TensorIndex
 
 #include <cudf/types.hpp>
 #include <glog/logging.h>  // for DCHECK_NOTNULL

--- a/morpheus/_lib/include/morpheus/objects/rmm_tensor.hpp
+++ b/morpheus/_lib/include/morpheus/objects/rmm_tensor.hpp
@@ -19,7 +19,7 @@
 
 #include "morpheus/objects/dtype.hpp"  // for DType
 #include "morpheus/objects/tensor_object.hpp"
-#include "morpheus/types.hpp"  // for RankType, shape_type_t, TensorIndex
+#include "morpheus/types.hpp"  // for RankType, ShapeType, TensorIndex
 
 #include <rmm/device_buffer.hpp>
 
@@ -48,8 +48,8 @@ class RMMTensor : public ITensor
     RMMTensor(std::shared_ptr<rmm::device_buffer> device_buffer,
               size_t offset,
               DType dtype,
-              shape_type_t shape,
-              shape_type_t stride = {});
+              ShapeType shape,
+              ShapeType stride = {});
 
     ~RMMTensor() override = default;
 
@@ -76,12 +76,12 @@ class RMMTensor : public ITensor
     /**
      * TODO(Documentation)
      */
-    std::shared_ptr<ITensor> reshape(const shape_type_t& dims) const override;
+    std::shared_ptr<ITensor> reshape(const ShapeType& dims) const override;
 
     /**
      * TODO(Documentation)
      */
-    std::shared_ptr<ITensor> slice(const shape_type_t& min_dims, const shape_type_t& max_dims) const override;
+    std::shared_ptr<ITensor> slice(const ShapeType& min_dims, const ShapeType& max_dims) const override;
 
     /**
      * @brief Creates a depp copy of the specified rows specified as vector<pair<start, stop>> not inclusive
@@ -127,12 +127,12 @@ class RMMTensor : public ITensor
     /**
      * TODO(Documentation)
      */
-    void get_shape(shape_type_t& s) const;
+    void get_shape(ShapeType& s) const;
 
     /**
      * TODO(Documentation)
      */
-    void get_stride(shape_type_t& s) const;
+    void get_stride(ShapeType& s) const;
 
     // Tensor reshape(std::vector<TensorIndex> shape)
     // {
@@ -162,8 +162,8 @@ class RMMTensor : public ITensor
     DType m_dtype;
 
     // Shape info
-    shape_type_t m_shape;
-    shape_type_t m_stride;
+    ShapeType m_shape;
+    ShapeType m_stride;
 };
 
 #pragma GCC visibility pop

--- a/morpheus/_lib/include/morpheus/objects/rmm_tensor.hpp
+++ b/morpheus/_lib/include/morpheus/objects/rmm_tensor.hpp
@@ -19,6 +19,7 @@
 
 #include "morpheus/objects/dtype.hpp"  // for DType
 #include "morpheus/objects/tensor_object.hpp"
+#include "morpheus/types.hpp"  // for RankType, shape_type_t, TensorIndex
 
 #include <rmm/device_buffer.hpp>
 
@@ -47,8 +48,8 @@ class RMMTensor : public ITensor
     RMMTensor(std::shared_ptr<rmm::device_buffer> device_buffer,
               size_t offset,
               DType dtype,
-              std::vector<TensorIndex> shape,
-              std::vector<TensorIndex> stride = {});
+              shape_type_t shape,
+              shape_type_t stride = {});
 
     ~RMMTensor() override = default;
 
@@ -75,13 +76,12 @@ class RMMTensor : public ITensor
     /**
      * TODO(Documentation)
      */
-    std::shared_ptr<ITensor> reshape(const std::vector<TensorIndex>& dims) const override;
+    std::shared_ptr<ITensor> reshape(const shape_type_t& dims) const override;
 
     /**
      * TODO(Documentation)
      */
-    std::shared_ptr<ITensor> slice(const std::vector<TensorIndex>& min_dims,
-                                   const std::vector<TensorIndex>& max_dims) const override;
+    std::shared_ptr<ITensor> slice(const shape_type_t& min_dims, const shape_type_t& max_dims) const override;
 
     /**
      * @brief Creates a depp copy of the specified rows specified as vector<pair<start, stop>> not inclusive
@@ -127,12 +127,12 @@ class RMMTensor : public ITensor
     /**
      * TODO(Documentation)
      */
-    void get_shape(std::vector<TensorIndex>& s) const;
+    void get_shape(shape_type_t& s) const;
 
     /**
      * TODO(Documentation)
      */
-    void get_stride(std::vector<TensorIndex>& s) const;
+    void get_stride(shape_type_t& s) const;
 
     // Tensor reshape(std::vector<TensorIndex> shape)
     // {
@@ -162,8 +162,8 @@ class RMMTensor : public ITensor
     DType m_dtype;
 
     // Shape info
-    std::vector<TensorIndex> m_shape;
-    std::vector<TensorIndex> m_stride;
+    shape_type_t m_shape;
+    shape_type_t m_stride;
 };
 
 #pragma GCC visibility pop

--- a/morpheus/_lib/include/morpheus/objects/tensor.hpp
+++ b/morpheus/_lib/include/morpheus/objects/tensor.hpp
@@ -19,6 +19,7 @@
 
 #include "morpheus/objects/dtype.hpp"
 #include "morpheus/objects/tensor_object.hpp"
+#include "morpheus/types.hpp"  // for shape_type_t, TensorIndex
 
 #include <rmm/device_buffer.hpp>
 
@@ -83,8 +84,8 @@ class Tensor
      */
     static TensorObject create(std::shared_ptr<rmm::device_buffer> buffer,
                                DType dtype,
-                               std::vector<TensorIndex> shape,
-                               std::vector<TensorIndex> strides,
+                               shape_type_t shape,
+                               shape_type_t strides,
                                size_t offset = 0);
 
   private:

--- a/morpheus/_lib/include/morpheus/objects/tensor.hpp
+++ b/morpheus/_lib/include/morpheus/objects/tensor.hpp
@@ -19,7 +19,7 @@
 
 #include "morpheus/objects/dtype.hpp"
 #include "morpheus/objects/tensor_object.hpp"
-#include "morpheus/types.hpp"  // for shape_type_t, TensorIndex
+#include "morpheus/types.hpp"  // for ShapeType, TensorIndex
 
 #include <rmm/device_buffer.hpp>
 
@@ -82,11 +82,8 @@ class Tensor
     /**
      * TODO(Documentation)
      */
-    static TensorObject create(std::shared_ptr<rmm::device_buffer> buffer,
-                               DType dtype,
-                               shape_type_t shape,
-                               shape_type_t strides,
-                               size_t offset = 0);
+    static TensorObject create(
+        std::shared_ptr<rmm::device_buffer> buffer, DType dtype, ShapeType shape, ShapeType strides, size_t offset = 0);
 
   private:
     size_t m_offset;

--- a/morpheus/_lib/include/morpheus/objects/tensor_object.hpp
+++ b/morpheus/_lib/include/morpheus/objects/tensor_object.hpp
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "morpheus/objects/dtype.hpp"
+#include "morpheus/types.hpp"  // for RankType, shape_type_t, TensorIndex
 #include "morpheus/utilities/string_util.hpp"
 
 #include <cuda_runtime.h>  // for cudaMemcpyDeviceToHost & cudaMemcpy
@@ -49,9 +50,6 @@ namespace morpheus {
  * @{
  * @file
  */
-
-using TensorIndex = long long;  // NOLINT
-using RankType    = int;        // NOLINT
 
 namespace detail {
 
@@ -139,10 +137,9 @@ struct ITensor;
 
 struct ITensorOperations
 {
-    virtual std::shared_ptr<ITensor> slice(const std::vector<TensorIndex>& min_dims,
-                                           const std::vector<TensorIndex>& max_dims) const = 0;
+    virtual std::shared_ptr<ITensor> slice(const shape_type_t& min_dims, const shape_type_t& max_dims) const = 0;
 
-    virtual std::shared_ptr<ITensor> reshape(const std::vector<TensorIndex>& dims) const = 0;
+    virtual std::shared_ptr<ITensor> reshape(const shape_type_t& dims) const = 0;
 
     virtual std::shared_ptr<ITensor> deep_copy() const = 0;
 
@@ -265,7 +262,7 @@ struct TensorObject final
         return m_tensor->is_compact();
     }
 
-    TensorObject slice(std::vector<TensorIndex> min_dims, std::vector<TensorIndex> max_dims) const
+    TensorObject slice(shape_type_t min_dims, shape_type_t max_dims) const
     {
         // Replace any -1 values
         std::replace_if(
@@ -278,7 +275,7 @@ struct TensorObject final
         return {m_md, m_tensor->slice(min_dims, max_dims)};
     }
 
-    TensorObject reshape(const std::vector<TensorIndex>& dims) const
+    TensorObject reshape(const shape_type_t& dims) const
     {
         return {m_md, m_tensor->reshape(dims)};
     }

--- a/morpheus/_lib/include/morpheus/objects/tensor_object.hpp
+++ b/morpheus/_lib/include/morpheus/objects/tensor_object.hpp
@@ -18,7 +18,7 @@
 #pragma once
 
 #include "morpheus/objects/dtype.hpp"
-#include "morpheus/types.hpp"  // for RankType, shape_type_t, TensorIndex
+#include "morpheus/types.hpp"  // for RankType, ShapeType, TensorIndex
 #include "morpheus/utilities/string_util.hpp"
 
 #include <cuda_runtime.h>  // for cudaMemcpyDeviceToHost & cudaMemcpy
@@ -137,9 +137,9 @@ struct ITensor;
 
 struct ITensorOperations
 {
-    virtual std::shared_ptr<ITensor> slice(const shape_type_t& min_dims, const shape_type_t& max_dims) const = 0;
+    virtual std::shared_ptr<ITensor> slice(const ShapeType& min_dims, const ShapeType& max_dims) const = 0;
 
-    virtual std::shared_ptr<ITensor> reshape(const shape_type_t& dims) const = 0;
+    virtual std::shared_ptr<ITensor> reshape(const ShapeType& dims) const = 0;
 
     virtual std::shared_ptr<ITensor> deep_copy() const = 0;
 
@@ -262,7 +262,7 @@ struct TensorObject final
         return m_tensor->is_compact();
     }
 
-    TensorObject slice(shape_type_t min_dims, shape_type_t max_dims) const
+    TensorObject slice(ShapeType min_dims, ShapeType max_dims) const
     {
         // Replace any -1 values
         std::replace_if(
@@ -275,7 +275,7 @@ struct TensorObject final
         return {m_md, m_tensor->slice(min_dims, max_dims)};
     }
 
-    TensorObject reshape(const shape_type_t& dims) const
+    TensorObject reshape(const ShapeType& dims) const
     {
         return {m_md, m_tensor->reshape(dims)};
     }

--- a/morpheus/_lib/include/morpheus/types.hpp
+++ b/morpheus/_lib/include/morpheus/types.hpp
@@ -1,0 +1,40 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace morpheus {
+
+struct TensorObject;
+
+/**
+ * @addtogroup objects
+ * @{
+ * @file
+ */
+using TensorIndex = long long;  // NOLINT
+using RankType    = int;        // NOLINT
+
+using shape_type_t = std::vector<TensorIndex>;
+using tensor_map_t = std::map<std::string, TensorObject>;
+
+/** @} */  // end of group
+}  // namespace morpheus

--- a/morpheus/_lib/include/morpheus/types.hpp
+++ b/morpheus/_lib/include/morpheus/types.hpp
@@ -34,8 +34,8 @@ struct TensorObject;
 using TensorIndex = long long;
 using RankType    = int;
 
-using ShapeType     = std::vector<TensorIndex>;
-using TensorMapType = std::map<std::string, TensorObject>;
+using ShapeType = std::vector<TensorIndex>;
+using TensorMap = std::map<std::string, TensorObject>;
 // NOLINTEND(readability-identifier-naming)
 
 /** @} */  // end of group

--- a/morpheus/_lib/include/morpheus/types.hpp
+++ b/morpheus/_lib/include/morpheus/types.hpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,11 +30,13 @@ struct TensorObject;
  * @{
  * @file
  */
-using TensorIndex = long long;  // NOLINT
-using RankType    = int;        // NOLINT
+// NOLINTBEGIN(readability-identifier-naming)
+using TensorIndex = long long;
+using RankType    = int;
 
-using shape_type_t = std::vector<TensorIndex>;
-using tensor_map_t = std::map<std::string, TensorObject>;
+using ShapeType     = std::vector<TensorIndex>;
+using TensorMapType = std::map<std::string, TensorObject>;
+// NOLINTEND(readability-identifier-naming)
 
 /** @} */  // end of group
 }  // namespace morpheus

--- a/morpheus/_lib/include/morpheus/utilities/tensor_util.hpp
+++ b/morpheus/_lib/include/morpheus/utilities/tensor_util.hpp
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "morpheus/objects/tensor_object.hpp"
+#include "morpheus/types.hpp"  // for shape_type_t, TensorIndex
 
 #include <algorithm>   // IWYU pragma: keep
 #include <functional>  // for multiplies
@@ -43,8 +44,6 @@ namespace morpheus {
  */
 struct TensorUtils
 {
-    using shape_type_t = std::vector<TensorIndex>;
-
     /**
      * @brief Write a formatted shape to a stream
      *
@@ -67,7 +66,7 @@ struct TensorUtils
      * @param shape
      * @param stride
      */
-    static void set_contiguous_stride(const std::vector<TensorIndex>& shape, std::vector<TensorIndex>& stride);
+    static void set_contiguous_stride(const shape_type_t& shape, shape_type_t& stride);
 
     /**
      * @brief Determines if the tensor layout is both contiguous and ordered.
@@ -75,7 +74,7 @@ struct TensorUtils
      * @note A tensor whose values are laid out in the storage starting from the rightmost
      * dimension onward (that is, moving along rows for a 2D tensor) is defined as contiguous.
      */
-    static bool has_contiguous_stride(const std::vector<TensorIndex>& shape, const shape_type_t& stride);
+    static bool has_contiguous_stride(const shape_type_t& shape, const shape_type_t& stride);
 
     /**
      * @brief Validate the shape and stride are compatible
@@ -85,8 +84,7 @@ struct TensorUtils
      * @return true
      * @return false
      */
-    static bool validate_shape_and_stride(const std::vector<TensorIndex>& shape,
-                                          const std::vector<TensorIndex>& stride);
+    static bool validate_shape_and_stride(const shape_type_t& shape, const shape_type_t& stride);
 
     /**
      * @brief Returns a stride expressed in terms of elements given a stride expressed either in terms of bytes or

--- a/morpheus/_lib/include/morpheus/utilities/tensor_util.hpp
+++ b/morpheus/_lib/include/morpheus/utilities/tensor_util.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "morpheus/types.hpp"  // for shape_type_t, TensorIndex
+#include "morpheus/types.hpp"  // for ShapeType, TensorIndex
 
 #include <algorithm>   // IWYU pragma: keep
 #include <functional>  // for multiplies
@@ -49,7 +49,7 @@ struct TensorUtils
      * @param shape
      * @param os
      */
-    static void write_shape_to_stream(const shape_type_t& shape, std::ostream& os);
+    static void write_shape_to_stream(const ShapeType& shape, std::ostream& os);
 
     /**
      * @brief Convenience method to get a string from write_shape_to_stream
@@ -57,7 +57,7 @@ struct TensorUtils
      * @param shape
      * @return std::string
      */
-    static std::string shape_to_string(const shape_type_t& shape);
+    static std::string shape_to_string(const ShapeType& shape);
 
     /**
      * @brief Set stride to be contiguous with respect to row-major layouts
@@ -65,7 +65,7 @@ struct TensorUtils
      * @param shape
      * @param stride
      */
-    static void set_contiguous_stride(const shape_type_t& shape, shape_type_t& stride);
+    static void set_contiguous_stride(const ShapeType& shape, ShapeType& stride);
 
     /**
      * @brief Determines if the tensor layout is both contiguous and ordered.
@@ -73,7 +73,7 @@ struct TensorUtils
      * @note A tensor whose values are laid out in the storage starting from the rightmost
      * dimension onward (that is, moving along rows for a 2D tensor) is defined as contiguous.
      */
-    static bool has_contiguous_stride(const shape_type_t& shape, const shape_type_t& stride);
+    static bool has_contiguous_stride(const ShapeType& shape, const ShapeType& stride);
 
     /**
      * @brief Validate the shape and stride are compatible
@@ -83,14 +83,14 @@ struct TensorUtils
      * @return true
      * @return false
      */
-    static bool validate_shape_and_stride(const shape_type_t& shape, const shape_type_t& stride);
+    static bool validate_shape_and_stride(const ShapeType& shape, const ShapeType& stride);
 
     /**
      * @brief Returns a stride expressed in terms of elements given a stride expressed either in terms of bytes or
      * elements.
      *
      * @param stride
-     * @return shape_type_t
+     * @return ShapeType
      */
     template <typename IndexT, typename SrcIndexT = IndexT>
     static std::vector<IndexT> get_element_stride(const std::vector<SrcIndexT>& stride)

--- a/morpheus/_lib/include/morpheus/utilities/tensor_util.hpp
+++ b/morpheus/_lib/include/morpheus/utilities/tensor_util.hpp
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include "morpheus/objects/tensor_object.hpp"
 #include "morpheus/types.hpp"  // for shape_type_t, TensorIndex
 
 #include <algorithm>   // IWYU pragma: keep

--- a/morpheus/_lib/src/messages/memory/inference_memory.cpp
+++ b/morpheus/_lib/src/messages/memory/inference_memory.cpp
@@ -17,6 +17,9 @@
 
 #include "morpheus/messages/memory/inference_memory.hpp"
 
+// for TensorObject
+#include "morpheus/objects/tensor_object.hpp"  // IWYU pragma: keep
+
 #include <string>
 #include <utility>  // for move
 

--- a/morpheus/_lib/src/messages/memory/inference_memory.cpp
+++ b/morpheus/_lib/src/messages/memory/inference_memory.cpp
@@ -27,7 +27,7 @@ namespace morpheus {
 /****** Component public implementations *******************/
 /****** InferenceMemory****************************************/
 InferenceMemory::InferenceMemory(size_t count) : TensorMemory(count) {}
-InferenceMemory::InferenceMemory(size_t count, TensorMapType&& tensors) : TensorMemory(count, std::move(tensors)) {}
+InferenceMemory::InferenceMemory(size_t count, TensorMap&& tensors) : TensorMemory(count, std::move(tensors)) {}
 
 bool InferenceMemory::has_input(const std::string& name) const
 {

--- a/morpheus/_lib/src/messages/memory/inference_memory.cpp
+++ b/morpheus/_lib/src/messages/memory/inference_memory.cpp
@@ -27,7 +27,7 @@ namespace morpheus {
 /****** Component public implementations *******************/
 /****** InferenceMemory****************************************/
 InferenceMemory::InferenceMemory(size_t count) : TensorMemory(count) {}
-InferenceMemory::InferenceMemory(size_t count, tensor_map_t&& tensors) : TensorMemory(count, std::move(tensors)) {}
+InferenceMemory::InferenceMemory(size_t count, TensorMapType&& tensors) : TensorMemory(count, std::move(tensors)) {}
 
 bool InferenceMemory::has_input(const std::string& name) const
 {

--- a/morpheus/_lib/src/messages/memory/inference_memory_fil.cpp
+++ b/morpheus/_lib/src/messages/memory/inference_memory_fil.cpp
@@ -18,7 +18,7 @@
 #include "morpheus/messages/memory/inference_memory_fil.hpp"
 
 #include "morpheus/messages/memory/inference_memory.hpp"
-#include "morpheus/types.hpp"  // for tensor_map_t
+#include "morpheus/types.hpp"  // for TensorMapType
 #include "morpheus/utilities/cupy_util.hpp"
 
 #include <cudf/types.hpp>

--- a/morpheus/_lib/src/messages/memory/inference_memory_fil.cpp
+++ b/morpheus/_lib/src/messages/memory/inference_memory_fil.cpp
@@ -18,7 +18,7 @@
 #include "morpheus/messages/memory/inference_memory_fil.hpp"
 
 #include "morpheus/messages/memory/inference_memory.hpp"
-#include "morpheus/types.hpp"  // for TensorMapType
+#include "morpheus/types.hpp"  // for TensorMap
 #include "morpheus/utilities/cupy_util.hpp"
 
 #include <cudf/types.hpp>

--- a/morpheus/_lib/src/messages/memory/inference_memory_fil.cpp
+++ b/morpheus/_lib/src/messages/memory/inference_memory_fil.cpp
@@ -18,7 +18,7 @@
 #include "morpheus/messages/memory/inference_memory_fil.hpp"
 
 #include "morpheus/messages/memory/inference_memory.hpp"
-#include "morpheus/messages/memory/tensor_memory.hpp"
+#include "morpheus/types.hpp"  // for tensor_map_t
 #include "morpheus/utilities/cupy_util.hpp"
 
 #include <cudf/types.hpp>

--- a/morpheus/_lib/src/messages/memory/inference_memory_nlp.cpp
+++ b/morpheus/_lib/src/messages/memory/inference_memory_nlp.cpp
@@ -18,7 +18,7 @@
 #include "morpheus/messages/memory/inference_memory_nlp.hpp"
 
 #include "morpheus/messages/memory/inference_memory.hpp"
-#include "morpheus/messages/memory/tensor_memory.hpp"
+#include "morpheus/types.hpp"  // for tensor_map_t
 #include "morpheus/utilities/cupy_util.hpp"
 
 #include <cudf/types.hpp>  // for size_type

--- a/morpheus/_lib/src/messages/memory/inference_memory_nlp.cpp
+++ b/morpheus/_lib/src/messages/memory/inference_memory_nlp.cpp
@@ -18,7 +18,7 @@
 #include "morpheus/messages/memory/inference_memory_nlp.hpp"
 
 #include "morpheus/messages/memory/inference_memory.hpp"
-#include "morpheus/types.hpp"  // for TensorMapType
+#include "morpheus/types.hpp"  // for TensorMap
 #include "morpheus/utilities/cupy_util.hpp"
 
 #include <cudf/types.hpp>  // for size_type

--- a/morpheus/_lib/src/messages/memory/inference_memory_nlp.cpp
+++ b/morpheus/_lib/src/messages/memory/inference_memory_nlp.cpp
@@ -18,7 +18,7 @@
 #include "morpheus/messages/memory/inference_memory_nlp.hpp"
 
 #include "morpheus/messages/memory/inference_memory.hpp"
-#include "morpheus/types.hpp"  // for tensor_map_t
+#include "morpheus/types.hpp"  // for TensorMapType
 #include "morpheus/utilities/cupy_util.hpp"
 
 #include <cudf/types.hpp>  // for size_type

--- a/morpheus/_lib/src/messages/memory/response_memory.cpp
+++ b/morpheus/_lib/src/messages/memory/response_memory.cpp
@@ -28,7 +28,7 @@ namespace morpheus {
 /****** Component public implementations *******************/
 /****** ResponseMemory****************************************/
 ResponseMemory::ResponseMemory(size_t count) : TensorMemory(count) {}
-ResponseMemory::ResponseMemory(size_t count, tensor_map_t&& tensors) : TensorMemory(count, std::move(tensors)) {}
+ResponseMemory::ResponseMemory(size_t count, TensorMapType&& tensors) : TensorMemory(count, std::move(tensors)) {}
 
 bool ResponseMemory::has_output(const std::string& name) const
 {

--- a/morpheus/_lib/src/messages/memory/response_memory.cpp
+++ b/morpheus/_lib/src/messages/memory/response_memory.cpp
@@ -28,7 +28,7 @@ namespace morpheus {
 /****** Component public implementations *******************/
 /****** ResponseMemory****************************************/
 ResponseMemory::ResponseMemory(size_t count) : TensorMemory(count) {}
-ResponseMemory::ResponseMemory(size_t count, TensorMapType&& tensors) : TensorMemory(count, std::move(tensors)) {}
+ResponseMemory::ResponseMemory(size_t count, TensorMap&& tensors) : TensorMemory(count, std::move(tensors)) {}
 
 bool ResponseMemory::has_output(const std::string& name) const
 {

--- a/morpheus/_lib/src/messages/memory/response_memory_probs.cpp
+++ b/morpheus/_lib/src/messages/memory/response_memory_probs.cpp
@@ -38,7 +38,7 @@ ResponseMemoryProbs::ResponseMemoryProbs(size_t count, TensorObject probs) : Res
     this->tensors["probs"] = std::move(probs);
 }
 
-ResponseMemoryProbs::ResponseMemoryProbs(size_t count, tensor_map_t&& tensors) :
+ResponseMemoryProbs::ResponseMemoryProbs(size_t count, TensorMapType&& tensors) :
   ResponseMemory(count, std::move(tensors))
 {
     CHECK(has_tensor("probs")) << "Tensor: 'probs' not found in memory";

--- a/morpheus/_lib/src/messages/memory/response_memory_probs.cpp
+++ b/morpheus/_lib/src/messages/memory/response_memory_probs.cpp
@@ -38,8 +38,7 @@ ResponseMemoryProbs::ResponseMemoryProbs(size_t count, TensorObject probs) : Res
     this->tensors["probs"] = std::move(probs);
 }
 
-ResponseMemoryProbs::ResponseMemoryProbs(size_t count, TensorMapType&& tensors) :
-  ResponseMemory(count, std::move(tensors))
+ResponseMemoryProbs::ResponseMemoryProbs(size_t count, TensorMap&& tensors) : ResponseMemory(count, std::move(tensors))
 {
     CHECK(has_tensor("probs")) << "Tensor: 'probs' not found in memory";
 }

--- a/morpheus/_lib/src/messages/memory/tensor_memory.cpp
+++ b/morpheus/_lib/src/messages/memory/tensor_memory.cpp
@@ -27,17 +27,17 @@ namespace morpheus {
 /****** Component public implementations *******************/
 /****** TensorMemory****************************************/
 TensorMemory::TensorMemory(size_t count) : count(count) {}
-TensorMemory::TensorMemory(size_t count, TensorMapType&& tensors) : count(count), tensors(std::move(tensors)) {}
+TensorMemory::TensorMemory(size_t count, TensorMap&& tensors) : count(count), tensors(std::move(tensors)) {}
 
 bool TensorMemory::has_tensor(const std::string& name) const
 {
     return this->tensors.find(name) != this->tensors.end();
 }
 
-TensorMapType TensorMemory::copy_tensor_ranges(const std::vector<std::pair<TensorIndex, TensorIndex>>& ranges,
-                                               size_t num_selected_rows) const
+TensorMap TensorMemory::copy_tensor_ranges(const std::vector<std::pair<TensorIndex, TensorIndex>>& ranges,
+                                           size_t num_selected_rows) const
 {
-    TensorMapType tensors;
+    TensorMap tensors;
     for (const auto& p : this->tensors)
     {
         tensors.insert(std::pair{p.first, p.second.copy_rows(ranges, num_selected_rows)});

--- a/morpheus/_lib/src/messages/memory/tensor_memory.cpp
+++ b/morpheus/_lib/src/messages/memory/tensor_memory.cpp
@@ -17,6 +17,9 @@
 
 #include "morpheus/messages/memory/tensor_memory.hpp"
 
+#include "morpheus/objects/tensor_object.hpp"  // for TensorObject
+
+#include <map>
 #include <string>
 #include <vector>
 

--- a/morpheus/_lib/src/messages/memory/tensor_memory.cpp
+++ b/morpheus/_lib/src/messages/memory/tensor_memory.cpp
@@ -27,17 +27,17 @@ namespace morpheus {
 /****** Component public implementations *******************/
 /****** TensorMemory****************************************/
 TensorMemory::TensorMemory(size_t count) : count(count) {}
-TensorMemory::TensorMemory(size_t count, tensor_map_t&& tensors) : count(count), tensors(std::move(tensors)) {}
+TensorMemory::TensorMemory(size_t count, TensorMapType&& tensors) : count(count), tensors(std::move(tensors)) {}
 
 bool TensorMemory::has_tensor(const std::string& name) const
 {
     return this->tensors.find(name) != this->tensors.end();
 }
 
-tensor_map_t TensorMemory::copy_tensor_ranges(const std::vector<std::pair<TensorIndex, TensorIndex>>& ranges,
-                                              size_t num_selected_rows) const
+TensorMapType TensorMemory::copy_tensor_ranges(const std::vector<std::pair<TensorIndex, TensorIndex>>& ranges,
+                                               size_t num_selected_rows) const
 {
-    tensor_map_t tensors;
+    TensorMapType tensors;
     for (const auto& p : this->tensors)
     {
         tensors.insert(std::pair{p.first, p.second.copy_rows(ranges, num_selected_rows)});

--- a/morpheus/_lib/src/messages/memory/tensor_memory.cpp
+++ b/morpheus/_lib/src/messages/memory/tensor_memory.cpp
@@ -31,8 +31,8 @@ bool TensorMemory::has_tensor(const std::string& name) const
     return this->tensors.find(name) != this->tensors.end();
 }
 
-TensorMemory::tensor_map_t TensorMemory::copy_tensor_ranges(
-    const std::vector<std::pair<TensorIndex, TensorIndex>>& ranges, size_t num_selected_rows) const
+tensor_map_t TensorMemory::copy_tensor_ranges(const std::vector<std::pair<TensorIndex, TensorIndex>>& ranges,
+                                              size_t num_selected_rows) const
 {
     tensor_map_t tensors;
     for (const auto& p : this->tensors)

--- a/morpheus/_lib/src/messages/multi_tensor.cpp
+++ b/morpheus/_lib/src/messages/multi_tensor.cpp
@@ -17,7 +17,7 @@
 
 #include "morpheus/messages/multi_tensor.hpp"
 
-#include "morpheus/types.hpp"  // for TensorIndex, TensorMapType
+#include "morpheus/types.hpp"  // for TensorIndex, TensorMap
 
 #include <cudf/types.hpp>  // for cudf::size_type>
 #include <glog/logging.h>

--- a/morpheus/_lib/src/messages/multi_tensor.cpp
+++ b/morpheus/_lib/src/messages/multi_tensor.cpp
@@ -17,6 +17,8 @@
 
 #include "morpheus/messages/multi_tensor.hpp"
 
+#include "morpheus/types.hpp"  // for TensorIndex, tensor_map_t
+
 #include <cudf/types.hpp>  // for cudf::size_type>
 #include <glog/logging.h>
 

--- a/morpheus/_lib/src/messages/multi_tensor.cpp
+++ b/morpheus/_lib/src/messages/multi_tensor.cpp
@@ -17,7 +17,7 @@
 
 #include "morpheus/messages/multi_tensor.hpp"
 
-#include "morpheus/types.hpp"  // for TensorIndex, tensor_map_t
+#include "morpheus/types.hpp"  // for TensorIndex, TensorMapType
 
 #include <cudf/types.hpp>  // for cudf::size_type>
 #include <glog/logging.h>

--- a/morpheus/_lib/src/stages/add_classification.cpp
+++ b/morpheus/_lib/src/stages/add_classification.cpp
@@ -20,7 +20,8 @@
 #include "morpheus/objects/dev_mem_info.hpp"  // for DevMemInfo
 #include "morpheus/objects/dtype.hpp"         // for DType
 #include "morpheus/objects/tensor.hpp"
-#include "morpheus/objects/tensor_object.hpp"  // for TensorIndex, TensorObject
+#include "morpheus/objects/tensor_object.hpp"  // for TensorObject
+#include "morpheus/types.hpp"                  // for TensorIndex
 #include "morpheus/utilities/matx_util.hpp"
 #include "morpheus/utilities/tensor_util.hpp"  // for TensorUtils::get_element_stride
 

--- a/morpheus/_lib/src/stages/add_scores.cpp
+++ b/morpheus/_lib/src/stages/add_scores.cpp
@@ -17,7 +17,8 @@
 
 #include "morpheus/stages/add_scores.hpp"
 
-#include "morpheus/objects/tensor_object.hpp"  // for TensorIndex, TensorObject
+#include "morpheus/objects/tensor_object.hpp"  // for TensorObject
+#include "morpheus/types.hpp"                  // for TensorIndex
 
 #include <glog/logging.h>
 

--- a/morpheus/_lib/src/stages/preprocess_fil.cpp
+++ b/morpheus/_lib/src/stages/preprocess_fil.cpp
@@ -23,7 +23,7 @@
 #include "morpheus/objects/dtype.hpp"
 #include "morpheus/objects/table_info.hpp"  // for TableInfo
 #include "morpheus/objects/tensor.hpp"
-#include "morpheus/objects/tensor_object.hpp"  // for TensorIndex
+#include "morpheus/types.hpp"  // for TensorIndex
 #include "morpheus/utilities/matx_util.hpp"
 
 #include <cuda_runtime.h>               // for cudaMemcpy, cudaMemcpyDeviceToDevice

--- a/morpheus/_lib/src/stages/preprocess_nlp.cpp
+++ b/morpheus/_lib/src/stages/preprocess_nlp.cpp
@@ -23,7 +23,7 @@
 #include "morpheus/objects/table_info.hpp"  // for TableInfo
 #include "morpheus/objects/tensor.hpp"
 #include "morpheus/objects/tensor_object.hpp"  // for TensorObject
-#include "morpheus/types.hpp"                  // for TensorIndex, tensor_map_t
+#include "morpheus/types.hpp"                  // for TensorIndex, TensorMapType
 
 #include <cudf/column/column.hpp>                // for column, column::contents
 #include <cudf/strings/strings_column_view.hpp>  // for strings_column_view

--- a/morpheus/_lib/src/stages/preprocess_nlp.cpp
+++ b/morpheus/_lib/src/stages/preprocess_nlp.cpp
@@ -23,7 +23,7 @@
 #include "morpheus/objects/table_info.hpp"  // for TableInfo
 #include "morpheus/objects/tensor.hpp"
 #include "morpheus/objects/tensor_object.hpp"  // for TensorObject
-#include "morpheus/types.hpp"                  // for TensorIndex, TensorMapType
+#include "morpheus/types.hpp"                  // for TensorIndex, TensorMap
 
 #include <cudf/column/column.hpp>                // for column, column::contents
 #include <cudf/strings/strings_column_view.hpp>  // for strings_column_view

--- a/morpheus/_lib/src/stages/preprocess_nlp.cpp
+++ b/morpheus/_lib/src/stages/preprocess_nlp.cpp
@@ -18,12 +18,12 @@
 #include "morpheus/stages/preprocess_nlp.hpp"
 
 #include "morpheus/messages/memory/inference_memory.hpp"  // for InferenceMemory
-#include "morpheus/messages/memory/tensor_memory.hpp"     // for tensor_map_t
 #include "morpheus/messages/multi_inference.hpp"
 #include "morpheus/objects/dtype.hpp"
 #include "morpheus/objects/table_info.hpp"  // for TableInfo
 #include "morpheus/objects/tensor.hpp"
-#include "morpheus/objects/tensor_object.hpp"  // for TensorIndex, TensorObject
+#include "morpheus/objects/tensor_object.hpp"  // for TensorObject
+#include "morpheus/types.hpp"                  // for TensorIndex, tensor_map_t
 
 #include <cudf/column/column.hpp>                // for column, column::contents
 #include <cudf/strings/strings_column_view.hpp>  // for strings_column_view

--- a/morpheus/_lib/src/stages/preprocess_nlp.cpp
+++ b/morpheus/_lib/src/stages/preprocess_nlp.cpp
@@ -18,7 +18,7 @@
 #include "morpheus/stages/preprocess_nlp.hpp"
 
 #include "morpheus/messages/memory/inference_memory.hpp"  // for InferenceMemory
-#include "morpheus/messages/memory/tensor_memory.hpp"     // for TensorMemory::tensor_map_t
+#include "morpheus/messages/memory/tensor_memory.hpp"     // for tensor_map_t
 #include "morpheus/messages/multi_inference.hpp"
 #include "morpheus/objects/dtype.hpp"
 #include "morpheus/objects/table_info.hpp"  // for TableInfo

--- a/morpheus/_lib/src/stages/triton_inference.cpp
+++ b/morpheus/_lib/src/stages/triton_inference.cpp
@@ -26,9 +26,9 @@
 #include "morpheus/objects/tensor.hpp"
 #include "morpheus/objects/tensor_object.hpp"  // for TensorObject
 #include "morpheus/objects/triton_in_out.hpp"
-#include "morpheus/types.hpp"                // for TensorIndex, TensorMapType
-#include "morpheus/utilities/matx_util.hpp"  // for MatxUtil::logits, MatxUtil::reduce_max
-#include "morpheus/utilities/stage_util.hpp"  // for foreach_map
+#include "morpheus/types.hpp"                  // for TensorIndex, TensorMap
+#include "morpheus/utilities/matx_util.hpp"    // for MatxUtil::logits, MatxUtil::reduce_max
+#include "morpheus/utilities/stage_util.hpp"   // for foreach_map
 #include "morpheus/utilities/string_util.hpp"  // for MORPHEUS_CONCAT_STR
 #include "morpheus/utilities/tensor_util.hpp"  // for get_elem_count
 
@@ -79,7 +79,7 @@ void InferenceClientStage__check_triton_errors(triton::client::Error status,
 void build_output_tensors(std::size_t count,
                           const std::vector<TritonInOut>& model_outputs,
                           buffer_map_t& output_buffers,
-                          TensorMapType& output_tensors)
+                          TensorMap& output_tensors)
 {
     // Create the output memory blocks
     for (auto& model_output : model_outputs)
@@ -162,15 +162,13 @@ std::shared_ptr<const triton::client::InferRequestedOutput> build_output(const T
     return out_shared;
 }
 
-void reduce_outputs(const InferenceClientStage::sink_type_t& x,
-                    buffer_map_t& output_buffers,
-                    TensorMapType& output_tensors)
+void reduce_outputs(const InferenceClientStage::sink_type_t& x, buffer_map_t& output_buffers, TensorMap& output_tensors)
 {
     // When our tensor lengths are longer than our dataframe we will need to use the seq_ids array to
     // lookup how the values should map back into the dataframe.
     auto host_seq_ids = get_seq_ids(x);
 
-    TensorMapType reduced_outputs;
+    TensorMap reduced_outputs;
 
     for (const auto& output : output_tensors)
     {
@@ -211,9 +209,9 @@ void reduce_outputs(const InferenceClientStage::sink_type_t& x,
     output_tensors = std::move(reduced_outputs);
 }
 
-void apply_logits(buffer_map_t& output_buffers, TensorMapType& output_tensors)
+void apply_logits(buffer_map_t& output_buffers, TensorMap& output_tensors)
 {
-    TensorMapType logit_outputs;
+    TensorMap logit_outputs;
 
     for (const auto& output : output_tensors)
     {
@@ -285,7 +283,7 @@ InferenceClientStage::subscribe_fn_t InferenceClientStage::build_operator()
                 // input is too large and needs to be broken up in chunks in the pre-process stage. When this is the
                 // case we will reduce the rows in the response outputs such that we have a single response for each
                 // row int he dataframe.
-                TensorMapType output_tensors;
+                TensorMap output_tensors;
                 buffer_map_t output_buffers;
                 build_output_tensors(x->count, m_model_outputs, output_buffers, output_tensors);
 

--- a/morpheus/_lib/src/stages/triton_inference.cpp
+++ b/morpheus/_lib/src/stages/triton_inference.cpp
@@ -19,18 +19,18 @@
 
 #include "morpheus/messages/memory/response_memory_probs.hpp"  // for ResponseMemoryProbs
 #include "morpheus/messages/memory/tensor_memory.hpp"          // for TensorMemory
-#include "morpheus/messages/multi_response_probs.hpp"
-#include "morpheus/objects/dev_mem_info.hpp"  // for DevMemInfo
-#include "morpheus/objects/dtype.hpp"         // for DType
-#include "morpheus/objects/rmm_tensor.hpp"
-#include "morpheus/objects/tensor.hpp"
-#include "morpheus/objects/tensor_object.hpp"  // for TensorObject
-#include "morpheus/objects/triton_in_out.hpp"
-#include "morpheus/types.hpp"                 // for TensorIndex, TensorMap
-#include "morpheus/utilities/matx_util.hpp"   // for MatxUtil::logits, MatxUtil::reduce_max
-#include "morpheus/utilities/stage_util.hpp"  // for foreach_map
-#include "morpheus/utilities/string_util.hpp"  // for MORPHEUS_CONCAT_STR
-#include "morpheus/utilities/tensor_util.hpp"  // for get_elem_count
+#include "morpheus/messages/multi_response_probs.hpp"          // for MultiResponseProbsMessage
+#include "morpheus/objects/dev_mem_info.hpp"                   // for DevMemInfo
+#include "morpheus/objects/dtype.hpp"                          // for DType
+#include "morpheus/objects/rmm_tensor.hpp"                     // for RMMTensor
+#include "morpheus/objects/tensor.hpp"                         // for Tensor::create
+#include "morpheus/objects/tensor_object.hpp"                  // for TensorObject
+#include "morpheus/objects/triton_in_out.hpp"                  // for TritonInOut
+#include "morpheus/types.hpp"                                  // for TensorIndex, TensorMap
+#include "morpheus/utilities/matx_util.hpp"                    // for MatxUtil::logits, MatxUtil::reduce_max
+#include "morpheus/utilities/stage_util.hpp"                   // for foreach_map
+#include "morpheus/utilities/string_util.hpp"                  // for MORPHEUS_CONCAT_STR
+#include "morpheus/utilities/tensor_util.hpp"                  // for get_elem_count
 
 #include <cuda_runtime.h>  // for cudaMemcpy, cudaMemcpy2D, cudaMemcpyDeviceToHost, cudaMemcpyHostToDevice
 #include <cudf/types.hpp>

--- a/morpheus/_lib/src/stages/triton_inference.cpp
+++ b/morpheus/_lib/src/stages/triton_inference.cpp
@@ -27,7 +27,7 @@
 #include "morpheus/objects/tensor_object.hpp"  // for TensorIndex, TensorObject
 #include "morpheus/objects/triton_in_out.hpp"
 #include "morpheus/utilities/matx_util.hpp"
-#include "morpheus/utilities/stage_util.hpp"   // for foreach_map
+#include "morpheus/utilities/stage_util.hpp"  // for foreach_map
 #include "morpheus/utilities/string_util.hpp"  // for MORPHEUS_CONCAT_STR
 #include "morpheus/utilities/tensor_util.hpp"  // for get_elem_count
 

--- a/morpheus/_lib/src/stages/triton_inference.cpp
+++ b/morpheus/_lib/src/stages/triton_inference.cpp
@@ -18,14 +18,15 @@
 #include "morpheus/stages/triton_inference.hpp"
 
 #include "morpheus/messages/memory/response_memory_probs.hpp"  // for ResponseMemoryProbs
-#include "morpheus/messages/memory/tensor_memory.hpp"          // for tensor_map_t
+#include "morpheus/messages/memory/tensor_memory.hpp"          // for TensorMemory
 #include "morpheus/messages/multi_response_probs.hpp"
 #include "morpheus/objects/dev_mem_info.hpp"  // for DevMemInfo
 #include "morpheus/objects/dtype.hpp"         // for DType
 #include "morpheus/objects/rmm_tensor.hpp"
 #include "morpheus/objects/tensor.hpp"
-#include "morpheus/objects/tensor_object.hpp"  // for TensorIndex, TensorObject
+#include "morpheus/objects/tensor_object.hpp"  // for TensorObject
 #include "morpheus/objects/triton_in_out.hpp"
+#include "morpheus/types.hpp"  // for TensorIndex, tensor_map_t
 #include "morpheus/utilities/matx_util.hpp"
 #include "morpheus/utilities/stage_util.hpp"  // for foreach_map
 #include "morpheus/utilities/string_util.hpp"  // for MORPHEUS_CONCAT_STR

--- a/morpheus/_lib/src/stages/triton_inference.cpp
+++ b/morpheus/_lib/src/stages/triton_inference.cpp
@@ -26,8 +26,8 @@
 #include "morpheus/objects/tensor.hpp"
 #include "morpheus/objects/tensor_object.hpp"  // for TensorObject
 #include "morpheus/objects/triton_in_out.hpp"
-#include "morpheus/types.hpp"  // for TensorIndex, tensor_map_t
-#include "morpheus/utilities/matx_util.hpp"
+#include "morpheus/types.hpp"                // for TensorIndex, TensorMapType
+#include "morpheus/utilities/matx_util.hpp"  // for MatxUtil::logits, MatxUtil::reduce_max
 #include "morpheus/utilities/stage_util.hpp"  // for foreach_map
 #include "morpheus/utilities/string_util.hpp"  // for MORPHEUS_CONCAT_STR
 #include "morpheus/utilities/tensor_util.hpp"  // for get_elem_count
@@ -58,7 +58,6 @@
 namespace {
 
 using namespace morpheus;
-using tensor_map_t = tensor_map_t;
 using buffer_map_t = std::map<std::string, std::shared_ptr<rmm::device_buffer>>;
 
 // Component-private free functions.
@@ -80,7 +79,7 @@ void InferenceClientStage__check_triton_errors(triton::client::Error status,
 void build_output_tensors(std::size_t count,
                           const std::vector<TritonInOut>& model_outputs,
                           buffer_map_t& output_buffers,
-                          tensor_map_t& output_tensors)
+                          TensorMapType& output_tensors)
 {
     // Create the output memory blocks
     for (auto& model_output : model_outputs)
@@ -165,13 +164,13 @@ std::shared_ptr<const triton::client::InferRequestedOutput> build_output(const T
 
 void reduce_outputs(const InferenceClientStage::sink_type_t& x,
                     buffer_map_t& output_buffers,
-                    tensor_map_t& output_tensors)
+                    TensorMapType& output_tensors)
 {
     // When our tensor lengths are longer than our dataframe we will need to use the seq_ids array to
     // lookup how the values should map back into the dataframe.
     auto host_seq_ids = get_seq_ids(x);
 
-    tensor_map_t reduced_outputs;
+    TensorMapType reduced_outputs;
 
     for (const auto& output : output_tensors)
     {
@@ -212,9 +211,9 @@ void reduce_outputs(const InferenceClientStage::sink_type_t& x,
     output_tensors = std::move(reduced_outputs);
 }
 
-void apply_logits(buffer_map_t& output_buffers, tensor_map_t& output_tensors)
+void apply_logits(buffer_map_t& output_buffers, TensorMapType& output_tensors)
 {
-    tensor_map_t logit_outputs;
+    TensorMapType logit_outputs;
 
     for (const auto& output : output_tensors)
     {
@@ -286,7 +285,7 @@ InferenceClientStage::subscribe_fn_t InferenceClientStage::build_operator()
                 // input is too large and needs to be broken up in chunks in the pre-process stage. When this is the
                 // case we will reduce the rows in the response outputs such that we have a single response for each
                 // row int he dataframe.
-                tensor_map_t output_tensors;
+                TensorMapType output_tensors;
                 buffer_map_t output_buffers;
                 build_output_tensors(x->count, m_model_outputs, output_buffers, output_tensors);
 

--- a/morpheus/_lib/src/stages/triton_inference.cpp
+++ b/morpheus/_lib/src/stages/triton_inference.cpp
@@ -26,9 +26,9 @@
 #include "morpheus/objects/tensor.hpp"
 #include "morpheus/objects/tensor_object.hpp"  // for TensorObject
 #include "morpheus/objects/triton_in_out.hpp"
-#include "morpheus/types.hpp"                  // for TensorIndex, TensorMap
-#include "morpheus/utilities/matx_util.hpp"    // for MatxUtil::logits, MatxUtil::reduce_max
-#include "morpheus/utilities/stage_util.hpp"   // for foreach_map
+#include "morpheus/types.hpp"                 // for TensorIndex, TensorMap
+#include "morpheus/utilities/matx_util.hpp"   // for MatxUtil::logits, MatxUtil::reduce_max
+#include "morpheus/utilities/stage_util.hpp"  // for foreach_map
 #include "morpheus/utilities/string_util.hpp"  // for MORPHEUS_CONCAT_STR
 #include "morpheus/utilities/tensor_util.hpp"  // for get_elem_count
 

--- a/morpheus/_lib/src/stages/triton_inference.cpp
+++ b/morpheus/_lib/src/stages/triton_inference.cpp
@@ -18,7 +18,7 @@
 #include "morpheus/stages/triton_inference.hpp"
 
 #include "morpheus/messages/memory/response_memory_probs.hpp"  // for ResponseMemoryProbs
-#include "morpheus/messages/memory/tensor_memory.hpp"          // for TensorMemory::tensor_map_t
+#include "morpheus/messages/memory/tensor_memory.hpp"          // for tensor_map_t
 #include "morpheus/messages/multi_response_probs.hpp"
 #include "morpheus/objects/dev_mem_info.hpp"  // for DevMemInfo
 #include "morpheus/objects/dtype.hpp"         // for DType
@@ -27,7 +27,7 @@
 #include "morpheus/objects/tensor_object.hpp"  // for TensorIndex, TensorObject
 #include "morpheus/objects/triton_in_out.hpp"
 #include "morpheus/utilities/matx_util.hpp"
-#include "morpheus/utilities/stage_util.hpp"  // for foreach_map
+#include "morpheus/utilities/stage_util.hpp"   // for foreach_map
 #include "morpheus/utilities/string_util.hpp"  // for MORPHEUS_CONCAT_STR
 #include "morpheus/utilities/tensor_util.hpp"  // for get_elem_count
 
@@ -57,7 +57,7 @@
 namespace {
 
 using namespace morpheus;
-using tensor_map_t = TensorMemory::tensor_map_t;
+using tensor_map_t = tensor_map_t;
 using buffer_map_t = std::map<std::string, std::shared_ptr<rmm::device_buffer>>;
 
 // Component-private free functions.

--- a/morpheus/_lib/src/utilities/cupy_util.cpp
+++ b/morpheus/_lib/src/utilities/cupy_util.cpp
@@ -17,8 +17,9 @@
 
 #include "morpheus/utilities/cupy_util.hpp"
 
-#include "morpheus/objects/dtype.hpp"  // for DType
-#include "morpheus/objects/tensor.hpp"
+#include "morpheus/objects/dtype.hpp"   // for DType
+#include "morpheus/objects/tensor.hpp"  // for Tensor
+#include "morpheus/types.hpp"           // for TensorIndex
 
 #include <glog/logging.h>  // for COMPACT_GOOGLE_LOG_FATAL, DCHECK, LogMessageFatal
 #include <pybind11/cast.h>

--- a/morpheus/_lib/src/utilities/tensor_util.cpp
+++ b/morpheus/_lib/src/utilities/tensor_util.cpp
@@ -28,14 +28,14 @@
 #include <vector>       // for vector
 
 namespace morpheus {
-void TensorUtils::write_shape_to_stream(const shape_type_t& shape, std::ostream& os)
+void TensorUtils::write_shape_to_stream(const ShapeType& shape, std::ostream& os)
 {
     os << "(";
     std::copy(shape.begin(), shape.end(), std::experimental::make_ostream_joiner(os, ", "));
     os << ")";
 }
 
-std::string TensorUtils::shape_to_string(const shape_type_t& shape)
+std::string TensorUtils::shape_to_string(const ShapeType& shape)
 {
     std::stringstream ss;
     write_shape_to_stream(shape, ss);
@@ -54,7 +54,7 @@ void TensorUtils::set_contiguous_stride(const std::vector<TensorIndex>& shape, s
     }
 }
 
-bool TensorUtils::has_contiguous_stride(const std::vector<TensorIndex>& shape, const shape_type_t& stride)
+bool TensorUtils::has_contiguous_stride(const std::vector<TensorIndex>& shape, const ShapeType& stride)
 {
     DCHECK_EQ(shape.size(), stride.size());
     auto count = get_elem_count(shape);

--- a/morpheus/_lib/tests/test_tensor.cpp
+++ b/morpheus/_lib/tests/test_tensor.cpp
@@ -19,8 +19,9 @@
 
 #include "morpheus/objects/dtype.hpp"  // for DType
 #include "morpheus/objects/rmm_tensor.hpp"
-#include "morpheus/objects/tensor_object.hpp"  // for TensorIndex
-#include "morpheus/utilities/tensor_util.hpp"  // for TensorUtils, shape_type_t
+#include "morpheus/objects/tensor_object.hpp"  // for ITensor
+#include "morpheus/types.hpp"                  // for shape_type_t, TensorIndex
+#include "morpheus/utilities/tensor_util.hpp"  // for TensorUtils
 
 #include <cuda_runtime.h>
 #include <gtest/gtest.h>  // for AssertionResult, SuiteApiResolver, TestInfo, EXPECT_TRUE, Message, TEST_F, Test, TestFactoryImpl, TestPartResult

--- a/morpheus/_lib/tests/test_tensor.cpp
+++ b/morpheus/_lib/tests/test_tensor.cpp
@@ -20,7 +20,7 @@
 #include "morpheus/objects/dtype.hpp"  // for DType
 #include "morpheus/objects/rmm_tensor.hpp"
 #include "morpheus/objects/tensor_object.hpp"  // for TensorIndex
-#include "morpheus/utilities/tensor_util.hpp"  // for TensorUtils, TensorUtils::shape_type_t
+#include "morpheus/utilities/tensor_util.hpp"  // for TensorUtils, shape_type_t
 
 #include <cuda_runtime.h>
 #include <gtest/gtest.h>  // for AssertionResult, SuiteApiResolver, TestInfo, EXPECT_TRUE, Message, TEST_F, Test, TestFactoryImpl, TestPartResult
@@ -47,17 +47,17 @@ class TestTensor : public ::testing::Test
 
 TEST_F(TestTensor, UtilsShapeString)
 {
-    TensorUtils::shape_type_t shape = {100, 10, 1};
-    auto shape_str                  = TensorUtils::shape_to_string(shape);
+    shape_type_t shape = {100, 10, 1};
+    auto shape_str     = TensorUtils::shape_to_string(shape);
     EXPECT_TRUE(shape_str == std::string("(100, 10, 1)"));
 }
 
 TEST_F(TestTensor, GetElementStride)
 {
-    EXPECT_EQ(TensorUtils::get_element_stride<TensorIndex>({10, 1}), TensorUtils::shape_type_t({10, 1}));
-    EXPECT_EQ(TensorUtils::get_element_stride<TensorIndex>({1, 13}), TensorUtils::shape_type_t({1, 13}));
-    EXPECT_EQ(TensorUtils::get_element_stride<TensorIndex>({8, 104}), TensorUtils::shape_type_t({1, 13}));
-    EXPECT_EQ(TensorUtils::get_element_stride<TensorIndex>({8, 16, 112}), TensorUtils::shape_type_t({1, 2, 14}));
+    EXPECT_EQ(TensorUtils::get_element_stride<TensorIndex>({10, 1}), shape_type_t({10, 1}));
+    EXPECT_EQ(TensorUtils::get_element_stride<TensorIndex>({1, 13}), shape_type_t({1, 13}));
+    EXPECT_EQ(TensorUtils::get_element_stride<TensorIndex>({8, 104}), shape_type_t({1, 13}));
+    EXPECT_EQ(TensorUtils::get_element_stride<TensorIndex>({8, 16, 112}), shape_type_t({1, 2, 14}));
 
     EXPECT_EQ(TensorUtils::get_element_stride<std::size_t>({10, 1}), std::vector<std::size_t>({10, 1}));
     EXPECT_EQ(TensorUtils::get_element_stride<std::size_t>({1, 13}), std::vector<std::size_t>({1, 13}));
@@ -66,22 +66,22 @@ TEST_F(TestTensor, GetElementStride)
 
     {
         auto results = TensorUtils::get_element_stride<TensorIndex, std::size_t>({10, 1});
-        EXPECT_EQ(results, TensorUtils::shape_type_t({10, 1}));
+        EXPECT_EQ(results, shape_type_t({10, 1}));
     }
 
     {
         auto results = TensorUtils::get_element_stride<TensorIndex, std::size_t>({1, 13});
-        EXPECT_EQ(results, TensorUtils::shape_type_t({1, 13}));
+        EXPECT_EQ(results, shape_type_t({1, 13}));
     }
 
     {
         auto results = TensorUtils::get_element_stride<TensorIndex, std::size_t>({8, 104});
-        EXPECT_EQ(results, TensorUtils::shape_type_t({1, 13}));
+        EXPECT_EQ(results, shape_type_t({1, 13}));
     }
 
     {
         auto results = TensorUtils::get_element_stride<TensorIndex, std::size_t>({8, 16, 112});
-        EXPECT_EQ(results, TensorUtils::shape_type_t({1, 2, 14}));
+        EXPECT_EQ(results, shape_type_t({1, 2, 14}));
     }
 }
 

--- a/morpheus/_lib/tests/test_tensor.cpp
+++ b/morpheus/_lib/tests/test_tensor.cpp
@@ -20,7 +20,7 @@
 #include "morpheus/objects/dtype.hpp"  // for DType
 #include "morpheus/objects/rmm_tensor.hpp"
 #include "morpheus/objects/tensor_object.hpp"  // for ITensor
-#include "morpheus/types.hpp"                  // for shape_type_t, TensorIndex
+#include "morpheus/types.hpp"                  // for ShapeType, TensorIndex
 #include "morpheus/utilities/tensor_util.hpp"  // for TensorUtils
 
 #include <cuda_runtime.h>
@@ -48,17 +48,17 @@ class TestTensor : public ::testing::Test
 
 TEST_F(TestTensor, UtilsShapeString)
 {
-    shape_type_t shape = {100, 10, 1};
-    auto shape_str     = TensorUtils::shape_to_string(shape);
+    ShapeType shape = {100, 10, 1};
+    auto shape_str  = TensorUtils::shape_to_string(shape);
     EXPECT_TRUE(shape_str == std::string("(100, 10, 1)"));
 }
 
 TEST_F(TestTensor, GetElementStride)
 {
-    EXPECT_EQ(TensorUtils::get_element_stride<TensorIndex>({10, 1}), shape_type_t({10, 1}));
-    EXPECT_EQ(TensorUtils::get_element_stride<TensorIndex>({1, 13}), shape_type_t({1, 13}));
-    EXPECT_EQ(TensorUtils::get_element_stride<TensorIndex>({8, 104}), shape_type_t({1, 13}));
-    EXPECT_EQ(TensorUtils::get_element_stride<TensorIndex>({8, 16, 112}), shape_type_t({1, 2, 14}));
+    EXPECT_EQ(TensorUtils::get_element_stride<TensorIndex>({10, 1}), ShapeType({10, 1}));
+    EXPECT_EQ(TensorUtils::get_element_stride<TensorIndex>({1, 13}), ShapeType({1, 13}));
+    EXPECT_EQ(TensorUtils::get_element_stride<TensorIndex>({8, 104}), ShapeType({1, 13}));
+    EXPECT_EQ(TensorUtils::get_element_stride<TensorIndex>({8, 16, 112}), ShapeType({1, 2, 14}));
 
     EXPECT_EQ(TensorUtils::get_element_stride<std::size_t>({10, 1}), std::vector<std::size_t>({10, 1}));
     EXPECT_EQ(TensorUtils::get_element_stride<std::size_t>({1, 13}), std::vector<std::size_t>({1, 13}));
@@ -67,22 +67,22 @@ TEST_F(TestTensor, GetElementStride)
 
     {
         auto results = TensorUtils::get_element_stride<TensorIndex, std::size_t>({10, 1});
-        EXPECT_EQ(results, shape_type_t({10, 1}));
+        EXPECT_EQ(results, ShapeType({10, 1}));
     }
 
     {
         auto results = TensorUtils::get_element_stride<TensorIndex, std::size_t>({1, 13});
-        EXPECT_EQ(results, shape_type_t({1, 13}));
+        EXPECT_EQ(results, ShapeType({1, 13}));
     }
 
     {
         auto results = TensorUtils::get_element_stride<TensorIndex, std::size_t>({8, 104});
-        EXPECT_EQ(results, shape_type_t({1, 13}));
+        EXPECT_EQ(results, ShapeType({1, 13}));
     }
 
     {
         auto results = TensorUtils::get_element_stride<TensorIndex, std::size_t>({8, 16, 112});
-        EXPECT_EQ(results, shape_type_t({1, 2, 14}));
+        EXPECT_EQ(results, ShapeType({1, 2, 14}));
     }
 }
 


### PR DESCRIPTION
* Create a `types.hpp` for type aliases like `TensorIndex` and `tensor_map_t`

This is a scaled back version of PR #720 without a `forward.hpp`. The forward header didn't improve build performance, and complicated IWYU checks. The real motivation behind this was having a convenient place for `tensor_map_t`.

fixes #715