### PR TITLE
Remove overload of 'add_node' handling null inputs in lambda

### DIFF
--- a/morpheus/_lib/llm/__init__.pyi
+++ b/morpheus/_lib/llm/__init__.pyi
@@ -136,6 +136,26 @@ class LLMLambdaNode(LLMNodeBase):
     def get_input_names(self) -> typing.List[str]: ...
     pass
 class LLMNode(LLMNodeBase):
+    def __init__(self) -> None: ...
+    def add_node(self, name: str, *, inputs: object = None, node: LLMNodeBase, is_output: bool = False) -> LLMNodeRunner: 
+        """
+        Add an LLMNode to the current node.
+
+        Parameters
+        ----------
+        name : str
+            The name of the node to add
+
+        inputs : list[tuple[str, str]], optional
+            List of input mappings to use for the node, in the form of `[(external_name, internal_name), ...]`
+            If unspecified the node's input_names will be used.
+
+        node : LLMNodeBase
+            The node to add
+
+        is_output : bool, optional
+            Indicates if the node is an output node, by default False
+        """
     pass
 class LLMEngine(LLMNode, LLMNodeBase):
     def __init__(self) -> None: ...


### PR DESCRIPTION
## Description
* The auto-generated docstrings created by pybind11 for `add_node` created errors for Sphinx.
* Disabling them, and adding explicit docstrings fixes the Sphinx issue, but causes stubgen to omit including `add_node` from the `pyi` file.
* This PR works-around both issues by removing the overload, and handling the difference in the lambda method.

Closes #1331

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
