### PR TITLE
C++ unit tests for LLMNodeRunner, LLMTaskHandlerRunner and LLMTask

### DIFF
--- a/morpheus/_lib/src/llm/llm_node_runner.cpp
+++ b/morpheus/_lib/src/llm/llm_node_runner.cpp
@@ -60,9 +60,9 @@ LLMNodeRunner::LLMNodeRunner(std::string name, input_mappings_t inputs, std::sha
     {
         const auto& external_name = inp.external_name;
 
-        if (specified_input_names_set.contains(inp.external_name))
+        if (specified_input_names_set.contains(inp.internal_name))
         {
-            throw std::runtime_error("Input '" + inp.external_name + "' is specified more than once");
+            throw std::runtime_error("Input '" + inp.internal_name + "' is specified more than once");
         }
 
         // Determine if the inputs are coming from a parent node or a sibling node

--- a/morpheus/_lib/tests/CMakeLists.txt
+++ b/morpheus/_lib/tests/CMakeLists.txt
@@ -148,6 +148,9 @@ add_morpheus_test(
   FILES
     llm/test_llm_engine.cpp
     llm/test_llm_node.cpp
+    llm/test_llm_node_runner.cpp
+    llm/test_llm_task.cpp
+    llm/test_llm_task_handler_runner.cpp
     llm/test_utils.cpp
 )
 

--- a/morpheus/_lib/tests/llm/test_llm_node_runner.cpp
+++ b/morpheus/_lib/tests/llm/test_llm_node_runner.cpp
@@ -1,0 +1,119 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../test_utils/common.hpp"  // IWYU pragma: associated
+
+#include "morpheus/llm/input_map.hpp"
+#include "morpheus/llm/llm_context.hpp"
+#include "morpheus/llm/llm_lambda_node.hpp"
+#include "morpheus/llm/llm_node.hpp"
+#include "morpheus/llm/llm_node_runner.hpp"
+#include "morpheus/llm/llm_task.hpp"
+#include "morpheus/types.hpp"
+
+#include <gtest/gtest.h>
+#include <mrc/channel/forward.hpp>
+#include <mrc/coroutines/sync_wait.hpp>
+
+#include <coroutine>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+using namespace morpheus;
+using namespace morpheus::test;
+using namespace mrc;
+
+TEST_CLASS(LLMNodeRunner);
+
+auto make_nr_dummy_node()
+{
+    return llm::make_lambda_node([]() -> Task<int> {
+        co_return 0;
+    });
+}
+
+auto make_nr_single_input_node()
+{
+    return llm::make_lambda_node([](int i) -> Task<int> {
+        co_return i + 1;
+    });
+}
+
+TEST_F(TestLLMNodeRunner, ParentInput)
+{
+    auto node   = make_nr_single_input_node();
+    auto inputs = llm::input_mappings_t{{"input0", "arg0"}};
+    llm::LLMNodeRunner runner{"runner", inputs, node};
+    ASSERT_EQ(runner.parent_input_names(), std::vector<std::string>{"input0"});
+    ASSERT_EQ(runner.sibling_input_names(), std::vector<std::string>{});
+}
+
+TEST_F(TestLLMNodeRunner, SiblingInput)
+{
+    auto node_1   = make_nr_single_input_node();
+    auto inputs_1 = llm::input_mappings_t{{"/ext", "arg0"}};
+    llm::LLMNodeRunner runner_1{"runner", inputs_1, node_1};
+    ASSERT_EQ(runner_1.parent_input_names(), std::vector<std::string>{});
+    ASSERT_EQ(runner_1.sibling_input_names(), std::vector<std::string>{"/ext"});
+
+    auto node_2   = make_nr_single_input_node();
+    auto inputs_2 = llm::input_mappings_t{{"/ext/input0", "arg0"}};
+    llm::LLMNodeRunner runner_2{"runner", inputs_2, node_2};
+    ASSERT_EQ(runner_2.parent_input_names(), std::vector<std::string>{});
+    ASSERT_EQ(runner_2.sibling_input_names(), std::vector<std::string>{"/ext/input0"});
+}
+
+TEST_F(TestLLMNodeRunner, DuplicateInput)
+{
+    auto node   = make_nr_single_input_node();
+    auto inputs = llm::input_mappings_t{{"input0", "arg0"}, {"input0", "arg0"}};
+    ASSERT_THROW(llm::LLMNodeRunner("runner", inputs, node), std::runtime_error);
+}
+
+TEST_F(TestLLMNodeRunner, InvalidExternalNode)
+{
+    auto node   = make_nr_single_input_node();
+    auto inputs = llm::input_mappings_t{{"ext/input0", "arg0"}};
+    ASSERT_THROW(llm::LLMNodeRunner("runner", inputs, node), std::invalid_argument);
+}
+
+TEST_F(TestLLMNodeRunner, InvalidInputForNode)
+{
+    auto node     = make_nr_single_input_node();
+    auto inputs_1 = llm::input_mappings_t{{"input0", "arg1"}};
+    ASSERT_THROW(llm::LLMNodeRunner("runner", inputs_1, node), std::runtime_error);
+
+    auto inputs_2 = llm::input_mappings_t{{"input0", "arg0"}, {"input1", "arg1"}};
+    ASSERT_THROW(llm::LLMNodeRunner("runner", inputs_2, node), std::runtime_error);
+}
+
+TEST_F(TestLLMNodeRunner, Execute)
+{
+    llm::LLMNode node;
+
+    auto runner_1 = node.add_node("Root1", {}, make_nr_dummy_node());
+    auto runner_2 = node.add_node("Root2", {{"/Root1"}}, make_nr_single_input_node(), true);
+
+    auto context = std::make_shared<llm::LLMContext>(llm::LLMTask{}, nullptr);
+
+    coroutines::sync_wait(runner_1->execute(context));
+    coroutines::sync_wait(runner_2->execute(context));
+
+    ASSERT_EQ(context->view_outputs()["Root1"], 0);
+    ASSERT_EQ(context->view_outputs()["Root2"], 1);
+}

--- a/morpheus/_lib/tests/llm/test_llm_node_runner.cpp
+++ b/morpheus/_lib/tests/llm/test_llm_node_runner.cpp
@@ -82,7 +82,7 @@ TEST_F(TestLLMNodeRunner, SiblingInputExternalNodeInputName)
     ASSERT_EQ(runner.sibling_input_names(), std::vector<std::string>{"/sibling/input0"});
 }
 
-TEST_F(TestLLMNodeRunner, ParentSiblingInput)
+TEST_F(TestLLMNodeRunner, ParentSiblingInputs)
 {
     auto node = std::make_shared<llm::LLMNode>();
 

--- a/morpheus/_lib/tests/llm/test_llm_task.cpp
+++ b/morpheus/_lib/tests/llm/test_llm_task.cpp
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../test_utils/common.hpp"  // IWYU pragma: associated
+
+#include "morpheus/llm/llm_task.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace morpheus;
+using namespace morpheus::test;
+
+TEST_CLASS(LLMTask);
+
+TEST_F(TestLLMTask, Initialization)
+{
+    llm::LLMTask task_1;
+    ASSERT_EQ(task_1.size(), 0);
+
+    nlohmann::json task_dict;
+    task_dict = {
+        {"task_type", "dictionary"},
+        {"model_name", "test1"},
+    };
+
+    llm::LLMTask task_2{"template", task_dict};
+    ASSERT_EQ(task_2.get("task_type"), "dictionary");
+    ASSERT_EQ(task_2.get("model_name"), "test1");
+    ASSERT_EQ(task_2.size(), 2);
+}
+
+TEST_F(TestLLMTask, SetTaskDict)
+{
+    llm::LLMTask task_1;
+
+    nlohmann::json task_dict;
+    task_dict = {
+        {"task_type", "dictionary"},
+        {"model_name", "test1"},
+    };
+
+    llm::LLMTask task_2{"template", task_dict};
+
+    task_2.set("model_name", "test2");
+    task_2.set("addkey_1", "val1");
+    task_2.set("addkey_2", "val2");
+    task_2.set("addkey_3", "val3");
+    ASSERT_EQ(task_2.get("task_type"), "dictionary");
+    ASSERT_EQ(task_2.get("model_name"), "test2");
+    ASSERT_EQ(task_2.get("addkey_1"), "val1");
+    ASSERT_EQ(task_2.get("addkey_2"), "val2");
+    ASSERT_EQ(task_2.get("addkey_3"), "val3");
+    ASSERT_EQ(task_2.size(), 5);
+}

--- a/morpheus/_lib/tests/llm/test_llm_task_handler_runner.cpp
+++ b/morpheus/_lib/tests/llm/test_llm_task_handler_runner.cpp
@@ -84,25 +84,40 @@ class TestTaskHandler : public llm::LLMTaskHandler
 
 TEST_CLASS(LLMTaskHandlerRunner);
 
+TEST_F(TestLLMTaskHandlerRunner, Initialization)
+{
+    auto names   = std::vector<std::string>{"input0", "input1"};
+    auto handler = std::make_shared<TestTaskHandler>(names);
+    auto inputs  = llm::input_mappings_t{{"/ext0", "input0"}, {"/ext1", "input1"}};
+
+    llm::LLMTaskHandlerRunner runner{inputs, handler};
+
+    auto returned_mappings = runner.input_names();
+    ASSERT_EQ(returned_mappings.size(), 2);
+    ASSERT_EQ(returned_mappings[0].external_name, "/ext0");
+    ASSERT_EQ(returned_mappings[0].internal_name, "input0");
+    ASSERT_EQ(returned_mappings[1].external_name, "/ext1");
+    ASSERT_EQ(returned_mappings[1].internal_name, "input1");
+}
+
 TEST_F(TestLLMTaskHandlerRunner, TryHandle)
 {
-    auto names = std::vector<std::string>{"input1", "input2"};
-    TestTaskHandler handler{names};
+    auto names   = std::vector<std::string>{"input0", "input1"};
+    auto handler = std::make_shared<TestTaskHandler>(names);
+    auto inputs  = llm::input_mappings_t{{"/ext0", "input0"}, {"/ext1", "input1"}};
 
-    ASSERT_EQ(handler.get_input_names(), names);
+    llm::LLMTaskHandlerRunner runner{inputs, handler};
 
-    auto context = std::make_shared<llm::LLMContext>(llm::LLMTask{}, nullptr);
+    auto context  = std::make_shared<llm::LLMContext>(llm::LLMTask{}, nullptr);
+    auto out_msgs = coroutines::sync_wait(runner.try_handle(context));
 
-    auto out_msgs = coroutines::sync_wait(handler.try_handle(context));
-
-    ASSERT_EQ(0, 0);
     ASSERT_EQ(out_msgs->size(), 2);
     ASSERT_EQ(out_msgs->at(0)->get_tasks().size(), 1);
     ASSERT_EQ(out_msgs->at(0)->get_tasks()["template"][0]["task_type"], "dictionary");
     ASSERT_EQ(out_msgs->at(0)->get_tasks()["template"][0]["model_name"], "test");
-    ASSERT_EQ(out_msgs->at(0)->get_tasks()["template"][0]["input"], "input1");
+    ASSERT_EQ(out_msgs->at(0)->get_tasks()["template"][0]["input"], "input0");
     ASSERT_EQ(out_msgs->at(1)->get_tasks().size(), 1);
     ASSERT_EQ(out_msgs->at(1)->get_tasks()["template"][0]["task_type"], "dictionary");
     ASSERT_EQ(out_msgs->at(1)->get_tasks()["template"][0]["model_name"], "test");
-    ASSERT_EQ(out_msgs->at(1)->get_tasks()["template"][0]["input"], "input2");
+    ASSERT_EQ(out_msgs->at(1)->get_tasks()["template"][0]["input"], "input1");
 }

--- a/morpheus/_lib/tests/llm/test_llm_task_handler_runner.cpp
+++ b/morpheus/_lib/tests/llm/test_llm_task_handler_runner.cpp
@@ -48,21 +48,21 @@ class TestTaskHandler : public llm::LLMTaskHandler
 
     TestTaskHandler(std::vector<std::string> input_names)
     {
-        _input_names = input_names;
+        m_input_names = input_names;
     }
 
-    ~TestTaskHandler() = default;
+    ~TestTaskHandler() override = default;
 
-    std::vector<std::string> get_input_names() const
+    std::vector<std::string> get_input_names() const override
     {
-        return _input_names;
+        return m_input_names;
     }
 
-    Task<return_t> try_handle(std::shared_ptr<llm::LLMContext> context)
+    Task<return_t> try_handle(std::shared_ptr<llm::LLMContext> context) override
     {
         std::vector<std::shared_ptr<ControlMessage>> results;
 
-        for (auto& name : _input_names)
+        for (auto& name : m_input_names)
         {
             auto msg_config = nlohmann::json();
             nlohmann::json task_properties;
@@ -79,7 +79,7 @@ class TestTaskHandler : public llm::LLMTaskHandler
     }
 
   private:
-    std::vector<std::string> _input_names;
+    std::vector<std::string> m_input_names;
 };
 
 TEST_CLASS(LLMTaskHandlerRunner);

--- a/morpheus/_lib/tests/llm/test_llm_task_handler_runner.cpp
+++ b/morpheus/_lib/tests/llm/test_llm_task_handler_runner.cpp
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../test_utils/common.hpp"  // IWYU pragma: associated
+
+#include "morpheus/llm/input_map.hpp"
+#include "morpheus/llm/llm_context.hpp"
+#include "morpheus/llm/llm_lambda_node.hpp"
+#include "morpheus/llm/llm_node.hpp"
+#include "morpheus/llm/llm_node_runner.hpp"
+#include "morpheus/llm/llm_task.hpp"
+#include "morpheus/llm/llm_task_handler.hpp"
+#include "morpheus/llm/llm_task_handler_runner.hpp"
+#include "morpheus/types.hpp"
+
+#include <gtest/gtest.h>
+#include <mrc/channel/forward.hpp>
+#include <mrc/coroutines/sync_wait.hpp>
+#include <mrc/coroutines/task.hpp>
+
+#include <coroutine>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+using namespace morpheus;
+using namespace morpheus::test;
+using namespace mrc;
+
+class TestTaskHandler : public llm::LLMTaskHandler
+{
+  public:
+    TestTaskHandler() = default;
+
+    TestTaskHandler(std::vector<std::string> input_names)
+    {
+        _input_names = input_names;
+    }
+
+    ~TestTaskHandler() = default;
+
+    std::vector<std::string> get_input_names() const
+    {
+        return _input_names;
+    }
+
+    Task<return_t> try_handle(std::shared_ptr<llm::LLMContext> context)
+    {
+        std::vector<std::shared_ptr<ControlMessage>> results;
+
+        for (auto& name : _input_names)
+        {
+            auto msg_config = nlohmann::json();
+            nlohmann::json task_properties;
+            task_properties          = {{"task_type", "dictionary"}, {"model_name", "test"}};
+            task_properties["input"] = name;
+            msg_config["tasks"]      = {{{"type", "template"}, {"properties", task_properties}}};
+
+            auto msg = std::make_shared<ControlMessage>(msg_config);
+
+            results.push_back(msg);
+        }
+
+        co_return results;
+    }
+
+  private:
+    std::vector<std::string> _input_names;
+};
+
+TEST_CLASS(LLMTaskHandlerRunner);
+
+TEST_F(TestLLMTaskHandlerRunner, TryHandle)
+{
+    auto names = std::vector<std::string>{"input1", "input2"};
+    TestTaskHandler handler{names};
+
+    ASSERT_EQ(handler.get_input_names(), names);
+
+    auto context = std::make_shared<llm::LLMContext>(llm::LLMTask{}, nullptr);
+
+    auto out_msgs = coroutines::sync_wait(handler.try_handle(context));
+
+    ASSERT_EQ(0, 0);
+    ASSERT_EQ(out_msgs->size(), 2);
+    ASSERT_EQ(out_msgs->at(0)->get_tasks().size(), 1);
+    ASSERT_EQ(out_msgs->at(0)->get_tasks()["template"][0]["task_type"], "dictionary");
+    ASSERT_EQ(out_msgs->at(0)->get_tasks()["template"][0]["model_name"], "test");
+    ASSERT_EQ(out_msgs->at(0)->get_tasks()["template"][0]["input"], "input1");
+    ASSERT_EQ(out_msgs->at(1)->get_tasks().size(), 1);
+    ASSERT_EQ(out_msgs->at(1)->get_tasks()["template"][0]["task_type"], "dictionary");
+    ASSERT_EQ(out_msgs->at(1)->get_tasks()["template"][0]["model_name"], "test");
+    ASSERT_EQ(out_msgs->at(1)->get_tasks()["template"][0]["input"], "input2");
+}


### PR DESCRIPTION
## Description
- C++ unit tests for LLMNodeRunner, LLMTaskHandlerRunner and LLMTask
- Fix check for duplicate input names in LLMNodeRunner

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
