### PR TITLE
Update .bashrc in container to activate morpheus conda environment

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -132,7 +132,8 @@ RUN --mount=type=cache,id=conda_pkgs,target=/opt/conda/pkgs,sharing=locked \
       python=${PYTHON_VER} && \
     # Clean and activate
     # conda clean -afy && \
-    echo ". /opt/conda/etc/profile.d/conda.sh; conda activate morpheus" >> ~/.bashrc
+    conda init bash && \
+    echo "conda activate morpheus" >> ~/.bashrc
 
 # Set the permenant conda channes to use for morpheus
 RUN source activate morpheus &&\

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -132,7 +132,7 @@ RUN --mount=type=cache,id=conda_pkgs,target=/opt/conda/pkgs,sharing=locked \
       python=${PYTHON_VER} && \
     # Clean and activate
     # conda clean -afy && \
-    sed -i 's/conda activate base/conda activate morpheus/g' ~/.bashrc
+    echo ". /opt/conda/etc/profile.d/conda.sh; conda activate morpheus" >> ~/.bashrc
 
 # Set the permenant conda channes to use for morpheus
 RUN source activate morpheus &&\

--- a/docker/conda/environments/cuda11.8_dev.yml
+++ b/docker/conda/environments/cuda11.8_dev.yml
@@ -33,7 +33,7 @@ dependencies:
     - configargparse=1.5
     - cuda-compiler=11.8
     - cuda-nvml-dev=11.8
-    - cudatoolkit=11.8
+    - cuda-toolkit=11.8
     - cudf=23.02
     - cupy=11.6.0
     - cxx-compiler


### PR DESCRIPTION
## Description
- Update `.bashrc` in container to activate `morpheus` conda environment. Dockerfile was previously using `sed` to replace existing `conda activate base` with `conda activate morpheus`. Base image no longer has `conda activate base` so now just appending `conda activate morpheus` to `.bashrc`.

Fixes #968

## Checklist
[x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
[x] New or existing tests cover these changes.
[x] The documentation is up to date with these changes.
