### PR TITLE
Move hard-coded path in E2E benchmarks to config json

### DIFF
--- a/tests/benchmarks/e2e_test_configs.json
+++ b/tests/benchmarks/e2e_test_configs.json
@@ -28,7 +28,8 @@
         "edge_buffer_size": 4
     },
     "test_cloudtrail_ae_e2e": {
-        "glob_path": "../../models/datasets/validation-data/dfp-cloudtrail-*-input.csv",
+        "input_glob_path": "../../models/datasets/validation-data/dfp-cloudtrail-*-input.csv",
+        "train_glob_path": "../../models/datasets/training-data/sdfp-cloudtrail-*-training-data.csv",
         "repeat": 1,
         "num_threads": 1,
         "pipeline_batch_size": 1024,

--- a/tests/benchmarks/e2e_test_configs.json
+++ b/tests/benchmarks/e2e_test_configs.json
@@ -29,7 +29,7 @@
     },
     "test_cloudtrail_ae_e2e": {
         "input_glob_path": "../../models/datasets/validation-data/dfp-cloudtrail-*-input.csv",
-        "train_glob_path": "../../models/datasets/training-data/sdfp-cloudtrail-*-training-data.csv",
+        "train_glob_path": "../../models/datasets/training-data/dfp-cloudtrail-*-training-data.csv",
         "repeat": 1,
         "num_threads": 1,
         "pipeline_batch_size": 1024,

--- a/tests/benchmarks/test_bench_e2e_pipelines.py
+++ b/tests/benchmarks/test_bench_e2e_pipelines.py
@@ -44,8 +44,8 @@ from morpheus.utils.file_utils import load_labels_file
 from morpheus.utils.logger import configure_logging
 from utils import TEST_DIRS
 
-e2e_config_file = "./e2e_test_configs.json"
-with open(e2e_config_file, 'r', encoding='UTF-8') as f:
+E2E_CONFIG_FILE = "./e2e_test_configs.json"
+with open(E2E_CONFIG_FILE, 'r', encoding='UTF-8') as f:
     E2E_TEST_CONFIGS = json.load(f)
 
 

--- a/tests/benchmarks/test_bench_e2e_pipelines.py
+++ b/tests/benchmarks/test_bench_e2e_pipelines.py
@@ -44,7 +44,7 @@ from morpheus.utils.file_utils import load_labels_file
 from morpheus.utils.logger import configure_logging
 from utils import TEST_DIRS
 
-e2e_config_file = os.path.join(TEST_DIRS.morpheus_root, "tests/benchmarks/e2e_test_configs.json")
+e2e_config_file = "./e2e_test_configs.json"
 with open(e2e_config_file, 'r', encoding='UTF-8') as f:
     E2E_TEST_CONFIGS = json.load(f)
 
@@ -226,9 +226,9 @@ def test_cloudtrail_ae_e2e(benchmark, tmp_path):
     config.ae.feature_columns = load_labels_file(ae_cols_filepath)
     CppConfig.set_should_use_cpp(False)
 
-    input_glob = E2E_TEST_CONFIGS["test_cloudtrail_ae_e2e"]["glob_path"]
+    input_glob = E2E_TEST_CONFIGS["test_cloudtrail_ae_e2e"]["input_glob_path"]
     repeat = E2E_TEST_CONFIGS["test_cloudtrail_ae_e2e"]["repeat"]
-    train_data_glob = os.path.join(TEST_DIRS.validation_data_dir, "dfp-cloudtrail-*-input.csv")
+    train_glob = E2E_TEST_CONFIGS["test_cloudtrail_ae_e2e"]["train_glob_path"]
     output_filepath = os.path.join(tmp_path, "cloudtrail_ae_e2e_output.csv")
 
-    benchmark(ae_pipeline, config, input_glob, repeat, train_data_glob, output_filepath)
+    benchmark(ae_pipeline, config, input_glob, repeat, train_glob, output_filepath)

--- a/tests/benchmarks/test_bench_e2e_pipelines.py
+++ b/tests/benchmarks/test_bench_e2e_pipelines.py
@@ -44,7 +44,7 @@ from morpheus.utils.file_utils import load_labels_file
 from morpheus.utils.logger import configure_logging
 from utils import TEST_DIRS
 
-E2E_CONFIG_FILE = "./e2e_test_configs.json"
+E2E_CONFIG_FILE = os.path.join(TEST_DIRS.morpheus_root, "tests/benchmarks/e2e_test_configs.json")
 with open(E2E_CONFIG_FILE, 'r', encoding='UTF-8') as f:
     E2E_TEST_CONFIGS = json.load(f)
 


### PR DESCRIPTION
## Description
- Move hard-coded glob (inside `MORPHEUS_ROOT`) for CloudTrail AE training data to `e2e_test_configs.json`.
- Fix CloudTrail AE training data glob to point to training data instead of validation/inference data. This will result in longer pipeline run times because training data used by pipeline will now be larger.

Fixes #1005

## Checklist
[x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
[x] New or existing tests cover these changes.
[x] The documentation is up to date with these changes.
