### PR TITLE
Skip milvus tests by default

### DIFF
--- a/ci/scripts/github/test.sh
+++ b/ci/scripts/github/test.sh
@@ -98,7 +98,7 @@ done
 rapids-logger "Running Python tests"
 set +e
 
-python -I -m pytest --run_slow --run_kafka --fail_missing \
+python -I -m pytest --run_slow --run_kafka --run_milvus --fail_missing \
        --junit-xml=${REPORTS_DIR}/report_pytest.xml \
        --cov=morpheus \
        --cov-report term-missing \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ markers = [
   "benchmark: Benchmarks",
   "slow: Slow tests",
   "kafka: Tests that require a running instance of kafka",
+  "milvus: Tests that require a running instance of milvus",
   "use_cpp: Test support C++ nodes and objects",
   "use_python: Test only supports Python nodes and objects",
   "use_cudf: Test supports cuDF datasets",

--- a/tests/_utils/__init__.py
+++ b/tests/_utils/__init__.py
@@ -167,3 +167,10 @@ def remove_module(mod_to_remove: str):
     for mod_name in list(sys.modules.keys()):
         if mod_name == mod_to_remove or mod_name.startswith(mod_prefix):
             del sys.modules[mod_name]
+
+
+def load_json_file(filename):
+    filepath = os.path.join(TEST_DIRS.tests_data_dir, filename)
+
+    with open(filepath, 'r', encoding="utf-8") as json_file:
+        return json.load(json_file)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,13 @@ def pytest_addoption(parser: pytest.Parser):
     )
 
     parser.addoption(
+        "--run_milvus",
+        action="store_true",
+        dest="run_milvus",
+        help="Run milvus tests that would otherwise be skipped",
+    )
+
+    parser.addoption(
         "--run_benchmark",
         action="store_true",
         dest="run_benchmark",
@@ -145,6 +152,10 @@ def pytest_runtest_setup(item):
     if (not item.config.getoption("--run_kafka")):
         if (item.get_closest_marker("kafka") is not None):
             pytest.skip("Skipping Kafka tests by default. Use --run_kafka to enable")
+
+    if (not item.config.getoption("--run_milvus")):
+        if (item.get_closest_marker("milvus") is not None):
+            pytest.skip("Skipping milvus tests by default. Use --run_milvus to enable")
 
     if (not item.config.getoption("--run_benchmark")):
         if (item.get_closest_marker("benchmark") is not None):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -991,3 +991,28 @@ def milvus_server_uri():
             default_server.stop()
         except Exception as exec_inf:
             logger.error("Error in stopping Milvus server: %s", exec_inf)
+
+
+@pytest.fixture(scope="function", name="milvus_service")
+def milvus_service_fixture(milvus_server_uri: str):
+    from morpheus.service.milvus_vector_db_service import MilvusVectorDBService
+    service = MilvusVectorDBService(uri=milvus_server_uri)
+    yield service
+
+
+@pytest.fixture(scope="session", name="milvus_data")
+def milvus_data_fixture():
+    inital_data = [{"id": i, "embedding": [i / 10.0] * 10, "age": 25 + i} for i in range(10)]
+    yield inital_data
+
+
+@pytest.fixture(scope="session", name="idx_part_collection_config")
+def idx_part_collection_config_fixture():
+    from _utils import load_json_file
+    yield load_json_file(filename="service/milvus_idx_part_collection_conf.json")
+
+
+@pytest.fixture(scope="session", name="simple_collection_config")
+def simple_collection_config_fixture():
+    from _utils import load_json_file
+    yield load_json_file(filename="service/milvus_simple_collection_conf.json")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -961,36 +961,34 @@ def _get_random_port():
 def milvus_server_uri(tmp_path_factory):
     """
     Pytest fixture to start and stop a Milvus server and provide its URI for testing.
+    Due to the high startup time for Milvus users can optionally start a Milvus server before running tests and
+    define a `MORPHEUS_MILVUS_URI` environment variable to use that server instead of starting a new one.
 
     This fixture starts a Milvus server, retrieves its URI (Uniform Resource Identifier), and provides
     the URI as a yield value to the tests using this fixture. After all tests in the module are
     completed, the Milvus server is stopped.
     """
-    from milvus import default_server
-
     logger = logging.getLogger(f"morpheus.{__name__}")
 
-    # Milvus checks for already bound ports but it doesnt seem to work for webservice_port. Use a random one
-    default_server.webservice_port = _get_random_port()
-    with default_server:
-        default_server.set_base_dir(tmp_path_factory.mktemp("milvus_store"))
-
-        host = default_server.server_address
-        port = default_server.listen_port
-        uri = f"http://{host}:{port}"
-
-        logger.info("Started Milvus at: %s", uri)
-
+    uri = os.environ.get('MORPHEUS_MILVUS_URI')
+    if uri is not None:
         yield uri
 
+    else:
+        from milvus import default_server
 
-@pytest.fixture(scope="function", name="milvus_service")
-def milvus_service_fixture(milvus_server_uri: str):
-    # This fixture is scoped to the function level since the WriteToVectorDBStage will close the connection on'
-    # pipeline completion
-    from morpheus.service.milvus_vector_db_service import MilvusVectorDBService
-    service = MilvusVectorDBService(uri=milvus_server_uri)
-    yield service
+        # Milvus checks for already bound ports but it doesnt seem to work for webservice_port. Use a random one
+        default_server.webservice_port = _get_random_port()
+        with default_server:
+            default_server.set_base_dir(tmp_path_factory.mktemp("milvus_store"))
+
+            host = default_server.server_address
+            port = default_server.listen_port
+            uri = f"http://{host}:{port}"
+
+            logger.info("Started Milvus at: %s", uri)
+
+            yield uri
 
 
 @pytest.fixture(scope="session", name="milvus_data")

--- a/tests/test_milvus_vector_db_service.py
+++ b/tests/test_milvus_vector_db_service.py
@@ -23,6 +23,15 @@ from morpheus.service.milvus_client import MILVUS_DATA_TYPE_MAP
 from morpheus.service.milvus_vector_db_service import MilvusVectorDBService
 
 
+@pytest.fixture(scope="module", name="milvus_service")
+def milvus_service_fixture(milvus_server_uri: str):
+    # This fixture is scoped to the function level since the WriteToVectorDBStage will close the connection on'
+    # pipeline completion
+    from morpheus.service.milvus_vector_db_service import MilvusVectorDBService
+    service = MilvusVectorDBService(uri=milvus_server_uri)
+    yield service
+
+
 @pytest.mark.milvus
 def test_list_store_objects(milvus_service: MilvusVectorDBService):
     # List all collections in the Milvus server.

--- a/tests/test_milvus_vector_db_service.py
+++ b/tests/test_milvus_vector_db_service.py
@@ -59,21 +59,21 @@ def simple_collection_config():
     yield collection_config
 
 
-@pytest.mark.slow
+@pytest.mark.milvus
 def test_list_store_objects(milvus_service_fixture: MilvusVectorDBService):
     # List all collections in the Milvus server.
     collections = milvus_service_fixture.list_store_objects()
     assert isinstance(collections, list)
 
 
-@pytest.mark.slow
+@pytest.mark.milvus
 def test_has_store_object(milvus_service_fixture: MilvusVectorDBService):
     # Check if a non-existing collection exists in the Milvus server.
     collection_name = "non_existing_collection"
     assert not milvus_service_fixture.has_store_object(collection_name)
 
 
-@pytest.mark.slow
+@pytest.mark.milvus
 def test_create_and_drop_collection(idx_part_collection_config_fixture: dict,
                                     milvus_service_fixture: MilvusVectorDBService):
     # Create a collection and check if it exists.
@@ -86,7 +86,7 @@ def test_create_and_drop_collection(idx_part_collection_config_fixture: dict,
     assert not milvus_service_fixture.has_store_object(collection_name)
 
 
-@pytest.mark.slow
+@pytest.mark.milvus
 def test_insert_and_retrieve_by_keys(milvus_service_fixture: MilvusVectorDBService,
                                      idx_part_collection_config_fixture: dict,
                                      data_fixture: list[dict]):
@@ -107,7 +107,7 @@ def test_insert_and_retrieve_by_keys(milvus_service_fixture: MilvusVectorDBServi
     milvus_service_fixture.drop(collection_name)
 
 
-@pytest.mark.slow
+@pytest.mark.milvus
 def test_search(milvus_service_fixture: MilvusVectorDBService,
                 idx_part_collection_config_fixture: dict,
                 data_fixture: list[dict]):
@@ -131,7 +131,7 @@ def test_search(milvus_service_fixture: MilvusVectorDBService,
     milvus_service_fixture.drop(collection_name)
 
 
-@pytest.mark.slow
+@pytest.mark.milvus
 def test_search_with_data(milvus_service_fixture: MilvusVectorDBService,
                           idx_part_collection_config_fixture: dict,
                           data_fixture: list[dict]):
@@ -164,7 +164,7 @@ def test_search_with_data(milvus_service_fixture: MilvusVectorDBService,
     milvus_service_fixture.drop(collection_name)
 
 
-@pytest.mark.slow
+@pytest.mark.milvus
 def test_count(milvus_service_fixture: MilvusVectorDBService,
                idx_part_collection_config_fixture: dict,
                data_fixture: list[dict]):
@@ -183,7 +183,7 @@ def test_count(milvus_service_fixture: MilvusVectorDBService,
     milvus_service_fixture.drop(collection_name)
 
 
-@pytest.mark.slow
+@pytest.mark.milvus
 def test_overwrite_collection_on_create(milvus_service_fixture: MilvusVectorDBService,
                                         idx_part_collection_config_fixture: dict,
                                         data_fixture: list[dict]):
@@ -213,7 +213,7 @@ def test_overwrite_collection_on_create(milvus_service_fixture: MilvusVectorDBSe
     milvus_service_fixture.drop(collection_name)
 
 
-@pytest.mark.slow
+@pytest.mark.milvus
 def test_insert_into_partition(milvus_service_fixture: MilvusVectorDBService,
                                idx_part_collection_config_fixture: dict,
                                data_fixture: list[dict]):
@@ -265,7 +265,7 @@ def test_insert_into_partition(milvus_service_fixture: MilvusVectorDBService,
     milvus_service_fixture.drop(collection_name)
 
 
-@pytest.mark.slow
+@pytest.mark.milvus
 def test_update(milvus_service_fixture: MilvusVectorDBService,
                 simple_collection_config_fixture: dict,
                 data_fixture: list[dict]):
@@ -300,7 +300,7 @@ def test_update(milvus_service_fixture: MilvusVectorDBService,
     milvus_service_fixture.drop(collection_name)
 
 
-@pytest.mark.slow
+@pytest.mark.milvus
 def test_delete_by_keys(milvus_service_fixture: MilvusVectorDBService,
                         idx_part_collection_config_fixture: dict,
                         data_fixture: list[dict]):
@@ -320,7 +320,7 @@ def test_delete_by_keys(milvus_service_fixture: MilvusVectorDBService,
     milvus_service_fixture.drop(collection_name)
 
 
-@pytest.mark.slow
+@pytest.mark.milvus
 def test_delete(milvus_service_fixture: MilvusVectorDBService,
                 idx_part_collection_config_fixture: dict,
                 data_fixture: list[dict]):
@@ -348,7 +348,7 @@ def test_delete(milvus_service_fixture: MilvusVectorDBService,
     milvus_service_fixture.drop(collection_name)
 
 
-@pytest.mark.slow
+@pytest.mark.milvus
 def test_single_instance_with_collection_lock(milvus_service_fixture: MilvusVectorDBService,
                                               idx_part_collection_config_fixture: dict,
                                               data_fixture: list[dict]):
@@ -384,7 +384,7 @@ def test_single_instance_with_collection_lock(milvus_service_fixture: MilvusVect
     assert execution_order == ["Count Collection Entities Executed", "Insert Executed", "Search Executed"]
 
 
-@pytest.mark.slow
+@pytest.mark.milvus
 def test_multi_instance_with_collection_lock(milvus_service_fixture: MilvusVectorDBService,
                                              idx_part_collection_config_fixture: dict,
                                              data_fixture: list[dict],
@@ -422,6 +422,9 @@ def test_multi_instance_with_collection_lock(milvus_service_fixture: MilvusVecto
 
 
 def test_get_collection_lock():
+    """
+    This test doesn't require milvus server to be running.
+    """
     collection_name = "test_collection_lock"
     lock = MilvusVectorDBService.get_collection_lock(collection_name)
     assert "lock" == type(lock).__name__

--- a/tests/test_milvus_vector_db_service.py
+++ b/tests/test_milvus_vector_db_service.py
@@ -15,132 +15,93 @@
 # limitations under the License.
 
 import concurrent.futures
-import json
-import os
 
 import numpy as np
 import pytest
 
-from _utils import TEST_DIRS
 from morpheus.service.milvus_client import MILVUS_DATA_TYPE_MAP
 from morpheus.service.milvus_vector_db_service import MilvusVectorDBService
 
 
-@pytest.fixture(scope="module", name="milvus_service_fixture")
-def milvus_service(milvus_server_uri: str):
-    service = MilvusVectorDBService(uri=milvus_server_uri)
-    yield service
-
-
-def load_json(filename):
-    conf_filepath = os.path.join(TEST_DIRS.tests_data_dir, "service", filename)
-
-    with open(conf_filepath, 'r', encoding="utf-8") as json_file:
-        collection_config = json.load(json_file)
-
-        return collection_config
-
-
-@pytest.fixture(scope="module", name="data_fixture")
-def data():
-    inital_data = [{"id": i, "embedding": [i / 10.0] * 10, "age": 25 + i} for i in range(10)]
-    yield inital_data
-
-
-@pytest.fixture(scope="module", name="idx_part_collection_config_fixture")
-def idx_part_collection_config():
-    collection_config = load_json(filename="milvus_idx_part_collection_conf.json")
-    yield collection_config
-
-
-@pytest.fixture(scope="module", name="simple_collection_config_fixture")
-def simple_collection_config():
-    collection_config = load_json(filename="milvus_simple_collection_conf.json")
-    yield collection_config
-
-
 @pytest.mark.milvus
-def test_list_store_objects(milvus_service_fixture: MilvusVectorDBService):
+def test_list_store_objects(milvus_service: MilvusVectorDBService):
     # List all collections in the Milvus server.
-    collections = milvus_service_fixture.list_store_objects()
+    collections = milvus_service.list_store_objects()
     assert isinstance(collections, list)
 
 
 @pytest.mark.milvus
-def test_has_store_object(milvus_service_fixture: MilvusVectorDBService):
+def test_has_store_object(milvus_service: MilvusVectorDBService):
     # Check if a non-existing collection exists in the Milvus server.
     collection_name = "non_existing_collection"
-    assert not milvus_service_fixture.has_store_object(collection_name)
+    assert not milvus_service.has_store_object(collection_name)
 
 
 @pytest.mark.milvus
-def test_create_and_drop_collection(idx_part_collection_config_fixture: dict,
-                                    milvus_service_fixture: MilvusVectorDBService):
+def test_create_and_drop_collection(idx_part_collection_config: dict, milvus_service: MilvusVectorDBService):
     # Create a collection and check if it exists.
     collection_name = "test_collection"
-    milvus_service_fixture.create(collection_name, **idx_part_collection_config_fixture)
-    assert milvus_service_fixture.has_store_object(collection_name)
+    milvus_service.create(collection_name, **idx_part_collection_config)
+    assert milvus_service.has_store_object(collection_name)
 
     # Drop the collection and check if it no longer exists.
-    milvus_service_fixture.drop(collection_name)
-    assert not milvus_service_fixture.has_store_object(collection_name)
+    milvus_service.drop(collection_name)
+    assert not milvus_service.has_store_object(collection_name)
 
 
 @pytest.mark.milvus
-def test_insert_and_retrieve_by_keys(milvus_service_fixture: MilvusVectorDBService,
-                                     idx_part_collection_config_fixture: dict,
-                                     data_fixture: list[dict]):
+def test_insert_and_retrieve_by_keys(milvus_service: MilvusVectorDBService,
+                                     idx_part_collection_config: dict,
+                                     milvus_data: list[dict]):
     # Create a collection.
     collection_name = "test_insert_collection"
-    milvus_service_fixture.create(collection_name, **idx_part_collection_config_fixture)
+    milvus_service.create(collection_name, **idx_part_collection_config)
 
     # Insert data into the collection.
-    response = milvus_service_fixture.insert(collection_name, data_fixture)
-    assert response["insert_count"] == len(data_fixture)
+    response = milvus_service.insert(collection_name, milvus_data)
+    assert response["insert_count"] == len(milvus_data)
 
     # Retrieve inserted data by primary keys.
     keys_to_retrieve = [2, 4, 6]
-    retrieved_data = milvus_service_fixture.retrieve_by_keys(collection_name, keys_to_retrieve)
+    retrieved_data = milvus_service.retrieve_by_keys(collection_name, keys_to_retrieve)
     assert len(retrieved_data) == len(keys_to_retrieve)
 
     # Clean up the collection.
-    milvus_service_fixture.drop(collection_name)
+    milvus_service.drop(collection_name)
 
 
 @pytest.mark.milvus
-def test_search(milvus_service_fixture: MilvusVectorDBService,
-                idx_part_collection_config_fixture: dict,
-                data_fixture: list[dict]):
+def test_search(milvus_service: MilvusVectorDBService, idx_part_collection_config: dict, milvus_data: list[dict]):
     # Create a collection.
     collection_name = "test_search_collection"
-    milvus_service_fixture.create(collection_name, **idx_part_collection_config_fixture)
+    milvus_service.create(collection_name, **idx_part_collection_config)
 
     # Insert data into the collection.
-    milvus_service_fixture.insert(collection_name, data_fixture)
+    milvus_service.insert(collection_name, milvus_data)
 
     # Define a search query.
     query = "age==26 or age==27"
 
     # Perform a search in the collection.
-    search_result = milvus_service_fixture.search(collection_name, query)
+    search_result = milvus_service.search(collection_name, query)
     assert len(search_result) == 2
     assert search_result[0]["age"] in [26, 27]
     assert search_result[1]["age"] in [26, 27]
 
     # Clean up the collection.
-    milvus_service_fixture.drop(collection_name)
+    milvus_service.drop(collection_name)
 
 
 @pytest.mark.milvus
-def test_search_with_data(milvus_service_fixture: MilvusVectorDBService,
-                          idx_part_collection_config_fixture: dict,
-                          data_fixture: list[dict]):
+def test_search_with_data(milvus_service: MilvusVectorDBService,
+                          idx_part_collection_config: dict,
+                          milvus_data: list[dict]):
     # Create a collection.
     collection_name = "test_search_with_data_collection"
-    milvus_service_fixture.create(collection_name, **idx_part_collection_config_fixture)
+    milvus_service.create(collection_name, **idx_part_collection_config)
 
     # Insert data to the collection.
-    milvus_service_fixture.insert(collection_name, data_fixture)
+    milvus_service.insert(collection_name, milvus_data)
 
     rng = np.random.default_rng(seed=100)
     search_vec = rng.random((1, 10))
@@ -149,10 +110,7 @@ def test_search_with_data(milvus_service_fixture: MilvusVectorDBService,
     fltr = "age==26 or age==27"
 
     # Perform a search in the collection.
-    search_result = milvus_service_fixture.search(collection_name,
-                                                  data=search_vec,
-                                                  filter=fltr,
-                                                  output_fields=["id", "age"])
+    search_result = milvus_service.search(collection_name, data=search_vec, filter=fltr, output_fields=["id", "age"])
 
     assert len(search_result[0]) == 2
     assert search_result[0][0]["entity"]["age"] in [26, 27]
@@ -161,121 +119,112 @@ def test_search_with_data(milvus_service_fixture: MilvusVectorDBService,
     assert sorted(list(search_result[0][0]["entity"].keys())) == ["age", "id"]
 
     # Clean up the collection.
-    milvus_service_fixture.drop(collection_name)
+    milvus_service.drop(collection_name)
 
 
 @pytest.mark.milvus
-def test_count(milvus_service_fixture: MilvusVectorDBService,
-               idx_part_collection_config_fixture: dict,
-               data_fixture: list[dict]):
+def test_count(milvus_service: MilvusVectorDBService, idx_part_collection_config: dict, milvus_data: list[dict]):
     # Create a collection.
     collection_name = "test_count_collection"
-    milvus_service_fixture.create(collection_name, **idx_part_collection_config_fixture)
+    milvus_service.create(collection_name, **idx_part_collection_config)
 
     # Insert data into the collection.
-    milvus_service_fixture.insert(collection_name, data_fixture)
+    milvus_service.insert(collection_name, milvus_data)
 
     # Get the count of entities in the collection.
-    count = milvus_service_fixture.count(collection_name)
-    assert count == len(data_fixture)
+    count = milvus_service.count(collection_name)
+    assert count == len(milvus_data)
 
     # Clean up the collection.
-    milvus_service_fixture.drop(collection_name)
+    milvus_service.drop(collection_name)
 
 
 @pytest.mark.milvus
-def test_overwrite_collection_on_create(milvus_service_fixture: MilvusVectorDBService,
-                                        idx_part_collection_config_fixture: dict,
-                                        data_fixture: list[dict]):
+def test_overwrite_collection_on_create(milvus_service: MilvusVectorDBService,
+                                        idx_part_collection_config: dict,
+                                        milvus_data: list[dict]):
     # Create a collection.
     collection_name = "test_overwrite_collection"
-    milvus_service_fixture.create(collection_name, **idx_part_collection_config_fixture)
+    milvus_service.create(collection_name, **idx_part_collection_config)
 
     # Insert data to the collection.
-    response1 = milvus_service_fixture.insert(collection_name, data_fixture)
-    assert response1["insert_count"] == len(data_fixture)
+    response1 = milvus_service.insert(collection_name, milvus_data)
+    assert response1["insert_count"] == len(milvus_data)
 
     # Create the same collection again with overwrite=True.
-    milvus_service_fixture.create(collection_name, overwrite=True, **idx_part_collection_config_fixture)
+    milvus_service.create(collection_name, overwrite=True, **idx_part_collection_config)
 
     # Insert different data into the collection.
     data2 = [{"id": i, "embedding": [i / 10] * 10, "age": 26 + i} for i in range(10)]
 
-    response2 = milvus_service_fixture.insert(collection_name, data2)
+    response2 = milvus_service.insert(collection_name, data2)
     assert response2["insert_count"] == len(data2)
 
     # Retrieve the data from the collection and check if it matches the second set of data.
-    retrieved_data = milvus_service_fixture.retrieve_by_keys(collection_name, list(range(10)))
+    retrieved_data = milvus_service.retrieve_by_keys(collection_name, list(range(10)))
     for i in range(10):
         assert retrieved_data[i]["age"] == data2[i]["age"]
 
     # Clean up the collection.
-    milvus_service_fixture.drop(collection_name)
+    milvus_service.drop(collection_name)
 
 
 @pytest.mark.milvus
-def test_insert_into_partition(milvus_service_fixture: MilvusVectorDBService,
-                               idx_part_collection_config_fixture: dict,
-                               data_fixture: list[dict]):
+def test_insert_into_partition(milvus_service: MilvusVectorDBService,
+                               idx_part_collection_config: dict,
+                               milvus_data: list[dict]):
     # Create a collection with a partition.
     collection_name = "test_partition_collection"
-    partition_name = idx_part_collection_config_fixture["collection_conf"]["partition_conf"]["partitions"][0]["name"]
-    milvus_service_fixture.create(collection_name, **idx_part_collection_config_fixture)
+    partition_name = idx_part_collection_config["collection_conf"]["partition_conf"]["partitions"][0]["name"]
+    milvus_service.create(collection_name, **idx_part_collection_config)
 
     # Insert data into the specified partition.
-    response = milvus_service_fixture.insert(collection_name,
-                                             data_fixture,
-                                             collection_conf={"partition_name": partition_name})
-    assert response["insert_count"] == len(data_fixture)
+    response = milvus_service.insert(collection_name, milvus_data, collection_conf={"partition_name": partition_name})
+    assert response["insert_count"] == len(milvus_data)
 
     # Retrieve inserted data by primary keys.
     keys_to_retrieve = [2, 4, 6]
-    retrieved_data = milvus_service_fixture.retrieve_by_keys(collection_name,
-                                                             keys_to_retrieve,
-                                                             partition_names=[partition_name])
+    retrieved_data = milvus_service.retrieve_by_keys(collection_name,
+                                                     keys_to_retrieve,
+                                                     partition_names=[partition_name])
     assert len(retrieved_data) == len(keys_to_retrieve)
 
-    retrieved_data_default_part = milvus_service_fixture.retrieve_by_keys(collection_name,
-                                                                          keys_to_retrieve,
-                                                                          partition_names=["_default"])
+    retrieved_data_default_part = milvus_service.retrieve_by_keys(collection_name,
+                                                                  keys_to_retrieve,
+                                                                  partition_names=["_default"])
     assert len(retrieved_data_default_part) == 0
     assert len(retrieved_data_default_part) != len(keys_to_retrieve)
 
     # Raises error if resource is partition and not passed partition name.
     with pytest.raises(ValueError, match="Mandatory argument 'partition_name' is required when resource='partition'"):
-        milvus_service_fixture.drop(name=collection_name, resource="partition")
+        milvus_service.drop(name=collection_name, resource="partition")
 
     # Clean up the partition
-    milvus_service_fixture.drop(name=collection_name, resource="partition", partition_name=partition_name)
+    milvus_service.drop(name=collection_name, resource="partition", partition_name=partition_name)
 
     # Raises error if resource is index and not passed partition name.
     with pytest.raises(ValueError,
                        match="Mandatory arguments 'field_name' and 'index_name' are required when resource='index'"):
-        milvus_service_fixture.drop(name=collection_name, resource="index")
+        milvus_service.drop(name=collection_name, resource="index")
 
-    milvus_service_fixture.drop(name=collection_name,
-                                resource="index",
-                                field_name="embedding",
-                                index_name="_default_idx_")
+    milvus_service.drop(name=collection_name, resource="index", field_name="embedding", index_name="_default_idx_")
 
-    retrieved_data_after_part_drop = milvus_service_fixture.retrieve_by_keys(collection_name, keys_to_retrieve)
+    retrieved_data_after_part_drop = milvus_service.retrieve_by_keys(collection_name, keys_to_retrieve)
     assert len(retrieved_data_after_part_drop) == 0
 
     # Clean up the collection.
-    milvus_service_fixture.drop(collection_name)
+    milvus_service.drop(collection_name)
 
 
 @pytest.mark.milvus
-def test_update(milvus_service_fixture: MilvusVectorDBService,
-                simple_collection_config_fixture: dict,
-                data_fixture: list[dict]):
+def test_update(milvus_service: MilvusVectorDBService, simple_collection_config: dict, milvus_data: list[dict]):
     collection_name = "test_update_collection"
 
     # Create a collection with the specified schema configuration.
-    milvus_service_fixture.create(collection_name, **simple_collection_config_fixture)
+    milvus_service.create(collection_name, **simple_collection_config)
 
     # Insert data to the collection.
-    milvus_service_fixture.insert(collection_name, data_fixture)
+    milvus_service.insert(collection_name, milvus_data)
 
     # Use updated data to test the update/upsert functionality.
     updated_data = [{
@@ -290,89 +239,87 @@ def test_update(milvus_service_fixture: MilvusVectorDBService,
                     }]
 
     # Apply update/upsert on updated_data.
-    result_dict = milvus_service_fixture.update(collection_name, updated_data)
+    result_dict = milvus_service.update(collection_name, updated_data)
 
     assert result_dict["upsert_count"] == 7
     assert result_dict["insert_count"] == 7
     assert result_dict["succ_count"] == 7
 
     # Clean up the collection.
-    milvus_service_fixture.drop(collection_name)
+    milvus_service.drop(collection_name)
 
 
 @pytest.mark.milvus
-def test_delete_by_keys(milvus_service_fixture: MilvusVectorDBService,
-                        idx_part_collection_config_fixture: dict,
-                        data_fixture: list[dict]):
+def test_delete_by_keys(milvus_service: MilvusVectorDBService,
+                        idx_part_collection_config: dict,
+                        milvus_data: list[dict]):
     # Create a collection.
     collection_name = "test_delete_by_keys_collection"
-    milvus_service_fixture.create(collection_name, **idx_part_collection_config_fixture)
+    milvus_service.create(collection_name, **idx_part_collection_config)
 
     # Insert data into the collection.
-    milvus_service_fixture.insert(collection_name, data_fixture)
+    milvus_service.insert(collection_name, milvus_data)
 
     # Delete data by keys from the collection.
     keys_to_delete = [2, 4, 6]
-    response = milvus_service_fixture.delete_by_keys(collection_name, keys_to_delete)
+    response = milvus_service.delete_by_keys(collection_name, keys_to_delete)
     assert response == keys_to_delete
 
     # Clean up the collection.
-    milvus_service_fixture.drop(collection_name)
+    milvus_service.drop(collection_name)
 
 
 @pytest.mark.milvus
-def test_delete(milvus_service_fixture: MilvusVectorDBService,
-                idx_part_collection_config_fixture: dict,
-                data_fixture: list[dict]):
+def test_delete(milvus_service: MilvusVectorDBService, idx_part_collection_config: dict, milvus_data: list[dict]):
     # Create a collection.
     collection_name = "test_delete_collection"
-    milvus_service_fixture.create(collection_name, **idx_part_collection_config_fixture)
+    milvus_service.create(collection_name, **idx_part_collection_config)
 
     # Insert data into the collection.
-    milvus_service_fixture.insert(collection_name, data_fixture)
+    milvus_service.insert(collection_name, milvus_data)
 
     # Delete expression.
     delete_expr = "id in [0,1]"
 
     # Delete data from the collection using the expression.
-    delete_response = milvus_service_fixture.delete(collection_name, delete_expr)
+    delete_response = milvus_service.delete(collection_name, delete_expr)
     assert delete_response["delete_count"] == 2
 
-    response = milvus_service_fixture.search(collection_name, query="id > 0")
-    assert len(response) == len(data_fixture) - 2
+    response = milvus_service.search(collection_name, query="id > 0")
+    assert len(response) == len(milvus_data) - 2
 
     for item in response:
         assert item["id"] > 1
 
     # Clean up the collection.
-    milvus_service_fixture.drop(collection_name)
+    milvus_service.drop(collection_name)
 
 
 @pytest.mark.milvus
-def test_single_instance_with_collection_lock(milvus_service_fixture: MilvusVectorDBService,
-                                              idx_part_collection_config_fixture: dict,
-                                              data_fixture: list[dict]):
+def test_single_instance_with_collection_lock(milvus_service: MilvusVectorDBService,
+                                              idx_part_collection_config: dict,
+                                              milvus_data: list[dict]):
 
     # Create a collection.
     collection_name = "test_insert_and_search_order_with_collection_lock"
-    milvus_service_fixture.create(collection_name, **idx_part_collection_config_fixture)
+    milvus_service.create(collection_name, **idx_part_collection_config)
 
     filter_query = "age == 26 or age == 27"
     search_vec = np.random.random((1, 10))
     execution_order = []
 
     def insert_data():
-        result = milvus_service_fixture.insert(collection_name, data_fixture)
-        assert result['insert_count'] == len(data_fixture)
+        result = milvus_service.insert(collection_name, milvus_data)
+        assert result['insert_count'] == len(milvus_data)
         execution_order.append("Insert Executed")
 
     def search_data():
-        result = milvus_service_fixture.search(collection_name, data=search_vec, filter=filter_query)
+        result = milvus_service.search(collection_name, data=search_vec, filter=filter_query)
         execution_order.append("Search Executed")
         assert isinstance(result, list)
 
     def count_entities():
-        milvus_service_fixture.count(collection_name)
+        milvus_service.count(collection_name)
         execution_order.append("Count Collection Entities Executed")
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
@@ -385,9 +332,9 @@ def test_single_instance_with_collection_lock(milvus_service_fixture: MilvusVect
 
 
 @pytest.mark.milvus
-def test_multi_instance_with_collection_lock(milvus_service_fixture: MilvusVectorDBService,
-                                             idx_part_collection_config_fixture: dict,
-                                             data_fixture: list[dict],
+def test_multi_instance_with_collection_lock(milvus_service: MilvusVectorDBService,
+                                             idx_part_collection_config: dict,
+                                             milvus_data: list[dict],
                                              milvus_server_uri: str):
 
     milvus_service_2 = MilvusVectorDBService(uri=milvus_server_uri)
@@ -399,16 +346,16 @@ def test_multi_instance_with_collection_lock(milvus_service_fixture: MilvusVecto
     execution_order = []
 
     def create_collection():
-        milvus_service_fixture.create(collection_name, **idx_part_collection_config_fixture)
+        milvus_service.create(collection_name, **idx_part_collection_config)
         execution_order.append("Create Executed")
 
     def insert_data():
-        result = milvus_service_2.insert(collection_name, data_fixture)
-        assert result['insert_count'] == len(data_fixture)
+        result = milvus_service_2.insert(collection_name, milvus_data)
+        assert result['insert_count'] == len(milvus_data)
         execution_order.append("Insert Executed")
 
     def search_data():
-        result = milvus_service_fixture.search(collection_name, data=search_vec, filter=filter_query)
+        result = milvus_service.search(collection_name, data=search_vec, filter=filter_query)
         execution_order.append("Search Executed")
         assert isinstance(result, list)
 

--- a/tests/test_milvus_write_to_vector_db_stage_pipe.py
+++ b/tests/test_milvus_write_to_vector_db_stage_pipe.py
@@ -63,7 +63,7 @@ def create_milvus_collection(collection_name: str, conf_file: str, service: Milv
     service.create(name=collection_name, overwrite=True, **collection_config)
 
 
-@pytest.mark.slow
+@pytest.mark.milvus
 @pytest.mark.use_cpp
 @pytest.mark.parametrize("use_instance, num_input_rows, expected_num_output_rows", [(True, 5, 5), (False, 5, 5)])
 def test_write_to_vector_db_stage_pipe(milvus_service_fixture: MilvusVectorDBService,

--- a/tests/test_milvus_write_to_vector_db_stage_pipe.py
+++ b/tests/test_milvus_write_to_vector_db_stage_pipe.py
@@ -14,15 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
-import os
 import random
 
 import pytest
 
 import cudf
 
-from _utils import TEST_DIRS
 from morpheus.config import Config
 from morpheus.messages import ControlMessage
 from morpheus.modules import to_control_message  # noqa: F401 # pylint: disable=unused-import
@@ -36,12 +33,6 @@ from morpheus.utils.module_ids import MORPHEUS_MODULE_NAMESPACE
 from morpheus.utils.module_ids import TO_CONTROL_MESSAGE
 
 
-@pytest.fixture(scope="function", name="milvus_service_fixture")
-def milvus_service(milvus_server_uri: str):
-    service = MilvusVectorDBService(uri=milvus_server_uri)
-    yield service
-
-
 def get_test_df(num_input_rows):
 
     df = cudf.DataFrame({
@@ -53,21 +44,12 @@ def get_test_df(num_input_rows):
     return df
 
 
-def create_milvus_collection(collection_name: str, conf_file: str, service: MilvusVectorDBService):
-
-    conf_filepath = os.path.join(TEST_DIRS.tests_data_dir, "service", conf_file)
-
-    with open(conf_filepath, 'r', encoding="utf-8") as json_file:
-        collection_config = json.load(json_file)
-
-    service.create(name=collection_name, overwrite=True, **collection_config)
-
-
 @pytest.mark.milvus
 @pytest.mark.use_cpp
 @pytest.mark.parametrize("use_instance, num_input_rows, expected_num_output_rows", [(True, 5, 5), (False, 5, 5)])
-def test_write_to_vector_db_stage_pipe(milvus_service_fixture: MilvusVectorDBService,
+def test_write_to_vector_db_stage_pipe(milvus_service: MilvusVectorDBService,
                                        milvus_server_uri: str,
+                                       idx_part_collection_config: dict,
                                        use_instance: bool,
                                        config: Config,
                                        num_input_rows: int,
@@ -76,8 +58,9 @@ def test_write_to_vector_db_stage_pipe(milvus_service_fixture: MilvusVectorDBSer
     collection_name = "test_stage_insert_collection"
 
     # Create milvus collection using config file.
-    create_milvus_collection(collection_name, "milvus_idx_part_collection_conf.json", milvus_service_fixture)
     df = get_test_df(num_input_rows)
+
+    milvus_service.create(name=collection_name, overwrite=True, **idx_part_collection_config)
 
     to_cm_module_config = {
         "module_id": TO_CONTROL_MESSAGE, "module_name": "to_control_message", "namespace": MORPHEUS_MODULE_NAMESPACE
@@ -99,7 +82,7 @@ def test_write_to_vector_db_stage_pipe(milvus_service_fixture: MilvusVectorDBSer
         # Instantiate stage with service instance and insert options.
         write_to_vdb_stage = WriteToVectorDBStage(config,
                                                   resource_name=collection_name,
-                                                  service=milvus_service_fixture,
+                                                  service=milvus_service,
                                                   resource_kwargs=resource_kwargs)
     else:
         # Instantiate stage with service name, uri and insert options.

--- a/tests/test_milvus_write_to_vector_db_stage_pipe.py
+++ b/tests/test_milvus_write_to_vector_db_stage_pipe.py
@@ -47,8 +47,7 @@ def get_test_df(num_input_rows):
 @pytest.mark.milvus
 @pytest.mark.use_cpp
 @pytest.mark.parametrize("use_instance, num_input_rows, expected_num_output_rows", [(True, 5, 5), (False, 5, 5)])
-def test_write_to_vector_db_stage_pipe(milvus_service: MilvusVectorDBService,
-                                       milvus_server_uri: str,
+def test_write_to_vector_db_stage_pipe(milvus_server_uri: str,
                                        idx_part_collection_config: dict,
                                        use_instance: bool,
                                        config: Config,
@@ -60,6 +59,7 @@ def test_write_to_vector_db_stage_pipe(milvus_service: MilvusVectorDBService,
     # Create milvus collection using config file.
     df = get_test_df(num_input_rows)
 
+    milvus_service = MilvusVectorDBService(uri=milvus_server_uri)
     milvus_service.create(name=collection_name, overwrite=True, **idx_part_collection_config)
 
     to_cm_module_config = {


### PR DESCRIPTION
## Description
* Builds on PR #1273
* Skip milvus tests by default requiring a `--run_milvus` flag, similar to the kafka tests which require the `--run_kafka` flag.
* Milvus takes over a minute just to start up, and the tests require an additional three minutes. Requiring four minutes just to run the milvus tests alone, while the rest of the slow tests take only a minute and a half.
* Consolidate milvus related fixtures.
* Specify an explicit temp dir as the storage location for milvus, ensuring we always start with an empty database.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
