### PR TITLE
Update to cuda-toolkit in release container

### DIFF
--- a/ci/conda/recipes/morpheus/meta.yaml
+++ b/ci/conda/recipes/morpheus/meta.yaml
@@ -69,9 +69,7 @@ outputs:
         - rapidjson 1.1
         - scikit-build 0.17.1
         - versioneer-518
-
-        # Remove cudatoolkit once `mamba repoquery whoneeds cudatoolkit` is empty. For now, we need to specify a version
-        - cudatoolkit {{ cuda_version }}.*
+        - cuda-toolkit {{ cuda_version }}.*
       run:
         # Runtime only requirements. This + setup.py is the definitive runtime requirement list
         - {{ pin_compatible('cuda-cudart', min_pin='x.x', max_pin='x') }}
@@ -100,7 +98,7 @@ outputs:
         - watchdog 2.1.*
       run_constrained:
         # Since we dont explicitly require this but other packages might, constrain the versions.
-        - {{ pin_compatible('cudatoolkit', min_pin='x.x', max_pin='x') }}
+        - {{ pin_compatible('cuda-toolkit', min_pin='x.x', max_pin='x') }}
     test:
       requires:
         - gputil


### PR DESCRIPTION
## Description
PR #966 fixes new conda environment and dev container builds by replacing `cudatoolkit` with `cuda-toolkit`. This PR does the same to fix the release container build error in issue #973. Updates the conda recipe to use `cuda-toolkit`.

## Checklist
[x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
[x] New or existing tests cover these changes.
[x] The documentation is up to date with these changes.
