### PR TITLE
remove unnecessary quotes from CMAKE_ARGS expression

### DIFF
--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -18,7 +18,7 @@ set -x
 set -e
 
 # Optionally can set INSTALL_PREFIX to build and install to a specific directory. Also causes cmake install to run
-BUILD_DIR=${BUILD_DIR:-"build"}
+BUILD_DIR=${BUILD_DIR:-build}
 
 echo "Runing CMake configure..."
 
@@ -30,10 +30,10 @@ cmake -B ${BUILD_DIR} -GNinja \
    -DMORPHEUS_USE_CLANG_TIDY=OFF \
    -DMORPHEUS_PYTHON_INPLACE_BUILD=ON \
    -DMORPHEUS_USE_CCACHE=ON \
-   -DMORPHEUS_USE_CONDA=${MORPHEUS_USE_CONDA:-"ON"} \
-   ${INSTALL_PREFIX:+"-DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}"} \
-   ${CMAKE_ARGS:+"${CMAKE_ARGS}"} \
-   ${CMAKE_CONFIGURE_EXTRA_ARGS:+"${CMAKE_CONFIGURE_EXTRA_ARGS}"} .
+   -DMORPHEUS_USE_CONDA=${MORPHEUS_USE_CONDA:-ON} \
+   ${INSTALL_PREFIX:+-DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}} \
+   ${CMAKE_ARGS:+${CMAKE_ARGS}} \
+   ${CMAKE_CONFIGURE_EXTRA_ARGS:+${CMAKE_CONFIGURE_EXTRA_ARGS}} .
 
 echo "Running CMake build..."
-cmake --build ${BUILD_DIR} -j ${INSTALL_PREFIX:+"--target install"} "$@"
+cmake --build ${BUILD_DIR} -j ${INSTALL_PREFIX:+--target install} "$@"


### PR DESCRIPTION
Fixes a bug where `CMAKE_ARGS` was being enclosed in extra quotes, causing `CMAKE_ARGS` to be evaluated a single filename, which was not found.

Closes #906 