### PR TITLE
Use AWS OIDC to get AWS creds

### DIFF
--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -71,6 +71,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
+          role-duration-seconds: 43200 # 12h
 
       - name: Check
         shell: bash
@@ -102,6 +103,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
+          role-duration-seconds: 43200 # 12h
 
       - name: Build:linux:x86_64:gcc
         shell: bash
@@ -138,6 +140,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
+          role-duration-seconds: 43200 # 12h
 
       - name: Test:linux:x86_64:gcc
         shell: bash
@@ -170,6 +173,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
+          role-duration-seconds: 43200 # 12h
 
       - name: build_docs
         shell: bash

--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -28,16 +28,10 @@ on:
         required: true
         type: string
     secrets:
-      GHA_AWS_ACCESS_KEY_ID:
-        required: true
-      GHA_AWS_SECRET_ACCESS_KEY:
-        required: true
       NGC_API_KEY:
         required: true
 
 env:
-  AWS_ACCESS_KEY_ID: "${{ secrets.GHA_AWS_ACCESS_KEY_ID }}"
-  AWS_SECRET_ACCESS_KEY: "${{ secrets.GHA_AWS_SECRET_ACCESS_KEY }}"
   CHANGE_TARGET: "${{ github.base_ref }}"
   CUDA_PATH: "/usr/local/cuda/"
   CUDA_VER: "11.5"
@@ -61,6 +55,8 @@ jobs:
       image: ${{ inputs.container }}
     strategy:
       fail-fast: true
+    permissions:
+      id-token: write
 
     steps:
       - name: Checkout
@@ -69,6 +65,12 @@ jobs:
           lfs: false
           path: 'morpheus'
           fetch-depth: 0
+
+      - name: Get AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Check
         shell: bash
@@ -85,6 +87,8 @@ jobs:
       image: ${{ inputs.container }}
     strategy:
       fail-fast: true
+    permissions:
+      id-token: write
 
     steps:
       - name: Checkout
@@ -92,6 +96,12 @@ jobs:
         with:
           lfs: false
           path: 'morpheus'
+
+      - name: Get AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Build:linux:x86_64:gcc
         shell: bash
@@ -113,6 +123,8 @@ jobs:
         PARALLEL_LEVEL: '10'
     strategy:
       fail-fast: true
+    permissions:
+      id-token: write
 
     steps:
       - name: Checkout
@@ -120,6 +132,12 @@ jobs:
         with:
           lfs: false
           path: 'morpheus'
+
+      - name: Get AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Test:linux:x86_64:gcc
         shell: bash
@@ -137,6 +155,8 @@ jobs:
       image: ${{ inputs.container }}
     strategy:
       fail-fast: true
+    permissions:
+      id-token: write
 
     steps:
       - name: Checkout
@@ -144,6 +164,12 @@ jobs:
         with:
           lfs: false
           path: 'morpheus'
+
+      - name: Get AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: build_docs
         shell: bash

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -29,11 +29,11 @@ concurrency:
 jobs:
   ci_pipe:
     uses: ./.github/workflows/ci_pipe.yml
+    permissions:
+      id-token: write
     with:
       run_check: ${{ startsWith(github.ref_name, 'pull-request/') }}
       container: nvcr.io/ea-nvidia-morpheus/morpheus:morpheus-ci-driver-230214
       test_container: nvcr.io/ea-nvidia-morpheus/morpheus:morpheus-ci-test-230214
     secrets:
-      GHA_AWS_ACCESS_KEY_ID: ${{ secrets.GHA_AWS_ACCESS_KEY_ID }}
-      GHA_AWS_SECRET_ACCESS_KEY: ${{ secrets.GHA_AWS_SECRET_ACCESS_KEY }}
       NGC_API_KEY: ${{ secrets.NGC_API_KEY }}


### PR DESCRIPTION
This PR is using the AWS OIDC to get AWS credentials ([doc](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services)). Currently we are using permanent tokens that we need to manually rotate every 90 days. This PR is removing this requirement.

The `AWS_ROLE_ARN` and `AWS_REGION` are orgs variables defined here: https://github.com/organizations/nv-morpheus/settings/variables/actions.