### PR TITLE
Update DFP training model_kwargs

### DIFF
--- a/examples/digital_fingerprinting/production/morpheus/dfp/modules/dfp_training_pipe.py
+++ b/examples/digital_fingerprinting/production/morpheus/dfp/modules/dfp_training_pipe.py
@@ -230,9 +230,9 @@ def dfp_training_pipe(builder: mrc.Builder):
             "encoder_layers": [512, 500],  # layers of the encoding part
             "decoder_layers": [512],  # layers of the decoding part
             "activation": 'relu',  # activation function
-            "swap_p": 0.2,  # noise parameter
-            "lr": 0.001,  # learning rate
-            "lr_decay": 0.99,  # learning decay
+            "swap_probability": 0.2,  # noise parameter
+            "learning_rate": 0.001,  # learning rate
+            "learning_rate_decay": 0.99,  # learning decay
             "batch_size": 512,
             "verbose": False,
             "optimizer": 'sgd',  # SGD optimizer is selected(Stochastic gradient descent)

--- a/examples/digital_fingerprinting/production/morpheus/dfp/stages/dfp_training.py
+++ b/examples/digital_fingerprinting/production/morpheus/dfp/stages/dfp_training.py
@@ -57,9 +57,9 @@ class DFPTraining(SinglePortStage):
             "encoder_layers": [512, 500],  # layers of the encoding part
             "decoder_layers": [512],  # layers of the decoding part
             "activation": 'relu',  # activation function
-            "swap_p": 0.2,  # noise parameter
-            "lr": 0.001,  # learning rate
-            "lr_decay": .99,  # learning decay
+            "swap_probability": 0.2,  # noise parameter
+            "learning_rate": 0.001,  # learning rate
+            "learning_rate_decay": .99,  # learning decay
             "batch_size": 512,
             "verbose": False,
             "optimizer": 'sgd',  # SGD optimizer is selected(Stochastic gradient descent)


### PR DESCRIPTION
## Description
- Update autoencoder `model_kwargs` in DFP training module/stage to match recently renamed constructor parameters in autoencoder.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
