### PR TITLE
Fix Kafka offset checking test

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,4 @@ NVIDIA Morpheus is an open AI application framework that provides cybersecurity 
 
 
 Full documentation for the latest official release is available at [https://docs.nvidia.com/morpheus/](https://docs.nvidia.com/morpheus/).
+

--- a/README.md
+++ b/README.md
@@ -39,4 +39,3 @@ NVIDIA Morpheus is an open AI application framework that provides cybersecurity 
 
 
 Full documentation for the latest official release is available at [https://docs.nvidia.com/morpheus/](https://docs.nvidia.com/morpheus/).
-

--- a/tests/test_kafka_source_stage_pipe.py
+++ b/tests/test_kafka_source_stage_pipe.py
@@ -134,13 +134,15 @@ class OffsetChecker(SinglePortStage):
         new_offsets = self._client.list_consumer_group_offsets(self._group_id)
 
         if self._offsets is not None:
-            for (topic_partition, prev_offset) in self._offsets.items():
-                new_offset = new_offsets[topic_partition]
+            at_least_one_gt = len(new_offsets) > len(self._offsets)
+            if not at_least_one_gt:
+                for (topic_partition, prev_offset) in self._offsets.items():
+                    new_offset = new_offsets[topic_partition]
 
-                assert new_offset.offset >= prev_offset.offset
+                    assert new_offset.offset >= prev_offset.offset
 
-                if new_offset.offset > prev_offset.offset:
-                    at_least_one_gt = True
+                    if new_offset.offset > prev_offset.offset:
+                        at_least_one_gt = True
 
             assert at_least_one_gt
 
@@ -149,7 +151,7 @@ class OffsetChecker(SinglePortStage):
         return x
 
     def _build_single(self, builder: mrc.Builder, input_stream):
-        node = builder.make_node(self.unique_name, ops.map(self._offset_checker))
+        node = builder.make_node_component(self.unique_name, ops.map(self._offset_checker))
         builder.make_edge(input_stream[0], node)
 
         return node, input_stream[1]

--- a/tests/test_kafka_source_stage_pipe.py
+++ b/tests/test_kafka_source_stage_pipe.py
@@ -134,15 +134,13 @@ class OffsetChecker(SinglePortStage):
         new_offsets = self._client.list_consumer_group_offsets(self._group_id)
 
         if self._offsets is not None:
-            at_least_one_gt = len(new_offsets) > len(self._offsets)
-            if not at_least_one_gt:
-                for (topic_partition, prev_offset) in self._offsets.items():
-                    new_offset = new_offsets[topic_partition]
+            for (topic_partition, prev_offset) in self._offsets.items():
+                new_offset = new_offsets[topic_partition]
 
-                    assert new_offset.offset >= prev_offset.offset
+                assert new_offset.offset >= prev_offset.offset
 
-                    if new_offset.offset > prev_offset.offset:
-                        at_least_one_gt = True
+                if new_offset.offset > prev_offset.offset:
+                    at_least_one_gt = True
 
             assert at_least_one_gt
 
@@ -151,7 +149,7 @@ class OffsetChecker(SinglePortStage):
         return x
 
     def _build_single(self, builder: mrc.Builder, input_stream):
-        node = builder.make_node_component(self.unique_name, ops.map(self._offset_checker))
+        node = builder.make_node(self.unique_name, ops.map(self._offset_checker))
         builder.make_edge(input_stream[0], node)
 
         return node, input_stream[1]


### PR DESCRIPTION
## Description
* Fixes intermittent failures in `tests/test_kafka_source_stage_pipe.py::test_kafka_source_commit`
* The test checked the offsets in a stage, however the C++ impl for the source stage performs a commit after calling `on_next`. This also limited us to only testing sync commits.
* Updated test performs the offset check after the pipeline completes when we can be assured that all commits have completed.

Fxies #1217

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
