### PR TITLE
Docstrings and tests for ExtracterNode

### DIFF
--- a/morpheus/llm/nodes/extracter_node.py
+++ b/morpheus/llm/nodes/extracter_node.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 class ExtracterNode(LLMNodeBase):
     """
-    Extracts fields from the DataFrame contained by the message attached to the `LLMContext` and copies then directly
+    Extracts fields from the DataFrame contained by the message attached to the `LLMContext` and copies them directly
     to the context.
 
     The list of fields to be extracted is provided by the task's `input_keys` attached to the `LLMContext`.

--- a/morpheus/llm/nodes/extracter_node.py
+++ b/morpheus/llm/nodes/extracter_node.py
@@ -30,6 +30,7 @@ class ExtracterNode(LLMNodeBase):
     """
 
     def get_input_names(self) -> list[str]:
+        # This node does not receive it's inputs from upstream nodes, but rather from the task itself
         return []
 
     async def execute(self, context: LLMContext) -> LLMContext:

--- a/morpheus/llm/nodes/extracter_node.py
+++ b/morpheus/llm/nodes/extracter_node.py
@@ -22,11 +22,17 @@ logger = logging.getLogger(__name__)
 
 
 class ExtracterNode(LLMNodeBase):
+    """
+    Extracts fields from the DataFrame contained by the message attached to the `LLMContext` and copies then directly
+    to the context.
+
+    The list of fields to be extracted is provided by the task's `input_keys` attached to the `LLMContext`.
+    """
 
     def get_input_names(self) -> list[str]:
         return []
 
-    async def execute(self, context: LLMContext):
+    async def execute(self, context: LLMContext) -> LLMContext:
 
         # Get the keys from the task
         input_keys: list[str] = typing.cast(list[str], context.task()["input_keys"])

--- a/tests/_utils/llm.py
+++ b/tests/_utils/llm.py
@@ -23,18 +23,17 @@ from morpheus.llm import LLMTaskHandler
 from morpheus.messages import ControlMessage
 
 
-def execute_node(node: LLMNodeBase, **input_values: dict) -> typing.Any:
-    """
-    Executes an LLM Node with the necessary LLM context, and extracts the output values.
-    """
+def _mk_context(parent_context: LLMContext, input_values: dict) -> LLMContext:
     inputs: list[InputMap] = []
-    parent_context = LLMContext()
 
     for input_name, input_value in input_values.items():
         inputs.append(InputMap(f"/{input_name}", input_name))
         parent_context.set_output(input_name, input_value)
 
-    context = parent_context.push("test", inputs)
+    return parent_context.push("test", inputs)
+
+
+def _execute_node(node: LLMNodeBase, context: LLMContext) -> typing.Any:
 
     async def execute():
         # `asyncio.run(obj)`` will raise a `ValueError`` if `asyncio.iscoutine(obj)` is `False` for composite nodes
@@ -48,20 +47,47 @@ def execute_node(node: LLMNodeBase, **input_values: dict) -> typing.Any:
     return context.view_outputs
 
 
-def execute_task_handler(task_handler: LLMTaskHandler, task_dict: dict, input_message,
+def execute_node(node: LLMNodeBase,
+                 task_dict: dict = None,
+                 input_message: ControlMessage = None,
+                 **input_values: dict) -> typing.Any:
+    """
+    Executes an LLM Node with the necessary LLM context, and extracts the output values.
+
+    If `task_dict` and `input_message` are provided, then the context will be created from the task and message.
+    """
+    if task_dict is not None:
+        assert input_message is not None, "If `task_dict` is provided, then `input_message` must also be provided."
+        task = LLMTask("unittests", task_dict)
+        parent_context = LLMContext(task, input_message)
+    else:
+        assert input_message is None, "If `input_message` is provided, then `task_dict` must also be provided."
+        parent_context = LLMContext()
+
+    context = _mk_context(parent_context, input_values)
+
+    async def execute():
+        # `asyncio.run(obj)`` will raise a `ValueError`` if `asyncio.iscoutine(obj)` is `False` for composite nodes
+        # that don't directly implement `execute()` this causes a failure because while
+        # `mrc.core.coro.CppToPyAwaitable` is awaitable it is not a coroutine.
+
+        return await node.execute(context)
+
+    context = asyncio.run(execute())
+
+    return context.view_outputs
+
+
+def execute_task_handler(task_handler: LLMTaskHandler,
+                         task_dict: dict,
+                         input_message: ControlMessage,
                          **input_values: dict) -> ControlMessage:
     """
     Executes an LLM task handler with the necessary LLM context.
     """
     task = LLMTask("unittests", task_dict)
-    inputs: list[InputMap] = []
     parent_context = LLMContext(task, input_message)
-
-    for input_name, input_value in input_values.items():
-        inputs.append(InputMap(f"/{input_name}", input_name))
-        parent_context.set_output(input_name, input_value)
-
-    context = parent_context.push("test", inputs)
+    context = _mk_context(parent_context, input_values)
 
     message = asyncio.run(task_handler.try_handle(context))
 

--- a/tests/_utils/llm.py
+++ b/tests/_utils/llm.py
@@ -53,16 +53,11 @@ def execute_node(node: LLMNodeBase,
                  **input_values: dict) -> typing.Any:
     """
     Executes an LLM Node with the necessary LLM context, and extracts the output values.
-
-    If `task_dict` and `input_message` are provided, then the context will be created from the task and message.
     """
-    if task_dict is not None:
-        assert input_message is not None, "If `task_dict` is provided, then `input_message` must also be provided."
-        task = LLMTask("unittests", task_dict)
-        parent_context = LLMContext(task, input_message)
-    else:
-        assert input_message is None, "If `input_message` is provided, then `task_dict` must also be provided."
-        parent_context = LLMContext()
+    task_dict = task_dict or {}
+    input_message = input_message or ControlMessage()
+    task = LLMTask("unittests", task_dict)
+    parent_context = LLMContext(task, input_message)
 
     context = _mk_context(parent_context, input_values)
 

--- a/tests/_utils/llm.py
+++ b/tests/_utils/llm.py
@@ -33,20 +33,6 @@ def _mk_context(parent_context: LLMContext, input_values: dict) -> LLMContext:
     return parent_context.push("test", inputs)
 
 
-def _execute_node(node: LLMNodeBase, context: LLMContext) -> typing.Any:
-
-    async def execute():
-        # `asyncio.run(obj)`` will raise a `ValueError`` if `asyncio.iscoutine(obj)` is `False` for composite nodes
-        # that don't directly implement `execute()` this causes a failure because while
-        # `mrc.core.coro.CppToPyAwaitable` is awaitable it is not a coroutine.
-
-        return await node.execute(context)
-
-    context = asyncio.run(execute())
-
-    return context.view_outputs
-
-
 def execute_node(node: LLMNodeBase,
                  task_dict: dict = None,
                  input_message: ControlMessage = None,

--- a/tests/io/test_data_record.py
+++ b/tests/io/test_data_record.py
@@ -31,10 +31,11 @@ from morpheus.io.data_record import DataRecord
 @pytest.fixture(scope='session')
 def test_data():
     # setup part
+    temp_dir = tempfile.mkdtemp()
     test_cudf_dataframe = cudf.DataFrame({'a': [9, 10], 'b': [11, 12]})
     test_pd_dataframe = pd.DataFrame({'a': [13, 14], 'b': [15, 16]})
-    test_parquet_filepath = 'test_file.parquet'
-    test_csv_filepath = 'test_file.csv'
+    test_parquet_filepath = os.path.join(temp_dir, 'test_file.parquet')
+    test_csv_filepath = os.path.join(temp_dir, 'test_file.csv')
 
     test_cudf_dataframe.to_parquet(test_parquet_filepath)
     test_cudf_dataframe.to_csv(test_csv_filepath, index=False, header=True)
@@ -47,10 +48,7 @@ def test_data():
     }
 
     # teardown part
-    if os.path.exists(test_parquet_filepath):
-        os.remove(test_parquet_filepath)
-    if os.path.exists(test_csv_filepath):
-        os.remove(test_csv_filepath)
+    shutil.rmtree(temp_dir)
 
 
 @pytest.mark.parametrize("storage_type", ['in_memory', 'filesystem'])

--- a/tests/llm/nodes/test_extractor_node.py
+++ b/tests/llm/nodes/test_extractor_node.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import cudf
+
+from _utils.dataset_manager import DatasetManager
+from _utils.llm import execute_node
+# pylint: disable=morpheus-incorrect-lib-from-import
+from morpheus._lib.messages import MessageMeta as MessageMetaCpp
+# pylint: enable=morpheus-incorrect-lib-from-import
+from morpheus.llm import LLMNodeBase
+from morpheus.llm.nodes.extracter_node import ExtracterNode
+from morpheus.messages import ControlMessage
+
+
+def test_constructor():
+    node = ExtracterNode()
+    assert isinstance(node, LLMNodeBase)
+
+
+def test_get_input_names():
+    node = ExtracterNode()
+    assert len(node.get_input_names()) == 0
+
+
+def test_execute():
+    insects = ["ant", "bee", "butterfly", "mosquito", "grasshopper"]
+    mammals = ["lion", "dolphin", "gorilla", "wolf", "tiger"]
+    reptiles = ['lizards', 'snakes', 'turtles', 'frogs', 'toads']
+    df = cudf.DataFrame({"insects": insects.copy(), "mammals": mammals.copy(), "reptiles": reptiles.copy()})
+    message = ControlMessage()
+    message.payload(MessageMetaCpp(df))
+
+    task_dict = {"input_keys": ["mammals", "reptiles"]}
+    node = ExtracterNode()
+    assert execute_node(node, task_dict=task_dict, input_message=message) == {"mammals": mammals, "reptiles": reptiles}

--- a/tests/llm/nodes/test_extractor_node.py
+++ b/tests/llm/nodes/test_extractor_node.py
@@ -15,7 +15,6 @@
 
 import cudf
 
-from _utils.dataset_manager import DatasetManager
 from _utils.llm import execute_node
 # pylint: disable=morpheus-incorrect-lib-from-import
 from morpheus._lib.messages import MessageMeta as MessageMetaCpp

--- a/tests/llm/test_extractor_simple_task_handler_pipe.py
+++ b/tests/llm/test_extractor_simple_task_handler_pipe.py
@@ -38,7 +38,7 @@ def _build_engine() -> LLMEngine:
 
 
 @pytest.mark.use_python
-def test_pipeline(config: Config, dataset_cudf: DatasetManager):
+def test_extractor_simple_task_handler_pipeline(config: Config, dataset_cudf: DatasetManager):
     input_df = dataset_cudf["filter_probs.csv"]
     expected_df = input_df.copy(deep=True)
     expected_df['response'] = input_df['v3']


### PR DESCRIPTION
## Description
* Adds docstrings and tests for ExtracterNode
* Update `execute_node` test helper to add a task and control message to the context
* Update `tests/io/test_data_record.py` to store test files in a temporary directory, prevents them from being left in the repo dir when tests are halted.
* Rename `tests/llm/task_handlers/test_simple_task_handler_pipe.py` -> `tests/llm/test_extractor_simple_task_handler_pipe.py` to reflect the fact that an end-to-end test for `ExtracterNode` requires also testing `SimpleTaskHandler`

Closes #1277 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
