### PR TITLE
Fix documentation builds

### DIFF
--- a/docs/conda_docs.yml
+++ b/docs/conda_docs.yml
@@ -17,7 +17,7 @@ name: morpheus
 channels:
   - conda-forge
 dependencies:
-  - breathe=4.35.0
+  - breathe=4.34.0
   - doxygen=1.9.2
   - exhale=0.3.6
   - ipython

--- a/docs/conda_docs.yml
+++ b/docs/conda_docs.yml
@@ -18,7 +18,7 @@ channels:
   - conda-forge
 dependencies:
   - breathe=4.34.0
-  - doxygen=1.9.2
+  - doxygen>=1.9.8,<2.0
   - exhale=0.3.6
   - ipython
   - myst-parser=0.17.2

--- a/docs/conda_docs.yml
+++ b/docs/conda_docs.yml
@@ -17,8 +17,8 @@ name: morpheus
 channels:
   - conda-forge
 dependencies:
-  - breathe=4.34.0
-  - doxygen>=1.9.8,<2.0
+  - breathe=4.35.0
+  - doxygen=1.9.2
   - exhale=0.3.6
   - ipython
   - myst-parser=0.17.2

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -138,6 +138,12 @@ exhale_args = {
         INPUT = ../../morpheus/_lib
         INTERACTIVE_SVG = YES
         SOURCE_BROWSER = YES
+        ENABLE_PREPROCESSING = YES
+        MACRO_EXPANSION = YES
+        EXPAND_ONLY_PREDEF = NO
+        PREDEFINED = "MORPHEUS_EXPORT=" \
+                     "PYBIND11_TYPE_CASTER=" \
+                     "DOXYGEN_SHOULD_SKIP_THIS=1"
     ''')
 }
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -129,7 +129,7 @@ exhale_args = {
         BUILTIN_STL_SUPPORT = YES
         DOT_IMAGE_FORMAT = svg
         EXCLUDE_PATTERNS = */tests/* */include/nvtext/* */__pycache__/* */doca/*
-        EXCLUDE_SYMBOLS = "@*" "cudf*" "py::literals" "RdKafka" "mrc*" "std*"
+        EXCLUDE_SYMBOLS = "@*" "cudf*" "py::literals" "RdKafka" "mrc*" "std*" "PYBIND11_NAMESPACE*"
         EXTENSION_MAPPING = cu=C++ cuh=C++
         EXTRACT_ALL = YES
         FILE_PATTERNS = *.c *.cc *.cpp *.h *.hpp *.cu *.cuh *.md
@@ -142,7 +142,6 @@ exhale_args = {
         MACRO_EXPANSION = YES
         EXPAND_ONLY_PREDEF = NO
         PREDEFINED = "MORPHEUS_EXPORT=" \
-                     "PYBIND11_TYPE_CASTER=" \
                      "DOXYGEN_SHOULD_SKIP_THIS=1"
     ''')
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -170,6 +170,7 @@ autodoc_mock_imports = [
     "cudf",  # Avoid loading GPU libraries during the documentation build
     "cupy",  # Avoid loading GPU libraries during the documentation build
     "databricks.connect",
+    "langchain",
     "merlin",
     "morpheus.cli.commands",  # Dont document the CLI in Sphinx
     "nvtabular",

--- a/docs/source/examples/llm/README.md
+++ b/docs/source/examples/llm/README.md
@@ -14,3 +14,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
+# LLM
+
+- [completion](./completion/README.md)
+- [vdb_upload](./vdb_upload/README.md)
+- [rag](./rag/README.md)
+- [agents](./agents/README.md)

--- a/docs/source/examples/llm/agents/README.md
+++ b/docs/source/examples/llm/agents/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,3 +14,5 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
+# LLM Agents

--- a/docs/source/examples/llm/completion/README.md
+++ b/docs/source/examples/llm/completion/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,3 +14,5 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
+# LLM Completion

--- a/docs/source/examples/llm/index.rst
+++ b/docs/source/examples/llm/index.rst
@@ -1,5 +1,5 @@
 ..
-   SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+   SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
    SPDX-License-Identifier: Apache-2.0
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,25 +15,16 @@
    limitations under the License.
 
 
-========
-Examples
-========
+===
+LLM
+===
 
 .. toctree::
    :maxdepth: 20
 
-   abp_nvsmi_detection/README.md
-   abp_pcap_detection/README.md
-   gnn_fraud_detection_pipeline/README.md
-   llm/index
-   log_parsing/README.md
-   nlp_si_detection/README.md
-   ransomware_detection/README.md
-   root_cause_analysis/README.md
-   sid_visualization/README.md
-
-.. toctree::
-   :hidden:
-
-   ../examples
+   ./README.md
+   ./completion/README.md
+   ./vdb_upload/README.md
+   ./rag/README.md
+   ./agents/README.md
 

--- a/docs/source/examples/llm/rag/README.md
+++ b/docs/source/examples/llm/rag/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,3 +14,5 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
+# LLM RAG

--- a/docs/source/examples/llm/vdb_upload/README.md
+++ b/docs/source/examples/llm/vdb_upload/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,3 +14,5 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
+# LLM VDB Upload

--- a/morpheus/_lib/llm/__init__.pyi
+++ b/morpheus/_lib/llm/__init__.pyi
@@ -34,26 +34,26 @@ class InputMap():
     @property
     def external_name(self) -> str:
         """
-        The name of node that will be mapped to this input. Use a leading '/' to indicate it is a sibling node otherwise it will be treated as a parent node. Can also specify a specific node output such as '/sibling_node/output1' to map the output 'output1' of 'sibling_node' to this input. Can also use a wild card such as '/sibling_node/*' to match all internal node names
+        The name of node that will be mapped to this input. Use a leading '/' to indicate it is a sibling node otherwise it will be treated as a parent node. Can also specify a specific node output such as '/sibling_node/output1' to map the output 'output1' of 'sibling_node' to this input. Can also use a wild card such as '/sibling_node/\*' to match all internal node names
 
         :type: str
         """
     @external_name.setter
     def external_name(self, arg0: str) -> None:
         """
-        The name of node that will be mapped to this input. Use a leading '/' to indicate it is a sibling node otherwise it will be treated as a parent node. Can also specify a specific node output such as '/sibling_node/output1' to map the output 'output1' of 'sibling_node' to this input. Can also use a wild card such as '/sibling_node/*' to match all internal node names
+        The name of node that will be mapped to this input. Use a leading '/' to indicate it is a sibling node otherwise it will be treated as a parent node. Can also specify a specific node output such as '/sibling_node/output1' to map the output 'output1' of 'sibling_node' to this input. Can also use a wild card such as '/sibling_node/\*' to match all internal node names
         """
     @property
     def internal_name(self) -> str:
         """
-        The internal node name that the external node maps to. Must match an input returned from `get_input_names()` of the desired node. Defaults to '-' which is a placeholder for the default input of the node. Use a wildcard '*' to match all inputs of the node (Must also use a wild card on the external mapping).
+        The internal node name that the external node maps to. Must match an input returned from `get_input_names()` of the desired node. Defaults to '-' which is a placeholder for the default input of the node. Use a wildcard '\*' to match all inputs of the node (Must also use a wild card on the external mapping).
 
         :type: str
         """
     @internal_name.setter
     def internal_name(self, arg0: str) -> None:
         """
-        The internal node name that the external node maps to. Must match an input returned from `get_input_names()` of the desired node. Defaults to '-' which is a placeholder for the default input of the node. Use a wildcard '*' to match all inputs of the node (Must also use a wild card on the external mapping).
+        The internal node name that the external node maps to. Must match an input returned from `get_input_names()` of the desired node. Defaults to '-' which is a placeholder for the default input of the node. Use a wildcard '\*' to match all inputs of the node (Must also use a wild card on the external mapping).
         """
     pass
 class LLMContext():
@@ -113,11 +113,6 @@ class LLMLambdaNode(LLMNodeBase):
     def get_input_names(self) -> typing.List[str]: ...
     pass
 class LLMNode(LLMNodeBase):
-    def __init__(self) -> None: ...
-    @typing.overload
-    def add_node(self, name: str, *, inputs: typing.List[typing.Union[InputMap, str, typing.Tuple[str, str], LLMNodeRunner]], node: LLMNodeBase, is_output: bool = False) -> LLMNodeRunner: ...
-    @typing.overload
-    def add_node(self, name: str, *, node: LLMNodeBase, is_output: bool = False) -> LLMNodeRunner: ...
     pass
 class LLMEngine(LLMNode, LLMNodeBase):
     def __init__(self) -> None: ...

--- a/morpheus/_lib/llm/module.cpp
+++ b/morpheus/_lib/llm/module.cpp
@@ -243,8 +243,7 @@ PYBIND11_MODULE(llm, _module)
             py::arg("name"),
             py::kw_only(),
             py::arg("node"),
-            py::arg("is_output") = false,
-            "Add an LLMNode to the current node")
+            py::arg("is_output") = false)
         .def("add_node",
              &LLMNode::add_node,
              py::arg("name"),
@@ -252,7 +251,25 @@ PYBIND11_MODULE(llm, _module)
              py::arg("inputs"),
              py::arg("node"),
              py::arg("is_output") = false,
-             "Add an LLMNode to the current node");
+             R"pbdoc(
+                Add an LLMNode to the current node.
+
+                Parameters
+                ----------
+                name : str
+                    The name of the node to add
+
+                inputs : list[tuple[str, str]], optional
+                    List of input mappings to use for the node, in the form of `[(external_name, internal_name), ...]`
+                    If unspecified the node's input_names will be used.
+
+                node : LLMNodeBase
+                    The node to add
+
+                is_output : bool, optional
+                    Indicates if the node is an output node, by default False
+
+            )pbdoc");
 
     options.enable_function_signatures();
 

--- a/morpheus/_lib/llm/module.cpp
+++ b/morpheus/_lib/llm/module.cpp
@@ -87,13 +87,14 @@ PYBIND11_MODULE(llm, _module)
                        "The name of node that will be mapped to this input. Use a leading '/' to indicate it is a "
                        "sibling node otherwise it will be treated as a parent node. Can also specify a specific node "
                        "output such as '/sibling_node/output1' to map the output 'output1' of 'sibling_node' to this "
-                       "input. Can also use a wild card such as '/sibling_node/*' to match all internal node names")
-        .def_readwrite("internal_name",
-                       &InputMap::internal_name,
-                       "The internal node name that the external node maps to. Must match an input returned from "
-                       "`get_input_names()` of the desired node. Defaults to '-' which is a placeholder for the "
-                       "default input of the node. Use a wildcard '*' to match all inputs of the node (Must also use a "
-                       "wild card on the external mapping).");
+                       "input. Can also use a wild card such as '/sibling_node/\\*' to match all internal node names")
+        .def_readwrite(
+            "internal_name",
+            &InputMap::internal_name,
+            "The internal node name that the external node maps to. Must match an input returned from "
+            "`get_input_names()` of the desired node. Defaults to '-' which is a placeholder for the "
+            "default input of the node. Use a wildcard '\\*' to match all inputs of the node (Must also use a "
+            "wild card on the external mapping).");
 
     py::class_<LLMTask>(_module, "LLMTask")
         .def(py::init<>())
@@ -221,6 +222,9 @@ PYBIND11_MODULE(llm, _module)
         .def_property_readonly("sibling_input_names", &LLMNodeRunner::sibling_input_names)
         .def("execute", &LLMNodeRunner::execute, py::arg("context"));
 
+    // The auto-generated docstrings for the overloaded function in this class cause sphinx errors
+    py::options options;
+    options.disable_function_signatures();
     py::class_<LLMNode, LLMNodeBase, PyLLMNode<>, std::shared_ptr<LLMNode>>(_module, "LLMNode")
         .def(py::init_alias<>())
         .def(
@@ -239,14 +243,18 @@ PYBIND11_MODULE(llm, _module)
             py::arg("name"),
             py::kw_only(),
             py::arg("node"),
-            py::arg("is_output") = false)
+            py::arg("is_output") = false,
+            "Add an LLMNode to the current node")
         .def("add_node",
              &LLMNode::add_node,
              py::arg("name"),
              py::kw_only(),
              py::arg("inputs"),
              py::arg("node"),
-             py::arg("is_output") = false);
+             py::arg("is_output") = false,
+             "Add an LLMNode to the current node");
+
+    options.enable_function_signatures();
 
     py::class_<LLMTaskHandler, PyLLMTaskHandler, std::shared_ptr<LLMTaskHandler>>(_module, "LLMTaskHandler")
         .def(py::init<>())

--- a/morpheus/_lib/src/llm/utils.cpp
+++ b/morpheus/_lib/src/llm/utils.cpp
@@ -35,8 +35,10 @@
 
 namespace morpheus::llm {
 
+#if !defined(DOXYGEN_SHOULD_SKIP_THIS)
 // Use this regex
 const std::regex VALID_INPUT_NAME(R"([a-zA-Z_][a-zA-Z0-9_]*)", std::regex_constants::ECMAScript);
+#endif  // DOXYGEN_SHOULD_SKIP_THIS
 
 bool is_valid_node_name(std::string_view name)
 {

--- a/morpheus/_lib/src/llm/utils.cpp
+++ b/morpheus/_lib/src/llm/utils.cpp
@@ -35,6 +35,7 @@
 
 namespace morpheus::llm {
 
+// Doxygen has problems parsing this regex
 #if !defined(DOXYGEN_SHOULD_SKIP_THIS)
 // Use this regex
 const std::regex VALID_INPUT_NAME(R"([a-zA-Z_][a-zA-Z0-9_]*)", std::regex_constants::ECMAScript);

--- a/morpheus/_lib/src/stages/kafka_source.cpp
+++ b/morpheus/_lib/src/stages/kafka_source.cpp
@@ -21,6 +21,7 @@
 #include "mrc/node/rx_source_base.hpp"
 #include "mrc/node/source_properties.hpp"
 #include "mrc/segment/object.hpp"
+#include "pymrc/utilities/function_wrappers.hpp"  // for PyFuncWrapper
 
 #include "morpheus/messages/meta.hpp"
 #include "morpheus/utilities/stage_util.hpp"
@@ -35,6 +36,8 @@
 #include <mrc/segment/builder.hpp>
 #include <mrc/types.hpp>  // for SharedFuture
 #include <nlohmann/json.hpp>
+#include <pybind11/cast.h>
+#include <pybind11/pytypes.h>
 #include <pymrc/node.hpp>
 
 #include <algorithm>  // for find, min, transform
@@ -45,11 +48,14 @@
 #include <functional>
 #include <initializer_list>  // for initializer_list
 #include <iterator>          // for back_insert_iterator, back_inserter
+#include <list>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <sstream>
 #include <stdexcept>
 #include <tuple>
+#include <type_traits>
 #include <utility>
 // IWYU thinks we need atomic for vector.emplace_back of a unique_ptr
 // and __alloc_traits<>::value_type for vector assignments
@@ -74,6 +80,29 @@
 #endif  // DOXYGEN_SHOULD_SKIP_THIS
 
 namespace morpheus {
+
+KafkaOAuthCallback::KafkaOAuthCallback(const std::function<std::map<std::string, std::string>()>& oauth_callback) :
+  m_oauth_callback(oauth_callback)
+{}
+
+void KafkaOAuthCallback::oauthbearer_token_refresh_cb(RdKafka::Handle* handle, const std::string& oauthbearer_config)
+{
+    try
+    {
+        auto response = m_oauth_callback();
+        // Build parameters to pass to librdkafka
+        std::string token         = response["token"];
+        int64_t token_lifetime_ms = std::stoll(response["token_expiration_in_epoch"]);
+        std::list<std::string> extensions;  // currently not supported
+        std::string errstr;
+        auto result = handle->oauthbearer_set_token(token, token_lifetime_ms, "kafka", extensions, errstr);
+        CHECK(result == RdKafka::ErrorCode::ERR_NO_ERROR) << "Error occurred while setting the oauthbearer token";
+    } catch (std::exception ex)
+    {
+        LOG(FATAL) << "Exception occured oauth refresh: " << ex.what();
+    }
+}
+
 // Component-private classes.
 // ************ KafkaSourceStage__UnsubscribedException**************//
 class KafkaSourceStageUnsubscribedException : public std::exception
@@ -263,8 +292,9 @@ KafkaSourceStage::KafkaSourceStage(TensorIndex max_batch_size,
                                    std::map<std::string, std::string> config,
                                    bool disable_commit,
                                    bool disable_pre_filtering,
-                                   TensorIndex stop_after,
-                                   bool async_commits) :
+                                   std::size_t stop_after,
+                                   bool async_commits,
+                                   std::unique_ptr<KafkaOAuthCallback> oauth_callback) :
   PythonSource(build()),
   m_max_batch_size(max_batch_size),
   m_topics(std::vector<std::string>{std::move(topic)}),
@@ -273,7 +303,8 @@ KafkaSourceStage::KafkaSourceStage(TensorIndex max_batch_size,
   m_disable_commit(disable_commit),
   m_disable_pre_filtering(disable_pre_filtering),
   m_stop_after{stop_after},
-  m_async_commits(async_commits)
+  m_async_commits(async_commits),
+  m_oauth_callback(std::move(oauth_callback))
 {}
 
 KafkaSourceStage::KafkaSourceStage(TensorIndex max_batch_size,
@@ -282,8 +313,9 @@ KafkaSourceStage::KafkaSourceStage(TensorIndex max_batch_size,
                                    std::map<std::string, std::string> config,
                                    bool disable_commit,
                                    bool disable_pre_filtering,
-                                   TensorIndex stop_after,
-                                   bool async_commits) :
+                                   std::size_t stop_after,
+                                   bool async_commits,
+                                   std::unique_ptr<KafkaOAuthCallback> oauth_callback) :
   PythonSource(build()),
   m_max_batch_size(max_batch_size),
   m_topics(std::move(topics)),
@@ -292,13 +324,14 @@ KafkaSourceStage::KafkaSourceStage(TensorIndex max_batch_size,
   m_disable_commit(disable_commit),
   m_disable_pre_filtering(disable_pre_filtering),
   m_stop_after{stop_after},
-  m_async_commits(async_commits)
+  m_async_commits(async_commits),
+  m_oauth_callback(std::move(oauth_callback))
 {}
 
 KafkaSourceStage::subscriber_fn_t KafkaSourceStage::build()
 {
     return [this](rxcpp::subscriber<source_type_t> sub) -> void {
-        TensorIndex records_emitted = 0;
+        std::size_t records_emitted = 0;
         // Build rebalancer
         KafkaSourceStage__Rebalancer rebalancer(
             [this]() { return this->batch_timeout_ms(); },
@@ -451,6 +484,15 @@ std::unique_ptr<RdKafka::KafkaConsumer> KafkaSourceStage::create_consumer(RdKafk
     if (RdKafka::Conf::ConfResult::CONF_OK != kafka_conf->set("rebalance_cb", &rebalancer, errstr))
     {
         LOG(FATAL) << "Error occurred while setting Kafka rebalance function. Error: " << errstr;
+    }
+
+    if (m_oauth_callback != nullptr)
+    {
+        if (RdKafka::Conf::ConfResult::CONF_OK !=
+            kafka_conf->set("oauthbearer_token_refresh_cb", m_oauth_callback.get(), errstr))
+        {
+            LOG(FATAL) << "Error occurred while setting Kafka OAuth Callback function. Error: " << errstr;
+        }
     }
 
     auto consumer = std::unique_ptr<RdKafka::KafkaConsumer>(RdKafka::KafkaConsumer::create(kafka_conf.get(), errstr));
@@ -618,9 +660,12 @@ std::shared_ptr<mrc::segment::Object<KafkaSourceStage>> KafkaSourceStageInterfac
     std::map<std::string, std::string> config,
     bool disable_commit,
     bool disable_pre_filtering,
-    TensorIndex stop_after,
-    bool async_commits)
+    std::size_t stop_after,
+    bool async_commits,
+    std::optional<pybind11::function> oauth_callback)
 {
+    auto oauth_callback_cpp = KafkaSourceStageInterfaceProxy::make_kafka_oauth_callback(std::move(oauth_callback));
+
     auto stage = builder.construct_object<KafkaSourceStage>(name,
                                                             max_batch_size,
                                                             topic,
@@ -629,7 +674,8 @@ std::shared_ptr<mrc::segment::Object<KafkaSourceStage>> KafkaSourceStageInterfac
                                                             disable_commit,
                                                             disable_pre_filtering,
                                                             stop_after,
-                                                            async_commits);
+                                                            async_commits,
+                                                            std::move(oauth_callback_cpp));
 
     return stage;
 }
@@ -643,9 +689,12 @@ std::shared_ptr<mrc::segment::Object<KafkaSourceStage>> KafkaSourceStageInterfac
     std::map<std::string, std::string> config,
     bool disable_commit,
     bool disable_pre_filtering,
-    TensorIndex stop_after,
-    bool async_commits)
+    std::size_t stop_after,
+    bool async_commits,
+    std::optional<pybind11::function> oauth_callback)
 {
+    auto oauth_callback_cpp = KafkaSourceStageInterfaceProxy::make_kafka_oauth_callback(std::move(oauth_callback));
+
     auto stage = builder.construct_object<KafkaSourceStage>(name,
                                                             max_batch_size,
                                                             topics,
@@ -654,8 +703,31 @@ std::shared_ptr<mrc::segment::Object<KafkaSourceStage>> KafkaSourceStageInterfac
                                                             disable_commit,
                                                             disable_pre_filtering,
                                                             stop_after,
-                                                            async_commits);
+                                                            async_commits,
+                                                            std::move(oauth_callback_cpp));
 
     return stage;
 }
+
+std::unique_ptr<KafkaOAuthCallback> KafkaSourceStageInterfaceProxy::make_kafka_oauth_callback(
+    std::optional<pybind11::function>&& oauth_callback)
+{
+    if (oauth_callback == std::nullopt)
+    {
+        return static_cast<std::unique_ptr<KafkaOAuthCallback>>(nullptr);
+    }
+
+    auto oauth_callback_wrapped = mrc::pymrc::PyFuncWrapper(std::move(oauth_callback.value()));
+
+    return std::make_unique<KafkaOAuthCallback>([oauth_callback_wrapped = std::move(oauth_callback_wrapped)]() {
+        auto kvp_cpp = std::map<std::string, std::string>();
+        auto kvp     = oauth_callback_wrapped.operator()<pybind11::dict>();
+        for (auto [key, value] : kvp)
+        {
+            kvp_cpp[key.cast<std::string>()] = value.cast<std::string>();
+        }
+        return kvp_cpp;
+    });
+}
+
 }  // namespace morpheus

--- a/morpheus/_lib/src/stages/kafka_source.cpp
+++ b/morpheus/_lib/src/stages/kafka_source.cpp
@@ -63,6 +63,11 @@
 // IWYU pragma: no_include <ext/alloc_traits.h>
 
 #if !defined(DOXYGEN_SHOULD_SKIP_THIS)
+    /**
+     * @brief Checks the error code returned by an RDKafka expression (`command`) against an `expected` code
+     * (usually `RdKafka::ERR_NO_ERROR`), and logs an error otherwise.
+     *
+     */
     #define CHECK_KAFKA(command, expected, msg)                                                                    \
         {                                                                                                          \
             RdKafka::ErrorCode __code = command;                                                                   \

--- a/morpheus/_lib/src/stages/kafka_source.cpp
+++ b/morpheus/_lib/src/stages/kafka_source.cpp
@@ -63,11 +63,6 @@
 // IWYU pragma: no_include <ext/alloc_traits.h>
 
 #if !defined(DOXYGEN_SHOULD_SKIP_THIS)
-    /**
-     * @brief Checks the error code returned by an RDKafka expression (`command`) against an `expected` code
-     * (usually `RdKafka::ERR_NO_ERROR`), and logs an error otherwise.
-     *
-     */
     #define CHECK_KAFKA(command, expected, msg)                                                                    \
         {                                                                                                          \
             RdKafka::ErrorCode __code = command;                                                                   \
@@ -210,8 +205,12 @@ void KafkaSourceStage__Rebalancer::rebalance_cb(RdKafka::KafkaConsumer* consumer
     std::vector<RdKafka::TopicPartition*> current_assignment;
     CHECK_KAFKA(consumer->assignment(current_assignment), RdKafka::ERR_NO_ERROR, "Error retrieving current assignment");
 
-    auto old_partition_ids = foreach_map(current_assignment, [](const auto& x) { return x->partition(); });
-    auto new_partition_ids = foreach_map(partitions, [](const auto& x) { return x->partition(); });
+    auto old_partition_ids = foreach_map(current_assignment, [](const auto& x) {
+        return x->partition();
+    });
+    auto new_partition_ids = foreach_map(partitions, [](const auto& x) {
+        return x->partition();
+    });
 
     if (err == RdKafka::ERR__ASSIGN_PARTITIONS)
     {
@@ -334,8 +333,12 @@ KafkaSourceStage::subscriber_fn_t KafkaSourceStage::build()
         std::size_t records_emitted = 0;
         // Build rebalancer
         KafkaSourceStage__Rebalancer rebalancer(
-            [this]() { return this->batch_timeout_ms(); },
-            [this]() { return this->max_batch_size(); },
+            [this]() {
+                return this->batch_timeout_ms();
+            },
+            [this]() {
+                return this->max_batch_size();
+            },
             [this](const std::string str_to_display) {
                 auto& ctx = mrc::runnable::Context::get_runtime_context();
                 return MORPHEUS_CONCAT_STR(ctx.info() << " " << str_to_display);
@@ -552,8 +555,9 @@ std::unique_ptr<RdKafka::KafkaConsumer> KafkaSourceStage::create_consumer(RdKafk
 
         auto const& parts = *(topic->partitions());
 
-        std::transform(
-            parts.cbegin(), parts.cend(), std::back_inserter(part_ids), [](auto const& part) { return part->id(); });
+        std::transform(parts.cbegin(), parts.cend(), std::back_inserter(part_ids), [](auto const& part) {
+            return part->id();
+        });
 
         auto toppar_list = foreach_map(parts, [&topic](const auto& part) {
             return std::unique_ptr<RdKafka::TopicPartition>{
@@ -561,20 +565,24 @@ std::unique_ptr<RdKafka::KafkaConsumer> KafkaSourceStage::create_consumer(RdKafk
         });
 
         std::vector<RdKafka::TopicPartition*> toppar_ptrs =
-            foreach_map(toppar_list, [](const std::unique_ptr<RdKafka::TopicPartition>& x) { return x.get(); });
+            foreach_map(toppar_list, [](const std::unique_ptr<RdKafka::TopicPartition>& x) {
+                return x.get();
+            });
 
         // Query Kafka to populate the TopicPartitions with the desired offsets
         CHECK_KAFKA(
             consumer->committed(toppar_ptrs, 2000), RdKafka::ERR_NO_ERROR, "Failed retrieve Kafka committed offsets");
 
-        auto committed =
-            foreach_map(toppar_list, [](const std::unique_ptr<RdKafka::TopicPartition>& x) { return x->offset(); });
+        auto committed = foreach_map(toppar_list, [](const std::unique_ptr<RdKafka::TopicPartition>& x) {
+            return x->offset();
+        });
 
         // Query Kafka to populate the TopicPartitions with the desired offsets
         CHECK_KAFKA(consumer->position(toppar_ptrs), RdKafka::ERR_NO_ERROR, "Failed retrieve Kafka positions");
 
-        auto positions =
-            foreach_map(toppar_list, [](const std::unique_ptr<RdKafka::TopicPartition>& x) { return x->offset(); });
+        auto positions = foreach_map(toppar_list, [](const std::unique_ptr<RdKafka::TopicPartition>& x) {
+            return x->offset();
+        });
 
         auto watermarks = foreach_map(toppar_list, [&consumer](const std::unique_ptr<RdKafka::TopicPartition>& x) {
             int64_t low;


### PR DESCRIPTION
## Description
* Exclude `PYBIND11_NAMESPACE` namespace from C++ documentation builds
* Define `DOXYGEN_SHOULD_SKIP_THIS` macro as recommended in https://www.doxygen.nl/manual/faq.html#faq_code
* Define `MORPHEUS_EXPORT` as an empty macro during doxygen builds to prevent doxygen parsing errors.
* Escape occurrences of `*` in docstrings as Sphinx interprets this as the start of a bold section.
* Disable Pybind11 auto-generated function signatures from being generated for `LLMNode`, as these created an error for Sphinx as it couldn't handle the overloaded signatures, instead explicitly define a docstring.
* Mock the `langchain` module during sphinx builds as it is not installed in the default env.
* 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
