### PR TITLE
Remove `loop` from several `asyncio` API calls

### DIFF
--- a/morpheus/stages/postprocess/generate_viz_frames_stage.py
+++ b/morpheus/stages/postprocess/generate_viz_frames_stage.py
@@ -151,7 +151,7 @@ class GenerateVizFramesStage(SinglePortStage):
         df["ts_round_sec"] = (df["timestamp"] / 1000.0).astype(int) * 1000
 
         # Return a list of tuples of (ts_round_sec, dataframe)
-        return [(key, group) for key, group in df.groupby(df.ts_round_sec)]
+        return list(df.groupby(df.ts_round_sec))
 
     def _write_viz_file(self, x: typing.List[typing.Tuple[int, pd.DataFrame]]):
 
@@ -250,13 +250,13 @@ class GenerateVizFramesStage(SinglePortStage):
                 sink = pa.BufferOutputStream()
 
                 # This is the timestamp of the earliest message
-                t0 = x.get_meta("timestamp").min()
+                time0 = x.get_meta("timestamp").min()
 
                 df = x.get_meta(["timestamp", "src_ip", "dest_ip", "secret_keys", "data"])
 
                 out_df = cudf.DataFrame()
 
-                out_df["dt"] = (df["timestamp"] - t0).astype(np.int32)
+                out_df["dt"] = (df["timestamp"] - time0).astype(np.int32)
                 out_df["src"] = df["src_ip"].str.ip_to_int().astype(np.int32)
                 out_df["dst"] = df["dest_ip"].str.ip_to_int().astype(np.int32)
                 out_df["lvl"] = df["secret_keys"].astype(np.int32)

--- a/morpheus/stages/postprocess/generate_viz_frames_stage.py
+++ b/morpheus/stages/postprocess/generate_viz_frames_stage.py
@@ -170,10 +170,9 @@ class GenerateVizFramesStage(SinglePortStage):
         Launch the Websocket server and asynchronously send messages via Websocket.
         """
 
-        loop = asyncio.get_event_loop()
-        self._loop = loop
+        self._loop = asyncio.get_event_loop()
 
-        self._buffer_queue = AsyncIOProducerConsumerQueue(maxsize=2, loop=loop)
+        self._buffer_queue = AsyncIOProducerConsumerQueue(maxsize=2)
 
         async def client_connected(websocket: websockets.legacy.server.WebSocketServerProtocol):
             """
@@ -216,9 +215,9 @@ class GenerateVizFramesStage(SinglePortStage):
                 logger.error("Error during serve", exc_info=e)
                 raise
 
-        self._server_task = loop.create_task(run_server())
+        self._server_task = self._loop.create_task(run_server())
 
-        self._server_close_event = asyncio.Event(loop=loop)
+        self._server_close_event = asyncio.Event()
 
         await asyncio.sleep(1.0)
 

--- a/morpheus/utils/producer_consumer_queue.py
+++ b/morpheus/utils/producer_consumer_queue.py
@@ -138,10 +138,10 @@ class AsyncIOProducerConsumerQueue(asyncio.Queue, typing.Generic[_T]):
     Custom queue.Queue implementation which supports closing and uses recursive locks
     """
 
-    def __init__(self, maxsize=0, *, loop=None) -> None:
-        super().__init__(maxsize=maxsize, loop=loop)
+    def __init__(self, maxsize=0) -> None:
+        super().__init__(maxsize=maxsize)
 
-        self._closed = asyncio.Event(loop=loop)
+        self._closed = asyncio.Event()
         self._is_closed = False
 
     async def join(self):
@@ -166,7 +166,7 @@ class AsyncIOProducerConsumerQueue(asyncio.Queue, typing.Generic[_T]):
         slot is available before adding item.
         """
         while self.full() and not self._is_closed:
-            putter = self._loop.create_future()
+            putter = self._get_loop().create_future()
             self._putters.append(putter)
             try:
                 await putter
@@ -196,7 +196,7 @@ class AsyncIOProducerConsumerQueue(asyncio.Queue, typing.Generic[_T]):
         If queue is empty, wait until an item is available.
         """
         while self.empty() and not self._is_closed:
-            getter = self._loop.create_future()
+            getter = self._get_loop().create_future()
             self._getters.append(getter)
             try:
                 await getter


### PR DESCRIPTION
## Description
Due to changes in `asyncio` in Python 3.10, we needed to remove the `loop` parameter from several API calls. See [here](https://blog.teclado.com/changes-to-async-event-loops-in-python-3-10/) for more info.

Fixes #1031 
