### PR TITLE
Setting `sqlalchemy` restrictions to be compatible with our version of `pandas`

### DIFF
--- a/ci/conda/recipes/morpheus/meta.yaml
+++ b/ci/conda/recipes/morpheus/meta.yaml
@@ -92,7 +92,7 @@ outputs:
         - pytorch 2.0.1
         - pytorch-cuda
         - scikit-learn 1.2.2.*
-        - sqlalchemy <=1.9 # 2.0 is incompatible with pandas=1.3
+        - sqlalchemy <=2.0 # 2.0 is incompatible with pandas=1.3
         - tqdm 4.*
         - tritonclient 2.26.*
         - typing_utils 0.1.*

--- a/ci/conda/recipes/morpheus/meta.yaml
+++ b/ci/conda/recipes/morpheus/meta.yaml
@@ -21,7 +21,7 @@ package:
   version: {{ version }}
 
 source:
-  path: ../../../..
+  git_url: ../../../..
 
 outputs:
 

--- a/ci/conda/recipes/morpheus/meta.yaml
+++ b/ci/conda/recipes/morpheus/meta.yaml
@@ -92,6 +92,7 @@ outputs:
         - pytorch 2.0.1
         - pytorch-cuda
         - scikit-learn 1.2.2.*
+        - sqlalchemy <=1.9 # 2.0 is incompatible with pandas=1.3
         - tqdm 4.*
         - tritonclient 2.26.*
         - typing_utils 0.1.*

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -111,9 +111,8 @@ RUN --mount=type=cache,id=conda_pkgs,target=/opt/conda/pkgs,sharing=locked \
     conda config --set ssl_verify false &&\
     conda config --add pkgs_dirs /opt/conda/pkgs &&\
     # Install mamba, boa and git here. Conda build breaks with other git installs
-    /opt/conda/bin/mamba install -y -n base -c conda-forge "boa" "git >=2.35.3" "git-lfs" "python=${PYTHON_VER}" "tini=0.19" &&\
-    source activate base &&\
-    git lfs install
+    /opt/conda/bin/mamba install -y -n base -c conda-forge "boa" "git >=2.35.3" "python=${PYTHON_VER}" "tini=0.19" &&\
+    source activate base
     # conda clean -afy
 
 # ============ Stage: conda_env ============
@@ -220,7 +219,10 @@ COPY . ./
 
 RUN --mount=type=cache,id=workspace_cache,target=/workspace/.cache,sharing=locked \
     --mount=type=cache,id=conda_pkgs,target=/opt/conda/pkgs,sharing=locked \
+    # Install git-lfs before running the build to avoid errors during conda build
+    /opt/conda/bin/mamba install -y -n base -c conda-forge "git-lfs" &&\
     source activate base &&\
+    git lfs install &&\
     # Need to get around recent versions of git locking paths until they are deemed safe
     git config --global --add safe.directory "*" &&\
     # Change to the morpheus directory and build the conda package

--- a/docker/build_container.sh
+++ b/docker/build_container.sh
@@ -42,7 +42,7 @@ RAPIDS_VER=${RAPIDS_VER:-23.06}
 TENSORRT_VERSION=${TENSORRT_VERSION:-8.2.1.3}
 
 # Determine the relative path from $PWD to $MORPHEUS_ROOT
-MORPHEUS_ROOT_HOST=${MORPHEUS_ROOT_HOST:-"./$(realpath --relative-to=${PWD} ${MORPHEUS_ROOT})"}
+MORPHEUS_ROOT_HOST=${MORPHEUS_ROOT_HOST:-"$(realpath --relative-to=${PWD} ${MORPHEUS_ROOT})"}
 
 # Build the docker arguments
 DOCKER_ARGS="-t ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}"

--- a/docker/conda/environments/cuda11.8_dev.yml
+++ b/docker/conda/environments/cuda11.8_dev.yml
@@ -89,9 +89,9 @@ dependencies:
     - scikit-learn=1.2.2
     - sphinx
     - sphinx_rtd_theme
-    - sqlalchemy<=1.9
+    - sqlalchemy<2.0 # 2.0 is incompatible with pandas=1.3
     - sysroot_linux-64=2.17
-    - tritonclient=2.26 #  Required by NvTabular, force the version, so we get protobufs compatible with 4.21
+    - tritonclient=2.26 # Required by NvTabular, force the version, so we get protobufs compatible with 4.21
     - tqdm=4
     - typing_utils=0.1
     - watchdog=2.1


### PR DESCRIPTION
This PR adds a runtime restriction on `sqlalchemy<2.0` because version 2.0 is incompatible with `pandas=1.3`. See [here](https://stackoverflow.com/a/75282604) for more information.

The runtime restriction was missing even though it was included in the conda dev dependencies.

Included in this PR are changes to remove Git LFS from the base image and only install it in later stages used to build the conda package.