### PR TITLE
Use new cudf C++ json writer

### DIFF
--- a/morpheus/_lib/include/morpheus/io/serializers.hpp
+++ b/morpheus/_lib/include/morpheus/io/serializers.hpp
@@ -68,10 +68,8 @@ std::string df_to_csv(const TableInfo& tbl, bool include_header, bool include_in
  * @param out_stream : Output stream to write the results to a destination
  * @param include_index_col : Determines whether or not to include the dataframe index
  * @param flush : When `true` flush `out_stream`.
- *
- * Requires MutableTableInfo since there is no C++ implementation of the JSON writer
  */
-void df_to_json(MutableTableInfo& tbl, std::ostream& out_stream, bool include_index_col = true, bool flush = false);
+void df_to_json(const TableInfo& tbl, std::ostream& out_stream, bool include_index_col = true, bool flush = false);
 
 /**
  * @brief Serialize a dataframe into a JSON formatted string
@@ -81,12 +79,11 @@ void df_to_json(MutableTableInfo& tbl, std::ostream& out_stream, bool include_in
  *
  * Note the include_index_col is currently being ignored in both versions of `df_to_json` due to a known issue in
  * Pandas: https://github.com/pandas-dev/pandas/issues/37600
- * Requires MutableTableInfo since there is no C++ implementation of the JSON writer
  */
-std::string df_to_json(MutableTableInfo& tbl, bool include_index_col = true);
+std::string df_to_json(const TableInfo& tbl, bool include_index_col = true);
 
 /**
- * @brief Serialize a dataframe to an output stream in CSV format
+ * @brief Serialize a dataframe to an output stream in Parquet format
  *
  * @param tbl : A wrapper around data in the dataframe
  * @param out_stream : Output stream to write the results to a destination
@@ -101,7 +98,7 @@ void df_to_parquet(const TableInfo& tbl,
                    bool flush             = false);
 
 /**
- * @brief Serialize a dataframe to an output stream in JSON format
+ * @brief Serialize a dataframe to an output stream in Parquet format
  *
  * @param tbl : A wrapper around data in the dataframe
  * @param include_header : Determines whether or not to include the header
@@ -111,7 +108,7 @@ void df_to_parquet(const TableInfo& tbl,
 std::string df_to_parquet(const TableInfo& tbl, bool include_header, bool include_index_col = true);
 
 /**
- * @brief Loads a cudf table from either CSV or JSON file returning the DataFrame as a Python object
+ * @brief Loads a cudf table from a CSV, JSON or Parquet file returning the DataFrame as a Python object
  *
  * @param filename : Name of the file that should be loaded into a table
  * @return pybind11::object

--- a/morpheus/_lib/src/io/serializers.cpp
+++ b/morpheus/_lib/src/io/serializers.cpp
@@ -157,9 +157,12 @@ void table_to_json(const TableInfoData& tbl, std::ostream& out_stream, bool incl
     std::iota(col_idexes.begin(), col_idexes.end(), 1);
     auto tbl_view = tbl.table_view.select(col_idexes);
 
+    cudf::io::table_metadata tbl_meta{
+        std::vector<cudf::io::column_name_info>{column_names.cbegin(), column_names.cend()}};
+
     OStreamSink sink(out_stream);
     auto destination     = cudf::io::sink_info(&sink);
-    auto options_builder = cudf::io::json_writer_options_builder(destination, tbl_view).lines(true);
+    auto options_builder = cudf::io::json_writer_options_builder(destination, tbl_view).metadata(tbl_meta).lines(true);
 
     cudf::io::write_json(options_builder.build(), rmm::mr::get_current_device_resource());
 

--- a/morpheus/_lib/src/io/serializers.cpp
+++ b/morpheus/_lib/src/io/serializers.cpp
@@ -29,15 +29,11 @@
 #include <cudf/types.hpp>
 #include <glog/logging.h>
 #include <pybind11/cast.h>
-#include <pybind11/gil.h>
-#include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
 #include <pybind11/stl.h>  // IWYU pragma: keep
 #include <rmm/mr/device/per_device_resource.hpp>
 
-#include <array>      // for array
-#include <cstddef>    // for size_t
-#include <exception>  // for exception
+#include <cstddef>  // for size_t
 #include <fstream>
 #include <numeric>
 #include <sstream>  // IWYU pragma: keep

--- a/morpheus/_lib/src/io/serializers.cpp
+++ b/morpheus/_lib/src/io/serializers.cpp
@@ -22,6 +22,7 @@
 
 #include <cudf/io/csv.hpp>
 #include <cudf/io/data_sink.hpp>
+#include <cudf/io/json.hpp>
 #include <cudf/io/parquet.hpp>
 #include <cudf/io/types.hpp>  // for column_name_info, sink_info, table_metadata
 #include <cudf/table/table_view.hpp>
@@ -144,58 +145,39 @@ std::string df_to_csv(const TableInfo& tbl, bool include_header, bool include_in
     return out_stream.str();
 }
 
-void table_to_json(py::object tbl, std::ostream& out_stream, bool include_index_col, bool flush)
+void table_to_json(const TableInfoData& tbl, std::ostream& out_stream, bool include_index_col, bool flush)
 {
     if (!include_index_col)
     {
         LOG(WARNING) << "Ignoring include_index_col=false as this isn't supported by cuDF";
     }
 
-    std::string results;
+    auto column_names = tbl.column_names;
+    std::vector<cudf::size_type> col_idexes(column_names.size());
+    std::iota(col_idexes.begin(), col_idexes.end(), 1);
+    auto tbl_view = tbl.table_view.select(col_idexes);
 
-    // no cpp impl for to_json, instead python module converts to pandas and calls to_json
-    {
-        py::gil_scoped_acquire gil;
-        py::object StringIO = py::module_::import("io").attr("StringIO");
-        auto buffer         = StringIO();
+    OStreamSink sink(out_stream);
+    auto destination     = cudf::io::sink_info(&sink);
+    auto options_builder = cudf::io::json_writer_options_builder(destination, tbl_view).lines(true);
 
-        try
-        {
-            py::dict kwargs = py::dict("orient"_a = "records", "lines"_a = true);
-
-            tbl.attr("to_json")(buffer, **kwargs);
-
-            buffer.attr("seek")(0);
-
-        } catch (std::exception& ex)
-        {
-            LOG(ERROR) << "Error during serialization to JSON. Message: " << ex.what();
-            throw ex;
-        }
-
-        py::object pyresults = buffer.attr("getvalue")();
-        results              = pyresults.cast<std::string>();
-    }
-
-    // Now write the contents to the stream
-    out_stream.write(results.data(), results.size());
+    cudf::io::write_json(options_builder.build(), rmm::mr::get_current_device_resource());
 
     if (flush)
     {
-        out_stream.flush();
+        sink.flush();
     }
 }
 
-void df_to_json(MutableTableInfo& tbl, std::ostream& out_stream, bool include_index_col, bool flush)
+void df_to_json(const TableInfo& tbl, std::ostream& out_stream, bool include_index_col, bool flush)
 {
-    py::gil_scoped_acquire gil;
-
-    auto df = CudfHelper::table_from_table_info(tbl);
-
-    table_to_json(std::move(df), out_stream, include_index_col, flush);
+    table_to_json(TableInfoData{tbl.get_view(), tbl.get_index_names(), tbl.get_column_names()},
+                  out_stream,
+                  include_index_col,
+                  flush);
 }
 
-std::string df_to_json(MutableTableInfo& tbl, bool include_index_col)
+std::string df_to_json(const TableInfo& tbl, bool include_index_col)
 {
     // Create an ostringstream and use that with the overload accepting an ostream
     std::ostringstream out_stream;
@@ -276,17 +258,19 @@ void SerializersProxy::write_df_to_file(pybind11::object df,
     std::ofstream out_file;
     out_file.open(filename);
 
+    auto tbl = CudfHelper::CudfHelper::table_info_data_from_table(df);
+
     switch (file_type)
     {
     case FileTypes::JSON: {
-        table_to_json(df,
+        table_to_json(tbl,
                       out_file,
                       get_with_default(kwargs, "include_index_col", true),
                       get_with_default(kwargs, "flush", false));
         break;
     }
     case FileTypes::CSV: {
-        table_to_csv(CudfHelper::CudfHelper::table_info_data_from_table(df),
+        table_to_csv(tbl,
                      out_file,
                      get_with_default(kwargs, "include_header", true),
                      get_with_default(kwargs, "include_index_col", true),

--- a/morpheus/_lib/src/stages/write_to_file.cpp
+++ b/morpheus/_lib/src/stages/write_to_file.cpp
@@ -80,9 +80,8 @@ WriteToFileStage::WriteToFileStage(
 
 void WriteToFileStage::write_json(WriteToFileStage::sink_type_t& msg)
 {
-    auto mutable_info = msg->get_mutable_info();
     // Call df_to_json passing our fstream
-    df_to_json(mutable_info, m_fstream, m_include_index_col, m_flush);
+    df_to_json(msg->get_info(), m_fstream, m_include_index_col, m_flush);
 }
 
 void WriteToFileStage::write_csv(WriteToFileStage::sink_type_t& msg)

--- a/morpheus/_lib/tests/test_file_in_out.cpp
+++ b/morpheus/_lib/tests/test_file_in_out.cpp
@@ -101,6 +101,7 @@ TEST_F(TestFileInOut, RoundTripJSON)
 
     auto meta = MessageMeta::create_from_cpp(std::move(table), index_col_count);
 
+    pybind11::gil_scoped_release no_gil;
     auto output_str = df_to_json(meta->get_info());
     boost::trim(output_str);
     std::vector<std::string> output_lines;

--- a/morpheus/_lib/tests/test_file_in_out.cpp
+++ b/morpheus/_lib/tests/test_file_in_out.cpp
@@ -101,10 +101,7 @@ TEST_F(TestFileInOut, RoundTripJSON)
 
     auto meta = MessageMeta::create_from_cpp(std::move(table), index_col_count);
 
-    pybind11::gil_scoped_release no_gil;
-    auto mutable_info = meta->get_mutable_info();
-
-    auto output_str = df_to_json(mutable_info);
+    auto output_str = df_to_json(meta->get_info());
     boost::trim(output_str);
     std::vector<std::string> output_lines;
     boost::split(output_lines, output_str, boost::is_any_of("\n"));


### PR DESCRIPTION
## Description
* Allows for writing JSON data in C++ without acquiring the gil
* Uses new C++ JSON writer in cudf added in v23.02
* Technically this is a breaking as the signature of the `df_to_json`  functions changed from accepting  `MutableTableInfo&` to `const TableInfo&`, however this isn't a breaking change for users of the Python API

fixes #761

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
