### PR TITLE
CI test stage no longer depends on build stage

### DIFF
--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -121,7 +121,6 @@ jobs:
 
   test:
     name: Test
-    needs: [build]
     runs-on: linux-amd64-gpu-v100-latest-1
     timeout-minutes: 60
     container:


### PR DESCRIPTION
## Description
* Test stage was updated a while ago to perform its own builds.

Closes #1213

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
