### PR TITLE
Fix documentation for morpheus.loaders.sql_loader

### DIFF
--- a/morpheus/utils/control_message_utils.py
+++ b/morpheus/utils/control_message_utils.py
@@ -37,6 +37,7 @@ def cm_skip_processing_if_failed(func: Callable[CM_SKIP_P, T]) -> Callable[CM_SK
         The decorated function.
     """
 
+    @wraps(func)
     def wrapper(control_message: ControlMessage, *args: CM_SKIP_P.args, **kwargs: CM_SKIP_P.kwargs) -> T:
         if (control_message.has_metadata("cm_failed") and control_message.get_metadata("cm_failed")):
             return control_message


### PR DESCRIPTION
Add `@wraps` decorator to `cm_skip_processing_if_failed` to allow docstrings for wrapped methods to generate documentation.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
