### PR TITLE
Update libweb-p to version 1.3.2 for CVE mitigation.

### DIFF
--- a/docker/conda/environments/cuda11.8_dev.yml
+++ b/docker/conda/environments/cuda11.8_dev.yml
@@ -65,6 +65,7 @@ dependencies:
     - jupyterlab
     - libgrpc>=1.49
     - librdkafka=1.9.2
+    - libwebp=1.3.2
     - mlflow>=2.2.1,<3
     - mrc=23.11
     - networkx=3.1

--- a/docker/conda/environments/cuda11.8_dev.yml
+++ b/docker/conda/environments/cuda11.8_dev.yml
@@ -65,7 +65,7 @@ dependencies:
     - jupyterlab
     - libgrpc>=1.49
     - librdkafka=1.9.2
-    - libwebp=1.3.2 # Required for CVE mitigation: https://nvd.nist.gov/vuln/detail/CVE-2023-4863
+    - libwebp>=1.3.2 # Required for CVE mitigation: https://nvd.nist.gov/vuln/detail/CVE-2023-4863
     - mlflow>=2.2.1,<3
     - mrc=23.11
     - networkx=3.1

--- a/docker/conda/environments/cuda11.8_dev.yml
+++ b/docker/conda/environments/cuda11.8_dev.yml
@@ -65,7 +65,7 @@ dependencies:
     - jupyterlab
     - libgrpc>=1.49
     - librdkafka=1.9.2
-    - libwebp=1.3.2
+    - libwebp=1.3.2 # Required for CVE mitigation: https://nvd.nist.gov/vuln/detail/CVE-2023-4863
     - mlflow>=2.2.1,<3
     - mrc=23.11
     - networkx=3.1

--- a/docker/conda/environments/cuda11.8_examples.yml
+++ b/docker/conda/environments/cuda11.8_examples.yml
@@ -31,7 +31,7 @@ dependencies:
     - dgl=1.0.2
     - dill=0.3.6
     - distributed>=2023.1.1
-    - libwebp=1.3.2 # Required for CVE mitigation: https://nvd.nist.gov/vuln/detail/CVE-2023-4863
+    - libwebp>=1.3.2 # Required for CVE mitigation: https://nvd.nist.gov/vuln/detail/CVE-2023-4863
     - mlflow>=2.2.1,<3
     - papermill=2.3.4
     - s3fs>=2023.6

--- a/docker/conda/environments/cuda11.8_examples.yml
+++ b/docker/conda/environments/cuda11.8_examples.yml
@@ -31,7 +31,7 @@ dependencies:
     - dgl=1.0.2
     - dill=0.3.6
     - distributed>=2023.1.1
-    - libwebp=1.3.2
+    - libwebp=1.3.2 # Required for CVE mitigation: https://nvd.nist.gov/vuln/detail/CVE-2023-4863
     - mlflow>=2.2.1,<3
     - papermill=2.3.4
     - s3fs>=2023.6

--- a/docker/conda/environments/cuda11.8_examples.yml
+++ b/docker/conda/environments/cuda11.8_examples.yml
@@ -31,6 +31,7 @@ dependencies:
     - dgl=1.0.2
     - dill=0.3.6
     - distributed>=2023.1.1
+    - libwebp=1.3.2
     - mlflow>=2.2.1,<3
     - papermill=2.3.4
     - s3fs>=2023.6

--- a/models/mlflow/docker/conda/mlflow-env.yml
+++ b/models/mlflow/docker/conda/mlflow-env.yml
@@ -20,6 +20,7 @@ channels:
 dependencies:
   - boto3
   - onnx
+  - libwebp>=1.3.2 # Required for CVE mitigation: https://nvd.nist.gov/vuln/detail/CVE-2023-4863
   - psycopg2<3
   - pymysql
   - python=3.11


### PR DESCRIPTION
Add libwebp to dependencies and pin to 1.3.2 for mitigation of https://nvd.nist.gov/vuln/detail/CVE-2023-4863