### PR TITLE
Update workflow `permissions` block

### DIFF
--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -41,6 +41,20 @@ env:
   WORKSPACE: "${{ github.workspace }}/morpheus"
   WORKSPACE_TMP: "${{ github.workspace }}/tmp"
 
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  discussions: none
+  id-token: write
+  issues: none
+  packages: read
+  pages: none
+  pull-requests: read
+  repository-projects: none
+  security-events: none
+  statuses: none
 
 jobs:
   check:
@@ -55,8 +69,6 @@ jobs:
       image: ${{ inputs.container }}
     strategy:
       fail-fast: true
-    permissions:
-      id-token: write
 
     steps:
       - name: Checkout
@@ -88,8 +100,6 @@ jobs:
       image: ${{ inputs.container }}
     strategy:
       fail-fast: true
-    permissions:
-      id-token: write
 
     steps:
       - name: Checkout
@@ -125,8 +135,6 @@ jobs:
         PARALLEL_LEVEL: '10'
     strategy:
       fail-fast: true
-    permissions:
-      id-token: write
 
     steps:
       - name: Checkout
@@ -158,8 +166,6 @@ jobs:
       image: ${{ inputs.container }}
     strategy:
       fail-fast: true
-    permissions:
-      id-token: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -29,8 +29,6 @@ concurrency:
 jobs:
   ci_pipe:
     uses: ./.github/workflows/ci_pipe.yml
-    permissions:
-      id-token: write
     with:
       run_check: ${{ startsWith(github.ref_name, 'pull-request/') }}
       container: nvcr.io/ea-nvidia-morpheus/morpheus:morpheus-ci-driver-230214

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,6 +26,21 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  discussions: none
+  id-token: write
+  issues: none
+  packages: read
+  pages: none
+  pull-requests: read
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   ci_pipe:
     uses: ./.github/workflows/ci_pipe.yml


### PR DESCRIPTION
This PR is a continuation of #742.

Omitting the other keys in the `permissions` block sets them to `none` ([src](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#overview)).

This is probably not a concern for `nv-morpheus`, but it caused issues for some private RAPIDS repositories so I wanted to update the `nv-morpheus` repos for consistency.

To remedy this, this PR includes the following changes:

- Keeps the `id-token` permission as `write`, but sets the remaining permissions as described in the `restricted` column [here](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
  - Also sets `pull_request` to `read` so that `fetch_base_branch` in `common.sh` can use it
- Moves the `permissions` block to the top of `ci_pipe.yml` to DRY it up
- ~~Removes the `permissions` block from `pull_request.yml` since that workflow only calls `ci_pipe.yml` and therefore is redundant~~ (this is required. otherwise this error occurs https://github.com/nv-morpheus/Morpheus/actions/runs/4359998192)