### PR TITLE
[ENH] Change external labeler to use the GH CLI for fine-grained token support

### DIFF
--- a/.github/workflows/label-external-issues.yml
+++ b/.github/workflows/label-external-issues.yml
@@ -35,5 +35,5 @@ jobs:
     steps: 
       - name: add-triage-label
         run: |
-          issue_url=${{ github.event.issue.url }}
-          gh issue edit ${issue_url} --add-label "Needs Triage"
+          issue_number=${{ github.event.issue.number }}
+          gh issue edit ${issue_number} --add-label "Needs Triage"

--- a/.github/workflows/label-external-issues.yml
+++ b/.github/workflows/label-external-issues.yml
@@ -36,6 +36,4 @@ jobs:
       - name: add-triage-label
         run: |
           issue_number=${{ github.event.issue.number }}
-          label="Needs Triage"
-
-          gh issue label add "${issue_number}" "${label}"
+          gh issue edit "${issue_number}" --add-label "Needs Triage"

--- a/.github/workflows/label-external-issues.yml
+++ b/.github/workflows/label-external-issues.yml
@@ -27,9 +27,6 @@ on:
 env:
   GITHUB_TOKEN: ${{ github.token }}
 
-permissions:
-  issues: write
-
 jobs:
   Label-Issue:
     runs-on: ubuntu-latest
@@ -41,5 +38,4 @@ jobs:
           issue_number=${{ github.event.issue.number }}
           label="Needs Triage"
 
-          gh auth login --with-token <<< "${GITHUB_TOKEN}"
           gh issue label add "${issue_number}" "${label}"

--- a/.github/workflows/label-external-issues.yml
+++ b/.github/workflows/label-external-issues.yml
@@ -25,9 +25,7 @@ on:
       - created
       
 env:
-  GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_PAT }}
-  # Label ID from an external graphQL query, represents 'Needs Triage'
-  LABEL_ID: LA_kwDOFrb0NM7yzEQv
+  GITHUB_TOKEN: ${{ github.token }}
 
 permissions:
   issues: write
@@ -40,12 +38,8 @@ jobs:
     steps: 
       - name: add-triage-label
         run: |
-          gh api graphql -f query='
-            mutation {
-              addLabelsToLabelable(input: {labelableId : "${{ github.event.issue.node_id }}" , 
-                                           labelIds: [ "${{ env.LABEL_ID }}" ]
-                                           }
-                                   ){
-                                     clientMutationId
-                                     }
-                       }'
+          issue_number=${{ github.event.issue.number }}
+          label="Needs Triage"
+
+          gh auth login --with-token <<< "${GITHUB_TOKEN}"
+          gh issue label add "${issue_number}" "${label}"

--- a/.github/workflows/label-external-issues.yml
+++ b/.github/workflows/label-external-issues.yml
@@ -20,10 +20,6 @@ on:
     types:
       - opened
       
-  discussion:
-    types:
-      - created
-      
 env:
   GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_PAT }}
 

--- a/.github/workflows/label-external-issues.yml
+++ b/.github/workflows/label-external-issues.yml
@@ -25,7 +25,7 @@ on:
       - created
       
 env:
-  GITHUB_TOKEN: ${{ github.token }}
+  GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_SECRET }}
 
 jobs:
   Label-Issue:

--- a/.github/workflows/label-external-issues.yml
+++ b/.github/workflows/label-external-issues.yml
@@ -36,4 +36,4 @@ jobs:
       - name: add-triage-label
         run: |
           issue_url=${{ github.event.issue.url }}
-          gh issue edit "${issue_url}" --add-label "Needs Triage"
+          gh issue edit ${issue_url} --add-label "Needs Triage"

--- a/.github/workflows/label-external-issues.yml
+++ b/.github/workflows/label-external-issues.yml
@@ -35,5 +35,5 @@ jobs:
     steps: 
       - name: add-triage-label
         run: |
-          issue_number=${{ github.event.issue.number }}
-          gh issue edit "${issue_number}" --add-label "Needs Triage"
+          issue_url=${{ github.event.issue.url }}
+          gh issue edit "${issue_url}" --add-label "Needs Triage"

--- a/.github/workflows/label-external-issues.yml
+++ b/.github/workflows/label-external-issues.yml
@@ -35,5 +35,5 @@ jobs:
     steps: 
       - name: add-triage-label
         run: |
-          issue_number=${{ github.event.issue.number }}
-          gh issue edit ${issue_number} --add-label "Needs Triage"
+          issue_url=${{ github.event.issue.html_url }}
+          gh issue edit ${issue_url} --add-label "Needs Triage"

--- a/.github/workflows/label-external-issues.yml
+++ b/.github/workflows/label-external-issues.yml
@@ -25,7 +25,7 @@ on:
       - created
       
 env:
-  GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_SECRET }}
+  GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_PAT }}
 
 jobs:
   Label-Issue:


### PR DESCRIPTION
## Description
This PR rewrites the action from `graphQL` to `gh cli`. 

~Functionality should remain the same.~ Removed discussions since they're not supported by the gh cli.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
