### PR TITLE
23.01 back-patch of #742 - Use AWS OIDC to get AWS creds 

### DIFF
--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -44,6 +44,20 @@ env:
   WORKSPACE: "${{ github.workspace }}/morpheus"
   WORKSPACE_TMP: "${{ github.workspace }}/tmp"
 
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  discussions: none
+  id-token: write
+  issues: none
+  packages: read
+  pages: none
+  pull-requests: read
+  repository-projects: none
+  security-events: none
+  statuses: none
 
 jobs:
   check:
@@ -58,8 +72,6 @@ jobs:
       image: ${{ inputs.container }}
     strategy:
       fail-fast: true
-    permissions:
-      id-token: write
 
     steps:
       - name: Checkout
@@ -91,8 +103,6 @@ jobs:
       image: ${{ inputs.container }}
     strategy:
       fail-fast: true
-    permissions:
-      id-token: write
 
     steps:
       - name: Checkout
@@ -128,8 +138,6 @@ jobs:
         PARALLEL_LEVEL: '10'
     strategy:
       fail-fast: true
-    permissions:
-      id-token: write
 
     steps:
       - name: Checkout
@@ -161,8 +169,6 @@ jobs:
       image: ${{ inputs.container }}
     strategy:
       fail-fast: true
-    permissions:
-      id-token: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -31,17 +31,10 @@ on:
         required: true
         type: string
     secrets:
-      GHA_AWS_ACCESS_KEY_ID:
-        required: true
-      GHA_AWS_SECRET_ACCESS_KEY:
-        required: true
       NGC_API_KEY:
         required: true
 
 env:
-  AWS_DEFAULT_REGION:  ${{ inputs.aws_region }}
-  AWS_ACCESS_KEY_ID: "${{ secrets.GHA_AWS_ACCESS_KEY_ID }}"
-  AWS_SECRET_ACCESS_KEY: "${{ secrets.GHA_AWS_SECRET_ACCESS_KEY }}"
   CHANGE_TARGET: "${{ github.base_ref }}"
   CUDA_PATH: "/usr/local/cuda/"
   CUDA_VER: "11.5"
@@ -65,6 +58,8 @@ jobs:
       image: ${{ inputs.container }}
     strategy:
       fail-fast: true
+    permissions:
+      id-token: write
 
     steps:
       - name: Checkout
@@ -73,6 +68,13 @@ jobs:
           lfs: false
           path: 'morpheus'
           fetch-depth: 0
+
+      - name: Get AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+          role-duration-seconds: 43200 # 12h
 
       - name: Check
         shell: bash
@@ -89,6 +91,8 @@ jobs:
       image: ${{ inputs.container }}
     strategy:
       fail-fast: true
+    permissions:
+      id-token: write
 
     steps:
       - name: Checkout
@@ -96,6 +100,13 @@ jobs:
         with:
           lfs: false
           path: 'morpheus'
+
+      - name: Get AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+          role-duration-seconds: 43200 # 12h
 
       - name: Build:linux:x86_64:gcc
         shell: bash
@@ -117,6 +128,8 @@ jobs:
         PARALLEL_LEVEL: '10'
     strategy:
       fail-fast: true
+    permissions:
+      id-token: write
 
     steps:
       - name: Checkout
@@ -124,6 +137,13 @@ jobs:
         with:
           lfs: false
           path: 'morpheus'
+
+      - name: Get AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+          role-duration-seconds: 43200 # 12h
 
       - name: Test:linux:x86_64:gcc
         shell: bash
@@ -141,6 +161,8 @@ jobs:
       image: ${{ inputs.container }}
     strategy:
       fail-fast: true
+    permissions:
+      id-token: write
 
     steps:
       - name: Checkout
@@ -148,6 +170,13 @@ jobs:
         with:
           lfs: false
           path: 'morpheus'
+
+      - name: Get AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+          role-duration-seconds: 43200 # 12h
 
       - name: build_docs
         shell: bash

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,11 +26,24 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  discussions: none
+  id-token: write
+  issues: none
+  packages: read
+  pages: none
+  pull-requests: read
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   ci_pipe:
     uses: ./.github/workflows/ci_pipe.yml
-    permissions:
-      id-token: write
     with:
       run_check: ${{ startsWith(github.ref_name, 'pull-request/') }}
       container: nvcr.io/ea-nvidia-morpheus/morpheus:morpheus-ci-driver-230125

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -29,11 +29,11 @@ concurrency:
 jobs:
   ci_pipe:
     uses: ./.github/workflows/ci_pipe.yml
+    permissions:
+      id-token: write
     with:
       run_check: ${{ startsWith(github.ref_name, 'pull-request/') }}
       container: nvcr.io/ea-nvidia-morpheus/morpheus:morpheus-ci-driver-230125
       test_container: nvcr.io/ea-nvidia-morpheus/morpheus:morpheus-ci-test-230125
     secrets:
-      GHA_AWS_ACCESS_KEY_ID: ${{ secrets.GHA_AWS_ACCESS_KEY_ID }}
-      GHA_AWS_SECRET_ACCESS_KEY: ${{ secrets.GHA_AWS_SECRET_ACCESS_KEY }}
       NGC_API_KEY: ${{ secrets.NGC_API_KEY }}


### PR DESCRIPTION
This PR is using the AWS OIDC to get AWS credentials ([doc](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services)). Currently we are using permanent tokens that we need to manually rotate every 90 days. This PR is removing this requirement.

The `AWS_ROLE_ARN` and `AWS_REGION` are orgs variables defined here: https://github.com/organizations/nv-morpheus/settings/variables/actions.

Authors:
  - Jordan Jacobelli (https://github.com/jjacobelli)
  - David Gardner (https://github.com/dagardner-nv)
 
Approvers:
  - AJ Schmidt (https://github.com/ajschmidt8)
  - Jordan Jacobelli (https://github.com/jjacobelli)
  - Michael Demoret (https://github.com/mdemoret-nv)

URL: https://github.com/nv-morpheus/Morpheus/pull/742