### PR TITLE
Document how to build the examples

### DIFF
--- a/docs/source/developer_guide/guides.md
+++ b/docs/source/developer_guide/guides.md
@@ -33,6 +33,11 @@ in both Python and C++.
 - [Simple C++ Stage](./guides/3_simple_cpp_stage.md)
 - [Creating a C++ Source Stage](./guides/4_source_cpp_stage.md)
 
+> **Note**: The code for the above guides can be found in the `examples/developer_guide` directory of the Morpheus repository. To build the C++ examples, pass `-DMORPHEUS_BUILD_EXAMPLES=ON` to CMake when building Morpheus. Users building Morpheus with the provided `scripts/compile.sh` script can do do by setting the `CMAKE_CONFIGURE_EXTRA_ARGS` environment variable:
+> ```bash
+> CMAKE_CONFIGURE_EXTRA_ARGS="-DMORPHEUS_BUILD_EXAMPLES=ON" ./scripts/compile.sh
+> ```
+
 ## Morpheus Modules
 
 Morpheus includes, as of version 23.03, a number of pre-defined module implementations to choose from when building a

--- a/docs/source/developer_guide/guides/1_simple_python_stage.md
+++ b/docs/source/developer_guide/guides/1_simple_python_stage.md
@@ -17,6 +17,8 @@ limitations under the License.
 
 # Simple Python Stage
 
+> **Note**: The code for this guide can be found in the `examples/developer_guide/1_simple_python_stage` directory of the Morpheus repository.
+
 ## Background
 
 Morpheus makes use of the MRC graph-execution framework. Morpheus pipelines are built on top of MRC pipelines, which are comprised of collections of nodes and edges, called segments (think sub-graphs),  which can in turn be connected by ingress/egress ports. In many common cases, an MRC pipeline will consist of only a single segment. Our Morpheus stages interact with the MRC segment to define, build, and add nodes to the MRC graph; the stages themselves can be thought of as packaged units of work to be applied to data flowing through the pipeline. These work units comprising an individual Morpheus stage may consist of a single MRC node, a small collection of nodes, or an entire MRC sub-graph.

--- a/docs/source/developer_guide/guides/2_real_world_phishing.md
+++ b/docs/source/developer_guide/guides/2_real_world_phishing.md
@@ -16,6 +16,7 @@ limitations under the License.
 -->
 
 # Real-World Application: Phishing Detection
+> **Note**: The code for this guide can be found in the `examples/developer_guide/2_1_real_world_phishing` directory of the Morpheus repository.
 
 ## Data Preprocessing
 
@@ -648,6 +649,8 @@ Options:
 ```
 
 ## Defining a New Source Stage
+
+> **Note**: The code for this guide can be found in the `examples/developer_guide/2_2_rabbitmq` directory of the Morpheus repository.
 
 Creating a new source stage is similar to defining any other stage with a few differences. First, we will be subclassing `SingleOutputSource` including the `PreallocatorMixin`. Second, the required methods are the `name` property, `_build_source` and `supports_cpp_node` methods.
 

--- a/docs/source/developer_guide/guides/3_simple_cpp_stage.md
+++ b/docs/source/developer_guide/guides/3_simple_cpp_stage.md
@@ -16,6 +16,9 @@ limitations under the License.
 -->
 
 # Simple C++ Stage
+> **Note**: The code for this guide can be found in the `examples/developer_guide/3_simple_cpp_stage` directory of the Morpheus repository. To build the C++ examples, pass `-DMORPHEUS_BUILD_EXAMPLES=ON` to CMake when building Morpheus. Users building Morpheus with the provided `scripts/compile.sh` script can do do by setting the `CMAKE_CONFIGURE_EXTRA_ARGS` environment variable:
+> ```bash
+> CMAKE_CONFIGURE_EXTRA_ARGS="-DMORPHEUS_BUILD_EXAMPLES=ON" ./scripts/compile.sh
 
 Morpheus offers the choice of writing pipeline stages in either Python or C++. For many use cases, a Python stage is perfectly fine. However, in the event that a Python stage becomes a bottleneck for the pipeline, then writing a C++ implementation for the stage becomes advantageous. The C++ implementations of Morpheus stages and messages utilize the [pybind11](https://pybind11.readthedocs.io/en/stable/index.html) library to provide Python bindings.
 

--- a/docs/source/developer_guide/guides/4_source_cpp_stage.md
+++ b/docs/source/developer_guide/guides/4_source_cpp_stage.md
@@ -16,6 +16,9 @@ limitations under the License.
 -->
 
 # Creating a C++ Source Stage
+> **Note**: The code for this guide can be found in the `examples/developer_guide/4_rabbitmq_cpp_stage` directory of the Morpheus repository. To build the C++ examples, pass `-DMORPHEUS_BUILD_EXAMPLES=ON` to CMake when building Morpheus. Users building Morpheus with the provided `scripts/compile.sh` script can do do by setting the `CMAKE_CONFIGURE_EXTRA_ARGS` environment variable:
+> ```bash
+> CMAKE_CONFIGURE_EXTRA_ARGS="-DMORPHEUS_BUILD_EXAMPLES=ON" ./scripts/compile.sh
 
 For this example, we are going to add a C++ implementation for the `RabbitMQSourceStage` we designed in the Python examples. The Python implementation of this stage emits messages of the type `MessageMeta`; as such, our C++ implementation must do the same.
 


### PR DESCRIPTION
## Description
* Add info on building the C++ examples
* Each guide specifies where the code lives under the examples dir


fixes #793

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
