### PR TITLE
Remove PIP_FIND_LINKS for torch from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,6 @@ import sys
 from setuptools import find_packages  # noqa: E402
 from setuptools import setup  # noqa: E402
 
-# Required to install torch via setup.py
-# Note: this is order dependent
-os.environ["PIP_FIND_LINKS"] = "https://download.pytorch.org/whl/cu116/torch_stable.html"
-
 try:
     import versioneer
 except ImportError:


### PR DESCRIPTION
## Description
- Remove `PIP_FIND_LINKS` for torch in `setup.py`. This was missed by PR #1015 which only removed it in `docker/conda/environments/requirements.txt`.

## Checklist
[x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
[x] New or existing tests cover these changes.
[x] The documentation is up to date with these changes.
