### PR TITLE
Removing explicit driver install from CI runner

### DIFF
--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -122,7 +122,7 @@ jobs:
   test:
     name: Test
     needs: [build]
-    runs-on: [self-hosted, linux, amd64, gpu-v100-525-1]
+    runs-on: [self-hosted, linux, amd64, gpu-v100-latest-1]
     timeout-minutes: 60
     container:
       credentials:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -46,7 +46,7 @@ jobs:
     uses: ./.github/workflows/ci_pipe.yml
     with:
       run_check: ${{ startsWith(github.ref_name, 'pull-request/') }}
-      container: nvcr.io/ea-nvidia-morpheus/morpheus:morpheus-ci-driver-230315
-      test_container: nvcr.io/ea-nvidia-morpheus/morpheus:morpheus-ci-test-230315
+      container: nvcr.io/ea-nvidia-morpheus/morpheus:morpheus-ci-build-230412
+      test_container: nvcr.io/ea-nvidia-morpheus/morpheus:morpheus-ci-test-230412
     secrets:
       NGC_API_KEY: ${{ secrets.NGC_API_KEY }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -46,7 +46,7 @@ jobs:
     uses: ./.github/workflows/ci_pipe.yml
     with:
       run_check: ${{ startsWith(github.ref_name, 'pull-request/') }}
-      container: nvcr.io/ea-nvidia-morpheus/morpheus:morpheus-ci-build-230412
-      test_container: nvcr.io/ea-nvidia-morpheus/morpheus:morpheus-ci-test-230412
+      container: nvcr.io/ea-nvidia-morpheus/morpheus:morpheus-ci-build-230413
+      test_container: nvcr.io/ea-nvidia-morpheus/morpheus:morpheus-ci-test-230413
     secrets:
       NGC_API_KEY: ${{ secrets.NGC_API_KEY }}

--- a/ci/runner/Dockerfile
+++ b/ci/runner/Dockerfile
@@ -50,8 +50,10 @@ RUN CONDA_ALWAYS_YES=true /opt/conda/bin/mamba env create -n ${PROJ_NAME} -q --f
     rm -rf /tmp/conda
 
 
-# ============ driver ==================
-FROM base as driver
+# ============ build ==================
+FROM base as build
+
+# Add any build only dependencies here.
 
 ARG CUDA_PKG_VER
 
@@ -63,13 +65,14 @@ RUN apt update && \
     libcufft-dev-${CUDA_PKG_VER} \
     libcurand-dev-${CUDA_PKG_VER} \
     libcusolver-dev-${CUDA_PKG_VER} \
-    libnvidia-compute-525 && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*
 
 
 # ============ test ==================
 FROM base as test
+
+# Add any test only dependencies here.
 
 ARG PROJ_NAME
 

--- a/ci/runner/Dockerfile
+++ b/ci/runner/Dockerfile
@@ -64,7 +64,7 @@ RUN apt update && \
     libcublas-dev-${CUDA_PKG_VER} \
     libcufft-dev-${CUDA_PKG_VER} \
     libcurand-dev-${CUDA_PKG_VER} \
-    libcusolver-dev-${CUDA_PKG_VER} \
+    libcusolver-dev-${CUDA_PKG_VER} && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -147,9 +147,10 @@ autodoc_typehints_description_target = "documented"  # Dont double up on type hi
 add_module_names = False  # Remove namespaces from class/method signatures
 myst_heading_anchors = 4  # Generate links for markdown headers
 autodoc_mock_imports = [
+    "cudf",  # Avoid loading GPU libraries during the documentation build
     "morpheus.cli.commands",  # Dont document the CLI in Sphinx
-    "tqdm",
     "tensorrt",
+    "tqdm",
 ]
 
 # Config numpydoc


### PR DESCRIPTION
## Description
This PR is follows the MRC PR: https://github.com/nv-morpheus/MRC/pull/313 which removes the explicit dependency on `libnvidia-ml.so` which allows us to no longer need the driver installed in our CI runner.

This allows us to use the `gpu-v100-latest-1` tag to stay up to date with the CI images.

@jjacobelli for Viz