### PR TITLE
Add COLLABORATOR to exclusion in label-external-issues.yml

### DIFF
--- a/.github/workflows/label-external-issues.yml
+++ b/.github/workflows/label-external-issues.yml
@@ -27,7 +27,7 @@ jobs:
   Label-Issue:
     runs-on: ubuntu-latest
     # Only run if the issue author is not part of NV-Morpheus
-    if: ${{ ! contains(fromJSON('["OWNER", "MEMBER", "CONTRIBUTOR"]'), github.event.issue.author_association)}}
+    if: ${{ ! contains(fromJSON('["OWNER", "MEMBER", "CONTRIBUTOR", "COLLABORATOR"]'), github.event.issue.author_association)}}
     steps: 
       - name: add-triage-label
         run: |


### PR DESCRIPTION
## Description
Sometimes `github.event.issue.authorAssociation` in the workflow will pick `COLLABORATOR` for our team members. This PR adds `COLLABORATOR` to the list of association Enums that we skip the triage label action for.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
