### PR TITLE
Set default DFP container version to 23.03

### DIFF
--- a/ci/conda/recipes/morpheus/meta.yaml
+++ b/ci/conda/recipes/morpheus/meta.yaml
@@ -77,6 +77,7 @@ outputs:
         - cudf_kafka {{ rapids_version }}.*
         - cupy # Version determined from cudf
         - datacompy 0.8.*
+        - dill
         - distributed
         - docker-py 5.0.*
         - grpcio # Version determined from cudf
@@ -88,6 +89,7 @@ outputs:
         - pandas 1.3.*
         - pluggy 1.0.*
         - python
+        - scikit-learn=0.23.1
         - tqdm 4.*
         - typing_utils 0.1.*
         - watchdog 2.1.*

--- a/examples/digital_fingerprinting/production/docker-compose.yml
+++ b/examples/digital_fingerprinting/production/docker-compose.yml
@@ -73,7 +73,7 @@ services:
       target: runtime
       args:
         - MORPHEUS_CONTAINER=${MORPHEUS_CONTAINER:-nvcr.io/nvidia/morpheus/morpheus}
-        - MORPHEUS_CONTAINER_VERSION=${MORPHEUS_CONTAINER_VERSION:-v23.01.00-runtime}
+        - MORPHEUS_CONTAINER_VERSION=${MORPHEUS_CONTAINER_VERSION:-v23.03.00-runtime}
     image: dfp_morpheus
     container_name: morpheus_pipeline
     deploy:

--- a/examples/digital_fingerprinting/production/docker-compose.yml
+++ b/examples/digital_fingerprinting/production/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       target: jupyter
       args:
         - MORPHEUS_CONTAINER=${MORPHEUS_CONTAINER:-nvcr.io/nvidia/morpheus/morpheus}
-        - MORPHEUS_CONTAINER_VERSION=${MORPHEUS_CONTAINER_VERSION:-v23.01.00-runtime}
+        - MORPHEUS_CONTAINER_VERSION=${MORPHEUS_CONTAINER_VERSION:-v23.03.00-runtime}
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
## Description
Currently the DFP containers build from morpheus-23.01 by default, this just changes the default to 23.03

Add scikitlearn & dill to release env fixes #814

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
