### PR TITLE
Fix build issues & tests

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -284,8 +284,9 @@ RUN --mount=type=cache,id=apt,target=/var/cache/apt \
     rm -rf /var/lib/apt/lists/*
 
 # Install camouflage needed for unittests to mock a triton server
-RUN source activate morpheus &&\
-    npm install -g camouflage-server
+RUN source activate morpheus && \
+    npm install -g camouflage-server@0.9 && \
+    npm cache clean --force
 
 # Setup git to allow other users to access /workspace. Requires git 2.35.3 or
 # greater. See https://marc.info/?l=git&m=164989570902912&w=2. Only enable for

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -284,6 +284,7 @@ RUN --mount=type=cache,id=apt,target=/var/cache/apt \
     rm -rf /var/lib/apt/lists/*
 
 # Install camouflage needed for unittests to mock a triton server
+# Pin to v0.9 until #967 is resolved
 RUN source activate morpheus && \
     npm install -g camouflage-server@0.9 && \
     npm cache clean --force

--- a/docker/conda/environments/cuda11.8_dev.yml
+++ b/docker/conda/environments/cuda11.8_dev.yml
@@ -33,7 +33,7 @@ dependencies:
     - configargparse=1.5
     - cuda-compiler=11.8
     - cuda-nvml-dev=11.8
-    - cudatoolkit=11.8
+    - cuda-toolkit=11.8
     - cudf=23.02
     - cupy=11.6.0
     - cxx-compiler

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -23,7 +23,18 @@ import pytest
 from morpheus.utils.downloader import DOWNLOAD_METHODS_MAP
 from morpheus.utils.downloader import Downloader
 from morpheus.utils.downloader import DownloadMethods
+from utils import import_or_skip
 from utils import TEST_DIRS
+
+
+@pytest.fixture(autouse=True, scope='session')
+def dask_distributed(fail_missing: bool):
+    """
+    Mark tests requiring dask.distributed
+    """
+    yield import_or_skip("dask.distributed",
+                         reason="Downloader requires dask and dask.distributed",
+                         fail_missing=fail_missing)
 
 
 @pytest.mark.usefixtures("restore_environ")

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -23,8 +23,8 @@ import pytest
 from morpheus.utils.downloader import DOWNLOAD_METHODS_MAP
 from morpheus.utils.downloader import Downloader
 from morpheus.utils.downloader import DownloadMethods
-from utils import import_or_skip
 from utils import TEST_DIRS
+from utils import import_or_skip
 
 
 @pytest.fixture(autouse=True, scope='session')

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -63,7 +63,7 @@ def test_constructor_enum_vals(dl_method: DownloadMethods):
                          [DownloadMethods.SINGLE_THREAD, DownloadMethods.DASK, DownloadMethods.DASK_THREAD])
 def test_constructor_env_wins(dl_method: DownloadMethods):
     os.environ['MORPHEUS_FILE_DOWNLOAD_TYPE'] = "multiprocessing"
-    downloader = Downloader(download_method="single_thread")
+    downloader = Downloader(download_method=dl_method)
     assert downloader.download_method == DownloadMethods.MULTIPROCESSING
 
 


### PR DESCRIPTION
## Description
* Restore pin for camouglage v0.9 in Dockerfile, newer versions are incompat
* Skip tests for `morpheus.utils.downloader` when `dask.distributed` is not installed.
* Install `cuda-toolkit` not `cudatoolkit`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
