### PR TITLE
Phishing example fix

### DIFF
--- a/models/data/labels_phishing.txt
+++ b/models/data/labels_phishing.txt
@@ -1,2 +1,2 @@
-score
-pred
+not_phishing
+is_phishing


### PR DESCRIPTION
## Description
- Update columns file to reflect actual model outputs: `not_phishing` and `is_phishing`
- Add `AddScores` stage to Python and CLI examples
- Remove `FilterDetectionsStage` because model output contains probabilities for both `not_phishing` and `is_phishing`one of which will always exceed threshold. This results in nothing ever being filtered out.

Closes #1208

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
