### PR TITLE
Fix absolute depfile causing python package to reinstall each build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 
-cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 
 
 list(APPEND CMAKE_MESSAGE_CONTEXT "morpheus")

--- a/morpheus/_lib/cmake/python_modules/messages.cmake
+++ b/morpheus/_lib/cmake/python_modules/messages.cmake
@@ -12,7 +12,7 @@
 # the License.
 # =============================================================================
 
-morpheus_utils_add_pybind11_module(
+morpheus_add_pybind11_module(
     messages
     SOURCE_FILES
       "${MORPHEUS_LIB_ROOT}/src/python_modules/messages.cpp"

--- a/morpheus/_lib/cmake/python_modules/stages.cmake
+++ b/morpheus/_lib/cmake/python_modules/stages.cmake
@@ -12,7 +12,7 @@
 # the License.
 # =============================================================================
 
-morpheus_utils_add_pybind11_module(
+morpheus_add_pybind11_module(
     stages
     SOURCE_FILES
       "${MORPHEUS_LIB_ROOT}/src/python_modules/stages.cpp"


### PR DESCRIPTION
Follow up to #754 which still reinstalled the package each build. This sets `cmake_minimum_required(3.24)` to match MRC and get consistent policies for the relative/absolute depfile options.

Also fixes some previous merge issues.