### PR TITLE
Fix LLMEngineStage crashes

### DIFF
--- a/examples/llm/common/llm_engine_stage.py
+++ b/examples/llm/common/llm_engine_stage.py
@@ -71,7 +71,7 @@ class LLMEngineStage(SinglePortStage):
     def _build_single(self, builder: mrc.Builder, input_stream: StreamPair) -> StreamPair:
 
         node = _llm.LLMEngineStage(builder, self.unique_name, self._engine)
-        node.launch_options.pe_count = 2
+        node.launch_options.pe_count = 1
 
         builder.make_edge(input_stream[0], node)
 


### PR DESCRIPTION
## Description
* Set `pe_count=1` a value of 2 was causing Morpheus to crash.

Closes #1291

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
