### PR TITLE
Fix `verify_init` decorator in DFPArgParser

### DIFF
--- a/examples/digital_fingerprinting/production/morpheus/benchmarks/conftest.py
+++ b/examples/digital_fingerprinting/production/morpheus/benchmarks/conftest.py
@@ -28,7 +28,7 @@ def get_json_lines_count(filename):
     return len(lines)
 
 
-def pytest_benchmark_update_json(config, benchmarks, output_json): # pylint:disable=unused-argument
+def pytest_benchmark_update_json(config, benchmarks, output_json):  # pylint:disable=unused-argument
 
     curr_dir = path.dirname(path.abspath(__file__))
 

--- a/examples/digital_fingerprinting/production/morpheus/benchmarks/conftest.py
+++ b/examples/digital_fingerprinting/production/morpheus/benchmarks/conftest.py
@@ -28,7 +28,7 @@ def get_json_lines_count(filename):
     return len(lines)
 
 
-def pytest_benchmark_update_json(_, __, output_json):
+def pytest_benchmark_update_json(config, benchmarks, output_json): # pylint:disable=unused-argument
 
     curr_dir = path.dirname(path.abspath(__file__))
 

--- a/examples/digital_fingerprinting/production/morpheus/dfp/utils/dfp_arg_parser.py
+++ b/examples/digital_fingerprinting/production/morpheus/dfp/utils/dfp_arg_parser.py
@@ -36,6 +36,7 @@ class TimeFields:
 class DFPArgParser:
 
     class Decorators:
+
         @classmethod
         def verify_init(cls, func):
 

--- a/examples/digital_fingerprinting/production/morpheus/dfp/utils/dfp_arg_parser.py
+++ b/examples/digital_fingerprinting/production/morpheus/dfp/utils/dfp_arg_parser.py
@@ -35,6 +35,17 @@ class TimeFields:
 
 class DFPArgParser:
 
+    class Decorators:
+        @classmethod
+        def verify_init(cls, func):
+
+            def wrapper(self, *args, **kwargs):
+                if not self._initialized:
+                    raise RuntimeError('Instance not initialized')
+                return func(self, *args, **kwargs)
+
+            return wrapper
+
     def __init__(self,
                  skip_user: str,
                  only_user: str,
@@ -68,22 +79,13 @@ class DFPArgParser:
         self._model_name_formatter = f"DFP-{source}-" + "{user_id}"
         self._experiment_name_formatter = f"dfp/{source}/training/" + "{reg_model_name}"
 
-    def verify_init(self, func):
-
-        def wrapper(self, *args, **kwargs):
-            if not self._initialized:
-                raise RuntimeError('Instance not initialized')
-            return func(self, *args, **kwargs)
-
-        return wrapper
-
     def _configure_logging(self):
         configure_logging(log_level=self._log_level)
         # To prevent unnecessary logs from the mlflow.tracking.fluent module, explicitly set the log level to WARN.
         logging.getLogger("mlflow").setLevel(logging.WARN)
 
     @property
-    @verify_init
+    @Decorators.verify_init
     def time_fields(self):
         return self._time_fields
 
@@ -92,7 +94,7 @@ class DFPArgParser:
         return self._silence_monitors
 
     @property
-    @verify_init
+    @Decorators.verify_init
     def include_generic(self):
         return self._include_generic
 
@@ -101,7 +103,7 @@ class DFPArgParser:
         return self._duration
 
     @property
-    @verify_init
+    @Decorators.verify_init
     def include_individual(self):
         return self._include_individual
 


### PR DESCRIPTION
## Description
- Revert updates to `verify_init` decorator and move to inner class to avoid pylint errors.
- Revert updates to dfp benchmark pytest hook and disable `unused-argument` pylint error.

Fixes #1151
Fixes #1153

## Checklist
[x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
[x] New or existing tests cover these changes.
[x] The documentation is up to date with these changes.
