### PR TITLE
Fix logging of wrong feature_columns in CLI

### DIFF
--- a/docs/source/cloud_deployment_guide.md
+++ b/docs/source/cloud_deployment_guide.md
@@ -636,7 +636,7 @@ helm install --set ngc.apiKey="$API_KEY" \
         --pipeline_batch_size=1024 \
         --model_max_batch_size=64 \
         --use_cpp=True \
-        pipeline-fil \
+        pipeline-fil --columns_file=data/columns_fil.txt \
           from-file --filename=./examples/data/nvsmi.jsonlines \
           monitor --description 'FromFile Rate' --smoothing=0.001 \
           deserialize \
@@ -661,7 +661,7 @@ helm install --set ngc.apiKey="$API_KEY" \
         --pipeline_batch_size=1024 \
         --model_max_batch_size=64 \
         --use_cpp=True \
-        pipeline-fil \
+        pipeline-fil --columns_file=data/columns_fil.txt \
           from-kafka --input_topic <YOUR_INPUT_KAFKA_TOPIC> --bootstrap_servers broker:9092 \
           monitor --description 'FromKafka Rate' --smoothing=0.001 \
           deserialize \

--- a/examples/abp_nvsmi_detection/README.md
+++ b/examples/abp_nvsmi_detection/README.md
@@ -101,7 +101,7 @@ morpheus --log_level=DEBUG \
    `# Run a pipeline with 8 threads and a model batch size of 32 (Must be equal or less than Triton config)` \
    run --num_threads=8 --pipeline_batch_size=1024 --model_max_batch_size=1024 \
    `# Specify a NLP pipeline with 256 sequence length (Must match Triton config)` \
-   pipeline-fil \
+   pipeline-fil --columns_file=${MORPHEUS_ROOT}/morpheus/data/columns_fil.txt \
    `# 1st Stage: Read from file` \
    from-file --filename=examples/data/nvsmi.jsonlines \
    `# 2nd Stage: Deserialize from JSON strings to objects` \

--- a/morpheus/cli/commands.py
+++ b/morpheus/cli/commands.py
@@ -108,8 +108,7 @@ class PluginGroup(AliasedGroup):
         duplicate_commands = [x for x in plugin_command_list if x in command_list]
 
         if (len(duplicate_commands) > 0):
-            raise RuntimeError("Plugins registered the following duplicate commands: {}".format(
-                ", ".join(duplicate_commands)))
+            raise RuntimeError(f"Plugins registered the following duplicate commands: {', '.join(duplicate_commands)}")
 
         command_list.extend(plugin_command_list)
 
@@ -205,9 +204,9 @@ def onnx_to_trt(ctx: click.Context, **kwargs):
 
     c = ConfigOnnxToTRT()
 
-    for param in kwargs:
+    for (param, val) in kwargs.items():
         if hasattr(c, param):
-            setattr(c, param, kwargs[param])
+            setattr(c, param, val)
 
     from morpheus.utils.onnx_to_trt import gen_engine
 
@@ -229,7 +228,7 @@ def show(shell):
     from morpheus.cli import click_completion_tools
     shell, path, code = click_completion_tools.get_code(shell=shell)
 
-    click.secho("To add %s completion, write the following code to '%s':\n" % (shell, path), fg="blue")
+    click.secho(f"To add {shell} completion, write the following code to '{path}':\n", fg="blue")
     click.echo(code)
 
 
@@ -247,7 +246,7 @@ def install(**kwargs):
     from morpheus.cli import click_completion_tools
     shell, path = click_completion_tools.install_code(**kwargs)
 
-    click.echo('%s completion installed in %s' % (shell, path))
+    click.echo(f'{shell} completion installed in {path}')
 
 
 @cli.group(short_help="Run one of the available pipelines", no_args_is_help=True, cls=AliasedGroup)
@@ -602,7 +601,7 @@ def post_pipeline(ctx: click.Context, *args, **kwargs):
     # TODO(MDD): Move visualization before `pipeline.run()` once Issue #230 is fixed.
     if ("viz_file" in kwargs and kwargs["viz_file"] is not None):
         pipeline.visualize(kwargs["viz_file"], rankdir="LR")
-        click.secho("Pipeline visualization saved to {}".format(kwargs["viz_file"]), fg="yellow")
+        click.secho(f"Pipeline visualization saved to {kwargs['viz_file']}", fg="yellow")
 
 
 # Manually create the subcommands for each command (necessary since commands can be used on multiple groups)

--- a/morpheus/cli/commands.py
+++ b/morpheus/cli/commands.py
@@ -368,7 +368,6 @@ def pipeline_nlp(ctx: click.Context, **kwargs):
                     "A label file is a simple text file where each line corresponds to a label. "
                     "If unspecified the value specified by the --label flag will be used."))
 @click.option('--columns_file',
-              default="data/columns_fil.txt",
               type=MorpheusRelativePath(dir_okay=False, exists=True, file_okay=True, resolve_path=True),
               help=("Specifies a file to read column features."))
 @click.option('--viz_file',
@@ -413,8 +412,6 @@ def pipeline_fil(ctx: click.Context, **kwargs):
     if ("columns_file" in kwargs and kwargs["columns_file"] is not None):
         config.fil.feature_columns = load_labels_file(kwargs["columns_file"])
         logger.debug("Loaded columns. Current columns: [%s]", str(config.fil.feature_columns))
-    else:
-        raise ValueError('Unable to find columns file')
 
     from morpheus.pipeline import LinearPipeline
 

--- a/morpheus/cli/commands.py
+++ b/morpheus/cli/commands.py
@@ -427,15 +427,14 @@ def pipeline_fil(ctx: click.Context, **kwargs):
              pipeline_mode=PipelineModes.AE)
 @click.option('--columns_file',
               required=True,
-              default="data/columns_ae.txt",
+              default=None,
               type=MorpheusRelativePath(dir_okay=False, exists=True, file_okay=True, resolve_path=True),
               help=("Specifies a file to read column features."))
 @click.option('--labels_file',
               default=None,
               type=MorpheusRelativePath(dir_okay=False, exists=True, file_okay=True, resolve_path=True),
               help=("Specifies a file to read labels from in order to convert class IDs into labels. "
-                    "A label file is a simple text file where each line corresponds to a label. "
-                    "If unspecified, only a single output label is created for FIL"))
+                    "A label file is a simple text file where each line corresponds to a label. "))
 @click.option('--userid_column_name',
               type=str,
               default="userIdentityaccountId",
@@ -492,19 +491,14 @@ def pipeline_ae(ctx: click.Context, **kwargs):
     config.ae.userid_column_name = kwargs["userid_column_name"]
     config.ae.feature_scaler = kwargs["feature_scaler"]
     config.ae.use_generic_model = kwargs["use_generic_model"]
-
-    if ("columns_file" in kwargs and kwargs["columns_file"] is not None):
-        config.ae.feature_columns = load_labels_file(kwargs["columns_file"])
-        logger.debug("Loaded columns. Current columns: [%s]", str(config.ae.feature_columns))
-    else:
-        # Use a default single label
-        config.class_labels = ["reconstruct_loss", "zscore"]
+    config.ae.feature_columns = load_labels_file(kwargs["columns_file"])
+    logger.debug("Loaded columns. Current columns: [%s]", str(config.ae.feature_columns))
 
     if ("labels_file" in kwargs and kwargs["labels_file"] is not None):
         config.class_labels = load_labels_file(kwargs["labels_file"])
         logger.debug("Loaded labels file. Current labels: [%s]", str(config.class_labels))
     else:
-        # Use a default single label
+        # Use default labels
         config.class_labels = ["reconstruct_loss", "zscore"]
 
     if ("userid_filter" in kwargs):

--- a/morpheus/pipeline/preallocator_mixin.py
+++ b/morpheus/pipeline/preallocator_mixin.py
@@ -89,7 +89,6 @@ class PreallocatorMixin(ABC):
     def _post_build_single(self, builder: mrc.Builder, out_pair: StreamPair) -> StreamPair:
         (out_stream, out_type) = out_pair
         pretty_type = pretty_print_type_name(out_type)
-        logger.info("Added source: {}\n  └─> {}".format(str(self), pretty_type))
 
         if len(self._needed_columns) > 0:
             node_name = f"{self.unique_name}-preallocate"

--- a/morpheus/pipeline/preallocator_mixin.py
+++ b/morpheus/pipeline/preallocator_mixin.py
@@ -110,8 +110,8 @@ class PreallocatorMixin(ABC):
             elif issubclass(out_type, (cudf.DataFrame, pd.DataFrame)):
                 stream = builder.make_node(node_name, ops.map(self._preallocate_df))
             else:
-                msg = ("Additional columns were requested to be inserted into the Dataframe, but the output type {}"
-                       " isn't a supported type".format(pretty_type))
+                msg = ("Additional columns were requested to be inserted into the Dataframe, but the output type "
+                       f"{pretty_type} isn't a supported type")
                 raise RuntimeError(msg)
 
             builder.make_edge(out_stream, stream)

--- a/morpheus/stages/input/file_source_stage.py
+++ b/morpheus/stages/input/file_source_stage.py
@@ -108,20 +108,6 @@ class FileSourceStage(PreallocatorMixin, SingleOutputSource):
 
         return out_stream, out_type
 
-    def _post_build_single(self, builder: mrc.Builder, out_pair: StreamPair) -> StreamPair:
-
-        out_stream = out_pair[0]
-        out_type = out_pair[1]
-
-        # Convert our list of dataframes into the desired type. Flatten if necessary
-        if (typing_utils.issubtype(out_type, typing.List)):
-            flattened = builder.make_node(self.unique_name + "-post", ops.flatten())
-            builder.make_edge(out_stream, flattened)
-            out_stream = flattened
-            out_type = typing.get_args(out_type)[0]
-
-        return super()._post_build_single(builder, (out_stream, out_type))
-
     def _generate_frames(self):
 
         df = read_file_to_df(

--- a/morpheus/stages/input/file_source_stage.py
+++ b/morpheus/stages/input/file_source_stage.py
@@ -11,14 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""File source stage."""
 
 import logging
 import pathlib
 import typing
 
 import mrc
-import typing_utils
-from mrc.core import operators as ops
 
 from morpheus.cli import register_stage
 from morpheus.common import FileTypes
@@ -86,6 +85,7 @@ class FileSourceStage(PreallocatorMixin, SingleOutputSource):
 
     @property
     def name(self) -> str:
+        """Return the name of the stage"""
         return "from-file"
 
     @property
@@ -93,7 +93,8 @@ class FileSourceStage(PreallocatorMixin, SingleOutputSource):
         """Return None for no max intput count"""
         return self._input_count
 
-    def supports_cpp_node(self):
+    def supports_cpp_node(self) -> bool:
+        """Indicates whether or not this stage supports a C++ node"""
         return True
 
     def _build_source(self, builder: mrc.Builder) -> StreamPair:
@@ -108,7 +109,7 @@ class FileSourceStage(PreallocatorMixin, SingleOutputSource):
 
         return out_stream, out_type
 
-    def _generate_frames(self):
+    def _generate_frames(self) -> typing.Iterable[MessageMeta]:
 
         df = read_file_to_df(
             self._filename,

--- a/scripts/validation/val-run-pipeline.sh
+++ b/scripts/validation/val-run-pipeline.sh
@@ -80,7 +80,7 @@ function run_pipeline_abp_nvsmi(){
    VAL_OUTPUT=$5
 
    morpheus --log_level=DEBUG run --num_threads=1 --pipeline_batch_size=1024 --model_max_batch_size=1024 --use_cpp=${USE_CPP} \
-      pipeline-fil \
+      pipeline-fil --columns_file=${MORPHEUS_ROOT}/morpheus/data/columns_fil.txt \
       from-file --filename=${INPUT_FILE} \
       deserialize \
       preprocess \

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -349,8 +349,9 @@ class TestCLI:
         """
         Creates a pipeline roughly matching that of the abp validation test
         """
-        args = (GENERAL_ARGS + ['pipeline-fil'] + FILE_SRC_ARGS + ['deserialize', 'preprocess'] + INF_TRITON_ARGS +
-                MONITOR_ARGS + ['add-class'] + VALIDATE_ARGS + ['serialize'] + TO_FILE_ARGS)
+        args = (GENERAL_ARGS + ['pipeline-fil', '--columns_file=data/columns_fil.txt'] + FILE_SRC_ARGS +
+                ['deserialize', 'preprocess'] + INF_TRITON_ARGS + MONITOR_ARGS + ['add-class'] + VALIDATE_ARGS +
+                ['serialize'] + TO_FILE_ARGS)
 
         obj = {}
         runner = CliRunner()
@@ -419,23 +420,24 @@ class TestCLI:
         with open(labels_file, 'w', encoding='UTF-8') as fh:
             fh.writelines(['frogs\n', 'lizards\n', 'toads'])
 
-        args = (GENERAL_ARGS + ['pipeline-fil', '--labels_file', labels_file] + FILE_SRC_ARGS + FROM_KAFKA_ARGS + [
-            'deserialize',
-            'filter',
-            'dropna',
-            '--column',
-            'xyz',
-            'preprocess',
-            'add-scores',
-            'unittest-conv-msg',
-            'inf-identity',
-            'inf-pytorch',
-            '--model_filename',
-            tmp_model,
-            'mlflow-drift',
-            '--tracking_uri',
-            mlflow_uri
-        ] + INF_TRITON_ARGS + MONITOR_ARGS + ['add-class'] + VALIDATE_ARGS + ['serialize'] + TO_FILE_ARGS +
+        args = (GENERAL_ARGS + ['pipeline-fil', '--labels_file', labels_file, '--columns_file=data/columns_fil.txt'] +
+                FILE_SRC_ARGS + FROM_KAFKA_ARGS + [
+                    'deserialize',
+                    'filter',
+                    'dropna',
+                    '--column',
+                    'xyz',
+                    'preprocess',
+                    'add-scores',
+                    'unittest-conv-msg',
+                    'inf-identity',
+                    'inf-pytorch',
+                    '--model_filename',
+                    tmp_model,
+                    'mlflow-drift',
+                    '--tracking_uri',
+                    mlflow_uri
+                ] + INF_TRITON_ARGS + MONITOR_ARGS + ['add-class'] + VALIDATE_ARGS + ['serialize'] + TO_FILE_ARGS +
                 TO_KAFKA_ARGS)
 
         obj = {}


### PR DESCRIPTION
## Description
The CLI command for the FIL pipeline set a default value for `--columns_file` flag but some FIL pipelines like ransomeware didn't use this config property, causing the default columns file to be loaded and for the values to be logged to the terminal.

* Removed default values for `--columns_file` and `--labels-file` flags
* Removed redundant checks for null values if they were already being enforced by `required=True`
* Misc pylint/flake8 errors

fixes #819

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
