### PR TITLE
Fix abp_pcap_detection example

### DIFF
--- a/examples/abp_pcap_detection/abp_pcap_preprocessing.py
+++ b/examples/abp_pcap_detection/abp_pcap_preprocessing.py
@@ -18,7 +18,6 @@ from functools import partial
 import cupy as cp
 import mrc
 import numpy as np
-import pandas as pd
 
 import cudf
 

--- a/examples/abp_pcap_detection/abp_pcap_preprocessing.py
+++ b/examples/abp_pcap_detection/abp_pcap_preprocessing.py
@@ -77,7 +77,10 @@ class AbpPcapPreprocessingStage(PreprocessBaseStage):
 
     @staticmethod
     def pre_process_batch(x: MultiMessage, fea_len: int, fea_cols: typing.List[str]) -> MultiInferenceFILMessage:
+        # Converts the int flags field into a binary string
         flags_bin_series = x.get_meta("flags").to_pandas().apply(lambda x: format(int(x), "05b"))
+
+        # Expand binary string into an array
         df = cudf.DataFrame(np.vstack(flags_bin_series.str.findall("[0-1]")).astype("int8"))
 
         # adding [ack, psh, rst, syn, fin] details from the binary flag

--- a/examples/abp_pcap_detection/abp_pcap_preprocessing.py
+++ b/examples/abp_pcap_detection/abp_pcap_preprocessing.py
@@ -81,7 +81,7 @@ class AbpPcapPreprocessingStage(PreprocessBaseStage):
         flags_bin_series = x.get_meta("flags").to_pandas().apply(lambda x: format(int(x), "05b"))
 
         # Expand binary string into an array
-        df = cudf.DataFrame(np.vstack(flags_bin_series.str.findall("[0-1]")).astype("int8"))
+        df = cudf.DataFrame(np.vstack(flags_bin_series.str.findall("[0-1]")).astype("int8"), index=x.get_meta().index)
 
         # adding [ack, psh, rst, syn, fin] details from the binary flag
         rename_cols_dct = {0: "ack", 1: "psh", 2: "rst", 3: "syn", 4: "fin"}
@@ -176,7 +176,7 @@ class AbpPcapPreprocessingStage(PreprocessBaseStage):
         del merged_df
 
         seg_ids = cp.zeros((count, 3), dtype=cp.uint32)
-        seg_ids[:, 0] = cp.arange(0, count, dtype=cp.uint32)
+        seg_ids[:, 0] = cp.arange(x.mess_offset, x.mess_offset + count, dtype=cp.uint32)
         seg_ids[:, 2] = fea_len - 1
 
         # Create the inference memory. Keep in mind count here could be > than input count

--- a/examples/abp_pcap_detection/abp_pcap_preprocessing.py
+++ b/examples/abp_pcap_detection/abp_pcap_preprocessing.py
@@ -85,7 +85,7 @@ class AbpPcapPreprocessingStage(PreprocessBaseStage):
 
         # adding [ack, psh, rst, syn, fin] details from the binary flag
         rename_cols_dct = {0: "ack", 1: "psh", 2: "rst", 3: "syn", 4: "fin"}
-        df.rename(columns=rename_cols_dct)
+        df = df.rename(columns=rename_cols_dct)
 
         df["flags_bin"] = flags_bin_series
         df["timestamp"] = x.get_meta("timestamp").astype("int64")
@@ -171,8 +171,7 @@ class AbpPcapPreprocessingStage(PreprocessBaseStage):
         req_cols = ["flow_id", "rollup_time"]
 
         for col in req_cols:
-            # TODO: temporary work-around for Issue #286
-            x.meta.df[col] = merged_df[col].copy(True)
+            x.set_meta(col, merged_df[col])
 
         del merged_df
 

--- a/morpheus/messages/multi_message.py
+++ b/morpheus/messages/multi_message.py
@@ -245,7 +245,7 @@ class MultiMessage(MessageData, cpp_class=_messages.MultiMessage):
                 try:
                     # Now update the slice
                     df.iloc[row_indexer, column_indexer] = value
-                except TypeError:
+                except (ValueError, TypeError):
                     # Try this as a fallback. Works better for strings. See issue #286
                     df[columns].iloc[row_indexer] = value
 

--- a/morpheus/messages/multi_message.py
+++ b/morpheus/messages/multi_message.py
@@ -245,7 +245,7 @@ class MultiMessage(MessageData, cpp_class=_messages.MultiMessage):
                 try:
                     # Now update the slice
                     df.iloc[row_indexer, column_indexer] = value
-                except ValueError:
+                except TypeError:
                     # Try this as a fallback. Works better for strings. See issue #286
                     df[columns].iloc[row_indexer] = value
 

--- a/tests/test_multi_message.py
+++ b/tests/test_multi_message.py
@@ -240,16 +240,20 @@ def test_set_meta_new_column_dup_index(filter_probs_df: cudf.DataFrame, df_type:
     test_set_meta_new_column(df, df_type)
 
 
-def test_set_meta_issue_286(filter_probs_df: cudf.DataFrame):
+@pytest.mark.use_cudf
+@pytest.mark.parametrize('mess_offset', [0, 5])
+@pytest.mark.parametrize('mess_count', [5])
+@pytest.mark.parametrize('use_series', [True, False])
+def test_set_meta_issue_286(filter_probs_df: cudf.DataFrame, mess_offset: int, mess_count: int, use_series: bool):
 
     meta = MessageMeta(filter_probs_df)
-    mm1 = MultiMessage(meta=meta, mess_offset=0, mess_count=5)
-    mm2 = MultiMessage(meta=meta, mess_offset=5, mess_count=5)
+    mm = MultiMessage(meta=meta, mess_offset=mess_offset, mess_count=mess_count)
 
     values = list(string.ascii_letters)
+    if use_series:
+        values = cudf.Series(values)
 
-    mm1.set_meta('letters', values[0:5])
-    mm2.set_meta('letters', values[5:10])
+    mm.set_meta('letters', values[0:5])
 
 
 def test_copy_ranges(filter_probs_df: cudf.DataFrame):

--- a/tests/test_multi_message.py
+++ b/tests/test_multi_message.py
@@ -241,19 +241,22 @@ def test_set_meta_new_column_dup_index(filter_probs_df: cudf.DataFrame, df_type:
 
 
 @pytest.mark.use_cudf
-@pytest.mark.parametrize('mess_offset', [0, 5])
-@pytest.mark.parametrize('mess_count', [5])
 @pytest.mark.parametrize('use_series', [True, False])
-def test_set_meta_issue_286(filter_probs_df: cudf.DataFrame, mess_offset: int, mess_count: int, use_series: bool):
+def test_set_meta_issue_286(filter_probs_df: cudf.DataFrame, use_series: bool):
+    """
+    Explicitly calling set_meta on two different non-overlapping slices.
+    """
 
     meta = MessageMeta(filter_probs_df)
-    mm = MultiMessage(meta=meta, mess_offset=mess_offset, mess_count=mess_count)
+    mm1 = MultiMessage(meta=meta, mess_offset=0, mess_count=5)
+    mm2 = MultiMessage(meta=meta, mess_offset=5, mess_count=5)
 
     values = list(string.ascii_letters)
     if use_series:
         values = cudf.Series(values)
 
-    mm.set_meta('letters', values[0:5])
+    mm1.set_meta('letters', values[0:5])
+    mm2.set_meta('letters', values[5:10])
 
 
 def test_copy_ranges(filter_probs_df: cudf.DataFrame):


### PR DESCRIPTION
## Description
* Work-around for change in cudf introduced by https://github.com/rapidsai/cudf/issues/10226
* Fix handling of indexes and offsets in `examples/abp_pcap_detection/abp_pcap_preprocessing.py`
* Cudf will throw a different exception on a series of strings than a list of strings

fixes #790

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
