### PR TITLE
Fix intermittent test failure in tests/test_message_meta.py

### DIFF
--- a/tests/test_message_meta.py
+++ b/tests/test_message_meta.py
@@ -136,5 +136,6 @@ def test_copy_dataframe(df: cudf.DataFrame):
     assert copied_df is not df, "But should be different instances"
 
     # Try setting a single value on the copy
-    meta.copy_dataframe()['v2'][3] = 47
+    cdf = meta.copy_dataframe()
+    cdf['v2'].iloc[3] = 47
     assert assert_df_equal(meta.copy_dataframe(), df), "Should be identical"

--- a/tests/test_message_meta.py
+++ b/tests/test_message_meta.py
@@ -105,9 +105,9 @@ def test_mutable_dataframe(df: cudf.DataFrame):
     meta = MessageMeta(df)
 
     with meta.mutable_dataframe() as df:
-        df['v2'][3] = 47
+        df['v2'].iloc[3] = 47
 
-    assert meta.copy_dataframe()['v2'][3] == 47
+    assert meta.copy_dataframe()['v2'].iloc[3] == 47
 
 
 def test_using_ctx_outside_with_block(df: cudf.DataFrame):


### PR DESCRIPTION
## Description
We had two tests that set values on row 3, however we now randomly duplicate the index, causing a situation where 3 might not exist in the index.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
