### PR TITLE
Improve DFP period functionality to allow for better sampling and ignoring period

### DIFF
--- a/examples/digital_fingerprinting/production/morpheus/dfp/stages/dfp_file_batcher_stage.py
+++ b/examples/digital_fingerprinting/production/morpheus/dfp/stages/dfp_file_batcher_stage.py
@@ -78,7 +78,6 @@ class DFPFileBatcherStage(SinglePortStage):
         file_objs = []
 
         # Determine the date of the file, and apply the window filter if we have one
-        ts_and_files = []
         for file_object in file_objects:
             ts = self._date_conversion_func(file_object)
 

--- a/examples/digital_fingerprinting/production/morpheus/dfp_duo_pipeline.py
+++ b/examples/digital_fingerprinting/production/morpheus/dfp_duo_pipeline.py
@@ -111,7 +111,7 @@ from morpheus.utils.logger import configure_logging
               type=int,
               default=0,
               show_envvar=True,
-              help="Minimum time step, in milliseconds, between object logs.")
+              help="Samples the input data files allowing only one file per bin defined by `sample_rate_s`.")
 @click.option(
     "--input_file",
     "-f",
@@ -248,8 +248,8 @@ def run_pipeline(train_users,
     # Batch files into buckets by time. Use the default ISO date extractor from the filename
     pipeline.add_stage(
         DFPFileBatcherStage(config,
-                            period="D",
-                            sampling_rate_s=sample_rate_s,
+                            period=None,
+                            sampling=f"{sample_rate_s}S" if sample_rate_s > 0 else None,
                             date_conversion_func=functools.partial(date_extractor, filename_regex=iso_date_regex),
                             start_time=start_time,
                             end_time=end_time))


### PR DESCRIPTION
## Description
Currently, the DFP pipeline simulates time by breaking incoming messages up by a specific period and processing each period independently. This makes it impossible to process all of the incoming data at once for batch mode with a single trained model.

This PR adds a few things:

- If `DFPFileBatcherStage.period == None`, then all messages will be processed in a single batch, instead of per period
- Fixes how periods were handled to work with counts
   - Before, `"D"` would work as expected but `"5D"` would not. This was due to using `to_period`
- The `DFPFileBatcherStage.sampling_rate_s` property was deprecated in favor of a more general `sampling` property
   - This property can support different values
      - If its a string, the value is interpreted as a frequency. The first row for each frequency will be taken
      - If its a value between [0,1), its a fraction. A percentage of rows will be taken
      - If its >=1, its a count. A random count of rows will be taken

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
