### PR TITLE
Add CONTRIBUTOR to triage label exception

### DIFF
--- a/.github/workflows/label-external-issues.yml
+++ b/.github/workflows/label-external-issues.yml
@@ -27,7 +27,7 @@ jobs:
   Label-Issue:
     runs-on: ubuntu-latest
     # Only run if the issue author is not part of NV-Morpheus
-    if: ${{ ! contains(fromJSON('["OWNER", "MEMBER"]'), github.event.issue.author_association)}}
+    if: ${{ ! contains(fromJSON('["OWNER", "MEMBER", "CONTRIBUTOR"]'), github.event.issue.author_association)}}
     steps: 
       - name: add-triage-label
         run: |


### PR DESCRIPTION
## Description
The graphQL API prefers to return `CONTRIBUTOR` over `MEMBER` and `OWNER`. This PR adds the exclusion of `CONTRIBUTOR` for labeling with https://github.com/nv-morpheus/Morpheus/labels/Needs%20Triage

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
