### PR TITLE
Adopt pybind11 v2.10.4 and install via conda

### DIFF
--- a/ci/conda/recipes/morpheus/meta.yaml
+++ b/ci/conda/recipes/morpheus/meta.yaml
@@ -60,6 +60,7 @@ outputs:
         - mrc {{ minor_version }}
         - pip
         - pyarrow * *_cuda # Ensure we get a CUDA build. Version determined by cuDF
+        - pybind11=2.10.4
         - pybind11-stubgen 0.10.5
         - python {{ python }}
         - rapidjson 1.1

--- a/docker/conda/environments/cuda11.8_dev.yml
+++ b/docker/conda/environments/cuda11.8_dev.yml
@@ -73,6 +73,7 @@ dependencies:
     - pluggy=1.0
     - protobuf=4.21.*
     - pyarrow * *_cuda # Ensure we get a CUDA build. Version determined by cuDF
+    - pybind11=2.10.4
     - pybind11-stubgen=0.10.5
     - pydot
     - pylint>=2.17.4,<2.18 # 2.17.4 contains a fix for toml support


### PR DESCRIPTION
## Description
* Install pybind11 via conda

Blocked on:
* https://github.com/nv-morpheus/utilities/pull/45 
* https://github.com/nv-morpheus/MRC/pull/359

fixes #1013

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
