### PR TITLE
Misc Documentation fixes for 23.03

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -114,7 +114,7 @@ exhale_args = {
         BUILTIN_STL_SUPPORT = YES
         DOT_IMAGE_FORMAT = svg
         EXCLUDE_PATTERNS = */tests/* */include/nvtext/* */__pycache__/*
-        EXCLUDE_SYMBOLS = "@85" "cudf*" "py::literals" "RdKafka" "mrc*" "std*"
+        EXCLUDE_SYMBOLS = "@*" "cudf*" "py::literals" "RdKafka" "mrc*" "std*"
         EXTENSION_MAPPING = cu=C++ cuh=C++
         EXTRACT_ALL = YES
         FILE_PATTERNS = *.c *.cc *.cpp *.h *.hpp *.cu *.cuh *.md

--- a/morpheus/_lib/include/morpheus/io/data_loader_registry.hpp
+++ b/morpheus/_lib/include/morpheus/io/data_loader_registry.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/io/deserializers.hpp
+++ b/morpheus/_lib/include/morpheus/io/deserializers.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/io/serializers.hpp
+++ b/morpheus/_lib/include/morpheus/io/serializers.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/messages/control.hpp
+++ b/morpheus/_lib/include/morpheus/messages/control.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/messages/memory/inference_memory.hpp
+++ b/morpheus/_lib/include/morpheus/messages/memory/inference_memory.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/messages/memory/inference_memory_fil.hpp
+++ b/morpheus/_lib/include/morpheus/messages/memory/inference_memory_fil.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/messages/memory/inference_memory_nlp.hpp
+++ b/morpheus/_lib/include/morpheus/messages/memory/inference_memory_nlp.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/messages/memory/response_memory.hpp
+++ b/morpheus/_lib/include/morpheus/messages/memory/response_memory.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/messages/memory/response_memory_probs.hpp
+++ b/morpheus/_lib/include/morpheus/messages/memory/response_memory_probs.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/messages/memory/tensor_memory.hpp
+++ b/morpheus/_lib/include/morpheus/messages/memory/tensor_memory.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/messages/meta.hpp
+++ b/morpheus/_lib/include/morpheus/messages/meta.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/messages/multi.hpp
+++ b/morpheus/_lib/include/morpheus/messages/multi.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/messages/multi_inference.hpp
+++ b/morpheus/_lib/include/morpheus/messages/multi_inference.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/messages/multi_inference_fil.hpp
+++ b/morpheus/_lib/include/morpheus/messages/multi_inference_fil.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/messages/multi_inference_nlp.hpp
+++ b/morpheus/_lib/include/morpheus/messages/multi_inference_nlp.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/messages/multi_response.hpp
+++ b/morpheus/_lib/include/morpheus/messages/multi_response.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/messages/multi_response_probs.hpp
+++ b/morpheus/_lib/include/morpheus/messages/multi_response_probs.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/messages/multi_tensor.hpp
+++ b/morpheus/_lib/include/morpheus/messages/multi_tensor.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/modules/data_loader_module.hpp
+++ b/morpheus/_lib/include/morpheus/modules/data_loader_module.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/objects/data_table.hpp
+++ b/morpheus/_lib/include/morpheus/objects/data_table.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/objects/dev_mem_info.hpp
+++ b/morpheus/_lib/include/morpheus/objects/dev_mem_info.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/objects/dtype.hpp
+++ b/morpheus/_lib/include/morpheus/objects/dtype.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/objects/factory_registry.hpp
+++ b/morpheus/_lib/include/morpheus/objects/factory_registry.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/objects/fiber_queue.hpp
+++ b/morpheus/_lib/include/morpheus/objects/fiber_queue.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/objects/file_types.hpp
+++ b/morpheus/_lib/include/morpheus/objects/file_types.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/objects/filter_source.hpp
+++ b/morpheus/_lib/include/morpheus/objects/filter_source.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/objects/memory_descriptor.hpp
+++ b/morpheus/_lib/include/morpheus/objects/memory_descriptor.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/objects/mutable_table_ctx_mgr.hpp
+++ b/morpheus/_lib/include/morpheus/objects/mutable_table_ctx_mgr.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/objects/python_data_table.hpp
+++ b/morpheus/_lib/include/morpheus/objects/python_data_table.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/objects/rmm_tensor.hpp
+++ b/morpheus/_lib/include/morpheus/objects/rmm_tensor.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/objects/table_info.hpp
+++ b/morpheus/_lib/include/morpheus/objects/table_info.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/objects/table_info_data.hpp
+++ b/morpheus/_lib/include/morpheus/objects/table_info_data.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/objects/tensor.hpp
+++ b/morpheus/_lib/include/morpheus/objects/tensor.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/objects/tensor_object.hpp
+++ b/morpheus/_lib/include/morpheus/objects/tensor_object.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/objects/wrapped_tensor.hpp
+++ b/morpheus/_lib/include/morpheus/objects/wrapped_tensor.hpp
@@ -1,5 +1,5 @@
 
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/stages/add_classification.hpp
+++ b/morpheus/_lib/include/morpheus/stages/add_classification.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/stages/add_scores.hpp
+++ b/morpheus/_lib/include/morpheus/stages/add_scores.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/stages/add_scores_stage_base.hpp
+++ b/morpheus/_lib/include/morpheus/stages/add_scores_stage_base.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/stages/deserialize.hpp
+++ b/morpheus/_lib/include/morpheus/stages/deserialize.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/stages/file_source.hpp
+++ b/morpheus/_lib/include/morpheus/stages/file_source.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/stages/filter_detection.hpp
+++ b/morpheus/_lib/include/morpheus/stages/filter_detection.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/stages/kafka_source.hpp
+++ b/morpheus/_lib/include/morpheus/stages/kafka_source.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/stages/preallocate.hpp
+++ b/morpheus/_lib/include/morpheus/stages/preallocate.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/stages/preprocess_fil.hpp
+++ b/morpheus/_lib/include/morpheus/stages/preprocess_fil.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/stages/preprocess_nlp.hpp
+++ b/morpheus/_lib/include/morpheus/stages/preprocess_nlp.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/stages/serialize.hpp
+++ b/morpheus/_lib/include/morpheus/stages/serialize.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/stages/triton_inference.hpp
+++ b/morpheus/_lib/include/morpheus/stages/triton_inference.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/stages/write_to_file.hpp
+++ b/morpheus/_lib/include/morpheus/stages/write_to_file.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/types.hpp
+++ b/morpheus/_lib/include/morpheus/types.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/utilities/cudf_util.hpp
+++ b/morpheus/_lib/include/morpheus/utilities/cudf_util.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/utilities/cupy_util.hpp
+++ b/morpheus/_lib/include/morpheus/utilities/cupy_util.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/utilities/matx_util.hpp
+++ b/morpheus/_lib/include/morpheus/utilities/matx_util.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/utilities/python_util.hpp
+++ b/morpheus/_lib/include/morpheus/utilities/python_util.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/utilities/stage_util.hpp
+++ b/morpheus/_lib/include/morpheus/utilities/stage_util.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/utilities/string_util.hpp
+++ b/morpheus/_lib/include/morpheus/utilities/string_util.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/utilities/table_util.hpp
+++ b/morpheus/_lib/include/morpheus/utilities/table_util.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/include/morpheus/utilities/tensor_util.hpp
+++ b/morpheus/_lib/include/morpheus/utilities/tensor_util.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/io/data_loader.cpp
+++ b/morpheus/_lib/src/io/data_loader.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/io/data_loader_registry.cpp
+++ b/morpheus/_lib/src/io/data_loader_registry.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/io/deserializers.cpp
+++ b/morpheus/_lib/src/io/deserializers.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/io/serializers.cpp
+++ b/morpheus/_lib/src/io/serializers.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/messages/control.cpp
+++ b/morpheus/_lib/src/messages/control.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/messages/memory/inference_memory.cpp
+++ b/morpheus/_lib/src/messages/memory/inference_memory.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/messages/memory/inference_memory_fil.cpp
+++ b/morpheus/_lib/src/messages/memory/inference_memory_fil.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/messages/memory/inference_memory_nlp.cpp
+++ b/morpheus/_lib/src/messages/memory/inference_memory_nlp.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/messages/memory/response_memory.cpp
+++ b/morpheus/_lib/src/messages/memory/response_memory.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/messages/memory/response_memory_probs.cpp
+++ b/morpheus/_lib/src/messages/memory/response_memory_probs.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/messages/memory/tensor_memory.cpp
+++ b/morpheus/_lib/src/messages/memory/tensor_memory.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/messages/meta.cpp
+++ b/morpheus/_lib/src/messages/meta.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/messages/multi.cpp
+++ b/morpheus/_lib/src/messages/multi.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/messages/multi_inference.cpp
+++ b/morpheus/_lib/src/messages/multi_inference.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/messages/multi_inference_fil.cpp
+++ b/morpheus/_lib/src/messages/multi_inference_fil.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/messages/multi_inference_nlp.cpp
+++ b/morpheus/_lib/src/messages/multi_inference_nlp.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/messages/multi_response.cpp
+++ b/morpheus/_lib/src/messages/multi_response.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/messages/multi_response_probs.cpp
+++ b/morpheus/_lib/src/messages/multi_response_probs.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/messages/multi_tensor.cpp
+++ b/morpheus/_lib/src/messages/multi_tensor.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/modules/data_loader_module.cpp
+++ b/morpheus/_lib/src/modules/data_loader_module.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/objects/data_table.cpp
+++ b/morpheus/_lib/src/objects/data_table.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/objects/dev_mem_info.cpp
+++ b/morpheus/_lib/src/objects/dev_mem_info.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/objects/dtype.cpp
+++ b/morpheus/_lib/src/objects/dtype.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/objects/fiber_queue.cpp
+++ b/morpheus/_lib/src/objects/fiber_queue.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/objects/file_types.cpp
+++ b/morpheus/_lib/src/objects/file_types.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/objects/memory_descriptor.cpp
+++ b/morpheus/_lib/src/objects/memory_descriptor.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/morpheus/_lib/src/objects/memory_descriptor.cpp
+++ b/morpheus/_lib/src/objects/memory_descriptor.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/objects/mutable_table_ctx_mgr.cpp
+++ b/morpheus/_lib/src/objects/mutable_table_ctx_mgr.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/objects/python_data_table.cpp
+++ b/morpheus/_lib/src/objects/python_data_table.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/objects/rmm_tensor.cpp
+++ b/morpheus/_lib/src/objects/rmm_tensor.cpp
@@ -29,7 +29,7 @@
 #include <rmm/cuda_stream_view.hpp>  // for cuda_stream_per_thread
 #include <rmm/device_buffer.hpp>
 
-#include <algorithm>   // for copy, transform
+#include <algorithm>  // for copy, transform
 #include <functional>  // for multiplies, plus, minus
 #include <iterator>    // for back_insert_iterator, back_inserter
 #include <memory>

--- a/morpheus/_lib/src/objects/rmm_tensor.cpp
+++ b/morpheus/_lib/src/objects/rmm_tensor.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -29,7 +29,7 @@
 #include <rmm/cuda_stream_view.hpp>  // for cuda_stream_per_thread
 #include <rmm/device_buffer.hpp>
 
-#include <algorithm>  // for copy, transform
+#include <algorithm>   // for copy, transform
 #include <functional>  // for multiplies, plus, minus
 #include <iterator>    // for back_insert_iterator, back_inserter
 #include <memory>

--- a/morpheus/_lib/src/objects/table_info.cpp
+++ b/morpheus/_lib/src/objects/table_info.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/objects/table_info_data.cpp
+++ b/morpheus/_lib/src/objects/table_info_data.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/objects/tensor.cpp
+++ b/morpheus/_lib/src/objects/tensor.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/objects/tensor_object.cpp
+++ b/morpheus/_lib/src/objects/tensor_object.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/objects/wrapped_tensor.cpp
+++ b/morpheus/_lib/src/objects/wrapped_tensor.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/python_modules/common.cpp
+++ b/morpheus/_lib/src/python_modules/common.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/python_modules/messages.cpp
+++ b/morpheus/_lib/src/python_modules/messages.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/python_modules/modules.cpp
+++ b/morpheus/_lib/src/python_modules/modules.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/python_modules/stages.cpp
+++ b/morpheus/_lib/src/python_modules/stages.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/stages/add_classification.cpp
+++ b/morpheus/_lib/src/stages/add_classification.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/stages/add_scores.cpp
+++ b/morpheus/_lib/src/stages/add_scores.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/stages/add_scores_stage_base.cpp
+++ b/morpheus/_lib/src/stages/add_scores_stage_base.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/stages/deserialize.cpp
+++ b/morpheus/_lib/src/stages/deserialize.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/stages/file_source.cpp
+++ b/morpheus/_lib/src/stages/file_source.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/stages/filter_detection.cpp
+++ b/morpheus/_lib/src/stages/filter_detection.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/stages/kafka_source.cpp
+++ b/morpheus/_lib/src/stages/kafka_source.cpp
@@ -57,6 +57,17 @@
 // IWYU pragma: no_include <atomic>
 // IWYU pragma: no_include <ext/alloc_traits.h>
 
+/**
+ * @addtogroup stages
+ * @{
+ * @file
+ */
+
+/**
+ * @brief Checks the error code returned by an RDKafka expression (`command`) against an `expected` code
+ * (usually `RdKafka::ERR_NO_ERROR`), and logs an error otherwise.
+ *
+ */
 #define CHECK_KAFKA(command, expected, msg)                                                                    \
     {                                                                                                          \
         RdKafka::ErrorCode __code = command;                                                                   \

--- a/morpheus/_lib/src/stages/kafka_source.cpp
+++ b/morpheus/_lib/src/stages/kafka_source.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/stages/preprocess_fil.cpp
+++ b/morpheus/_lib/src/stages/preprocess_fil.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/stages/preprocess_nlp.cpp
+++ b/morpheus/_lib/src/stages/preprocess_nlp.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/stages/serialize.cpp
+++ b/morpheus/_lib/src/stages/serialize.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/stages/triton_inference.cpp
+++ b/morpheus/_lib/src/stages/triton_inference.cpp
@@ -58,6 +58,16 @@
 #include <utility>
 // IWYU pragma: no_include <initializer_list>
 
+/**
+ * @addtogroup stages
+ * @{
+ * @file
+ */
+
+/**
+ * @brief Checks the status object returned by a Triton client call logging any potential errors.
+ *
+ */
 #define CHECK_TRITON(method) ::InferenceClientStage__check_triton_errors(method, #method, __FILE__, __LINE__);
 
 namespace {

--- a/morpheus/_lib/src/stages/triton_inference.cpp
+++ b/morpheus/_lib/src/stages/triton_inference.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/stages/write_to_file.cpp
+++ b/morpheus/_lib/src/stages/write_to_file.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/utilities/cudf_util.cpp
+++ b/morpheus/_lib/src/utilities/cudf_util.cpp
@@ -27,7 +27,7 @@
 #include <memory>
 #include <ostream>  // Needed for logging
 #include <utility>  // for move
-/**
+/*
  * **************This needs to come last.********************
  * A note to posterity: We only ever want to have a single place where cudf_helpers_api.h is included in any
  * translation unit.

--- a/morpheus/_lib/src/utilities/cudf_util.cpp
+++ b/morpheus/_lib/src/utilities/cudf_util.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/utilities/cupy_util.cpp
+++ b/morpheus/_lib/src/utilities/cupy_util.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/utilities/matx_util.cu
+++ b/morpheus/_lib/src/utilities/matx_util.cu
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/utilities/python_util.cpp
+++ b/morpheus/_lib/src/utilities/python_util.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/utilities/string_util.cpp
+++ b/morpheus/_lib/src/utilities/string_util.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/utilities/table_util.cpp
+++ b/morpheus/_lib/src/utilities/table_util.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/src/utilities/tensor_util.cpp
+++ b/morpheus/_lib/src/utilities/tensor_util.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/tests/test_cuda.cu
+++ b/morpheus/_lib/tests/test_cuda.cu
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/tests/test_dev_mem_info.cpp
+++ b/morpheus/_lib/tests/test_dev_mem_info.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/tests/test_main.cpp
+++ b/morpheus/_lib/tests/test_main.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/tests/test_matx_util.cpp
+++ b/morpheus/_lib/tests/test_matx_util.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/tests/test_morpheus.cpp
+++ b/morpheus/_lib/tests/test_morpheus.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/tests/test_morpheus.hpp
+++ b/morpheus/_lib/tests/test_morpheus.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/morpheus/_lib/tests/test_tensor.cpp
+++ b/morpheus/_lib/tests/test_tensor.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *


### PR DESCRIPTION
## Description
* Fix accidental parsing of license headers (fixes #837 )
* Exclude auto-generated namespaces prefixed with '@' from doxygen (fixes #836)
* Fix documentation for `CHECK_TRITON` and `CHECK_KAFKA` macros (fixes #835)


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
