### PR TITLE
[ENH] Label External Issues: Update secret, add discussions

### DIFF
--- a/.github/workflows/label-external-issues.yml
+++ b/.github/workflows/label-external-issues.yml
@@ -20,9 +20,13 @@ on:
     types:
       - opened
       
+  discussion:
+    types:
+      - created
+      
 env:
-  GITHUB_TOKEN: ${{ github.token }}
-  # Label ID from an external graphQL query, represents '? - Needs Triage'
+  GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_PAT }}
+  # Label ID from an external graphQL query, represents 'Needs Triage'
   LABEL_ID: LA_kwDOFrb0NM7yzEQv
 
 permissions:


### PR DESCRIPTION
## Description
This PR updates the secret in the external issue labeler GHA to use one with permissions to see who is a member of `nv-morpheus`.

It also auto-labels new external discussions with the `Needs Triage` label as well.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
