### PR TITLE
Fix debug log message caused by breaking the long string

### DIFF
--- a/morpheus/stages/postprocess/filter_detections_stage.py
+++ b/morpheus/stages/postprocess/filter_detections_stage.py
@@ -200,7 +200,7 @@ class FilterDetectionsStage(SinglePortStage):
 
             logger.debug(
                 f"filter_source was set to Auto, infering a filter source of {self._filter_source} based on an input "
-                "message type of {message_type}")
+                f"message type of {message_type}")
 
         if self._build_cpp_node():
             node = _stages.FilterDetectionsStage(builder,


### PR DESCRIPTION
## Description
Fixes the printing of the type

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
