### PR TITLE
Make manual_seed an autouse fixture for gnn_fraud_detection_pipeline tests

### DIFF
--- a/tests/examples/gnn_fraud_detection_pipeline/conftest.py
+++ b/tests/examples/gnn_fraud_detection_pipeline/conftest.py
@@ -53,7 +53,7 @@ def config_fixture(config):
     yield config
 
 
-@pytest.fixture(name="manual_seed", scope="function")
+@pytest.fixture(name="manual_seed", scope="function", autouse=True)
 def manual_seed_fixture(manual_seed):
     """
     Extends the base `manual_seed` fixture to also set the seed for dgl, ensuring deterministic results in tests

--- a/tests/examples/gnn_fraud_detection_pipeline/test_classification_stage.py
+++ b/tests/examples/gnn_fraud_detection_pipeline/test_classification_stage.py
@@ -26,14 +26,12 @@ from morpheus.messages import MessageMeta
 
 @pytest.mark.use_python
 class TestClassificationStage:
-
     def test_constructor(self, config: Config, xgb_model: str, cuml: types.ModuleType):
         from stages.classification_stage import ClassificationStage
 
         stage = ClassificationStage(config, xgb_model)
         assert isinstance(stage._xgb_model, cuml.ForestInference)
 
-    @pytest.mark.usefixtures("manual_seed")
     def test_process_message(self, config: Config, xgb_model: str, dataset_cudf: DatasetManager):
         from stages.classification_stage import ClassificationStage
         from stages.graph_sage_stage import GraphSAGEMultiMessage

--- a/tests/examples/gnn_fraud_detection_pipeline/test_classification_stage.py
+++ b/tests/examples/gnn_fraud_detection_pipeline/test_classification_stage.py
@@ -26,6 +26,7 @@ from morpheus.messages import MessageMeta
 
 @pytest.mark.use_python
 class TestClassificationStage:
+
     def test_constructor(self, config: Config, xgb_model: str, cuml: types.ModuleType):
         from stages.classification_stage import ClassificationStage
 

--- a/tests/examples/gnn_fraud_detection_pipeline/test_graph_sage_stage.py
+++ b/tests/examples/gnn_fraud_detection_pipeline/test_graph_sage_stage.py
@@ -27,7 +27,6 @@ from morpheus.messages import MultiMessage
 
 @pytest.mark.use_python
 class TestGraphSageStage:
-
     def test_constructor(self, config: Config, model_dir: str):
         from stages.graph_sage_stage import GraphSAGEStage
         from stages.model import HinSAGE
@@ -38,7 +37,6 @@ class TestGraphSageStage:
         assert stage._record_id == "test_id"
         assert stage._target_node == "test_node"
 
-    @pytest.mark.usefixtures("manual_seed")
     def test_process_message(self,
                              config: Config,
                              training_file: str,

--- a/tests/examples/gnn_fraud_detection_pipeline/test_graph_sage_stage.py
+++ b/tests/examples/gnn_fraud_detection_pipeline/test_graph_sage_stage.py
@@ -27,6 +27,7 @@ from morpheus.messages import MultiMessage
 
 @pytest.mark.use_python
 class TestGraphSageStage:
+
     def test_constructor(self, config: Config, model_dir: str):
         from stages.graph_sage_stage import GraphSAGEStage
         from stages.model import HinSAGE


### PR DESCRIPTION
## Description
* thd `manual_seed` fixture for `gnn_fraud_detection_pipeline` is now set to autouse
* fixes #1164

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
