### PR TITLE
Add end-to-end tests for completion and stand-alone rag pipelines

### DIFF
--- a/examples/llm/agents/kafka_pipeline.py
+++ b/examples/llm/agents/kafka_pipeline.py
@@ -86,7 +86,7 @@ def pipeline(num_threads, pipeline_batch_size, model_max_batch_size, model_name)
 
     pipe.add_stage(LLMEngineStage(config, engine=_build_engine(model_name=model_name)))
 
-    pipe.add_stage(InMemorySinkStage(config))
+    sink = pipe.add_stage(InMemorySinkStage(config))
 
     # pipe.add_stage(MonitorStage(config, description="Upload rate", unit="events", delayed_start=True))
 

--- a/examples/llm/common/utils.py
+++ b/examples/llm/common/utils.py
@@ -17,24 +17,35 @@ import pymilvus
 from langchain.embeddings import HuggingFaceEmbeddings
 
 from morpheus.llm.services.nemo_llm_service import NeMoLLMService
+from morpheus.llm.services.openai_chat_service import OpenAIChatService
 from morpheus.service.vdb.milvus_vector_db_service import MilvusVectorDBService
 from morpheus.service.vdb.utils import VectorDBServiceFactory
 
 logger = logging.getLogger(__name__)
 
 
-def build_huggingface_embeddings(model_name: str, model_kwargs: dict = None, encode_kwargs: dict = None):
-    embeddings = HuggingFaceEmbeddings(model_name=model_name, model_kwargs=model_kwargs, encode_kwargs=encode_kwargs)
+def build_huggingface_embeddings(model_name: str,
+                                 model_kwargs: dict = None,
+                                 encode_kwargs: dict = None):
+    embeddings = HuggingFaceEmbeddings(model_name=model_name,
+                                       model_kwargs=model_kwargs,
+                                       encode_kwargs=encode_kwargs)
 
     return embeddings
 
 
-def build_llm_service(model_name: str, model_type, **model_kwargs):
-    if (model_type.lower() in ('nemo', )):
+def build_llm_service(model_name: str, llm_service: str,
+                      tokens_to_generate: int, **model_kwargs):
+    lowered_llm_service = llm_service.lower()
+    if (lowered_llm_service == 'nemollm'):
+        model_kwargs['tokens_to_generate'] = tokens_to_generate
         llm_service = NeMoLLMService()
+    elif (lowered_llm_service == 'openai'):
+        model_kwargs['max_tokens'] = tokens_to_generate
+        llm_service = OpenAIChatService()
     else:
         # TODO(Devin) : Add additional options
-        raise RuntimeError(f"Unsupported LLM model type: {model_type}")
+        raise RuntimeError(f"Unsupported LLM service name: {llm_service}")
 
     return llm_service.get_client(model_name, **model_kwargs)
 
@@ -51,13 +62,15 @@ def build_milvus_config(embedding_size: int):
             },
         },
         "schema_conf": {
-            "enable_dynamic_field": True,
+            "enable_dynamic_field":
+            True,
             "schema_fields": [
-                pymilvus.FieldSchema(name="id",
-                                     dtype=pymilvus.DataType.INT64,
-                                     description="Primary key for the collection",
-                                     is_primary=True,
-                                     auto_id=True).to_dict(),
+                pymilvus.FieldSchema(
+                    name="id",
+                    dtype=pymilvus.DataType.INT64,
+                    description="Primary key for the collection",
+                    is_primary=True,
+                    auto_id=True).to_dict(),
                 pymilvus.FieldSchema(name="title",
                                      dtype=pymilvus.DataType.VARCHAR,
                                      description="The title of the RSS Page",
@@ -70,28 +83,30 @@ def build_milvus_config(embedding_size: int):
                                      dtype=pymilvus.DataType.VARCHAR,
                                      description="The summary of the RSS Page",
                                      max_length=65_535).to_dict(),
-                pymilvus.FieldSchema(name="page_content",
-                                     dtype=pymilvus.DataType.VARCHAR,
-                                     description="A chunk of text from the RSS Page",
-                                     max_length=65_535).to_dict(),
+                pymilvus.FieldSchema(
+                    name="page_content",
+                    dtype=pymilvus.DataType.VARCHAR,
+                    description="A chunk of text from the RSS Page",
+                    max_length=65_535).to_dict(),
                 pymilvus.FieldSchema(name="embedding",
                                      dtype=pymilvus.DataType.FLOAT_VECTOR,
                                      description="Embedding vectors",
                                      dim=embedding_size).to_dict(),
             ],
-            "description": "Test collection schema"
+            "description":
+            "Test collection schema"
         }
     }
 
     return milvus_resource_kwargs
 
 
-def build_milvus_service(embedding_size: int, uri: str = "http://localhost:19530"):
+def build_milvus_service(embedding_size: int,
+                         uri: str = "http://localhost:19530"):
     milvus_resource_kwargs = build_milvus_config(embedding_size)
 
-    vdb_service: MilvusVectorDBService = VectorDBServiceFactory.create_instance("milvus",
-                                                                                uri=uri,
-                                                                                **milvus_resource_kwargs)
+    vdb_service: MilvusVectorDBService = VectorDBServiceFactory.create_instance(
+        "milvus", uri=uri, **milvus_resource_kwargs)
 
     return vdb_service
 

--- a/examples/llm/common/utils.py
+++ b/examples/llm/common/utils.py
@@ -24,18 +24,13 @@ from morpheus.service.vdb.utils import VectorDBServiceFactory
 logger = logging.getLogger(__name__)
 
 
-def build_huggingface_embeddings(model_name: str,
-                                 model_kwargs: dict = None,
-                                 encode_kwargs: dict = None):
-    embeddings = HuggingFaceEmbeddings(model_name=model_name,
-                                       model_kwargs=model_kwargs,
-                                       encode_kwargs=encode_kwargs)
+def build_huggingface_embeddings(model_name: str, model_kwargs: dict = None, encode_kwargs: dict = None):
+    embeddings = HuggingFaceEmbeddings(model_name=model_name, model_kwargs=model_kwargs, encode_kwargs=encode_kwargs)
 
     return embeddings
 
 
-def build_llm_service(model_name: str, llm_service: str,
-                      tokens_to_generate: int, **model_kwargs):
+def build_llm_service(model_name: str, llm_service: str, tokens_to_generate: int, **model_kwargs):
     lowered_llm_service = llm_service.lower()
     if (lowered_llm_service == 'nemollm'):
         model_kwargs['tokens_to_generate'] = tokens_to_generate
@@ -62,15 +57,13 @@ def build_milvus_config(embedding_size: int):
             },
         },
         "schema_conf": {
-            "enable_dynamic_field":
-            True,
+            "enable_dynamic_field": True,
             "schema_fields": [
-                pymilvus.FieldSchema(
-                    name="id",
-                    dtype=pymilvus.DataType.INT64,
-                    description="Primary key for the collection",
-                    is_primary=True,
-                    auto_id=True).to_dict(),
+                pymilvus.FieldSchema(name="id",
+                                     dtype=pymilvus.DataType.INT64,
+                                     description="Primary key for the collection",
+                                     is_primary=True,
+                                     auto_id=True).to_dict(),
                 pymilvus.FieldSchema(name="title",
                                      dtype=pymilvus.DataType.VARCHAR,
                                      description="The title of the RSS Page",
@@ -83,30 +76,28 @@ def build_milvus_config(embedding_size: int):
                                      dtype=pymilvus.DataType.VARCHAR,
                                      description="The summary of the RSS Page",
                                      max_length=65_535).to_dict(),
-                pymilvus.FieldSchema(
-                    name="page_content",
-                    dtype=pymilvus.DataType.VARCHAR,
-                    description="A chunk of text from the RSS Page",
-                    max_length=65_535).to_dict(),
+                pymilvus.FieldSchema(name="page_content",
+                                     dtype=pymilvus.DataType.VARCHAR,
+                                     description="A chunk of text from the RSS Page",
+                                     max_length=65_535).to_dict(),
                 pymilvus.FieldSchema(name="embedding",
                                      dtype=pymilvus.DataType.FLOAT_VECTOR,
                                      description="Embedding vectors",
                                      dim=embedding_size).to_dict(),
             ],
-            "description":
-            "Test collection schema"
+            "description": "Test collection schema"
         }
     }
 
     return milvus_resource_kwargs
 
 
-def build_milvus_service(embedding_size: int,
-                         uri: str = "http://localhost:19530"):
+def build_milvus_service(embedding_size: int, uri: str = "http://localhost:19530"):
     milvus_resource_kwargs = build_milvus_config(embedding_size)
 
-    vdb_service: MilvusVectorDBService = VectorDBServiceFactory.create_instance(
-        "milvus", uri=uri, **milvus_resource_kwargs)
+    vdb_service: MilvusVectorDBService = VectorDBServiceFactory.create_instance("milvus",
+                                                                                uri=uri,
+                                                                                **milvus_resource_kwargs)
 
     return vdb_service
 

--- a/examples/llm/rag/run.py
+++ b/examples/llm/rag/run.py
@@ -64,6 +64,10 @@ def run():
     type=click.IntRange(min=1),
     help="Number of times to repeat the input query. Useful for testing performance.",
 )
+@click.option("--llm_service",
+              default="NemoLLM",
+              type=click.Choice(['NemoLLM', 'OpenAI'], case_sensitive=False),
+              help="LLM service to issue requests to, should be used in conjunction with --model_name.")
 def pipeline(**kwargs):
 
     from .standalone_pipeline import standalone
@@ -104,6 +108,10 @@ def pipeline(**kwargs):
     default='gpt-43b-002',
     help="The name of the model that is deployed on Triton server",
 )
+@click.option("--llm_service",
+              default="NemoLLM",
+              type=click.Choice(['NemoLLM', 'OpenAI'], case_sensitive=False),
+              help="LLM service to issue requests to, should be used in conjunction with --model_name.")
 def persistant(**kwargs):
 
     from .persistant_pipeline import pipeline as _pipeline

--- a/examples/llm/rag/run.py
+++ b/examples/llm/rag/run.py
@@ -45,6 +45,12 @@ def run():
     help="Max batch size to use for the model",
 )
 @click.option(
+    "--embedding_size",
+    default=384,
+    type=click.IntRange(min=1),
+    help="The output size of the embedding calculation. Depends on the model supplied by --model_name",
+)
+@click.option(
     "--model_name",
     required=True,
     type=str,

--- a/examples/llm/rag/standalone_pipeline.py
+++ b/examples/llm/rag/standalone_pipeline.py
@@ -15,6 +15,7 @@ import logging
 import time
 
 import pandas as pd
+
 import cudf
 
 from morpheus.config import Config

--- a/morpheus/stages/input/rss_source_stage.py
+++ b/morpheus/stages/input/rss_source_stage.py
@@ -124,15 +124,15 @@ class RSSSourceStage(PreallocatorMixin, SingleOutputSource):
 
                     self._records_emitted += df_size
 
+                    if (self._stop_after > 0 and self._records_emitted >= self._stop_after):
+                        self._stop_requested = True
+                        logger.debug("Stop limit reached... preparing to halt the source.")
+                        break
+
             except Exception as exc:
                 if not self._controller.run_indefinitely:
                     logger.error("Failed either in the process of fetching or processing entries: %d.", exc)
                     raise
-
-            if (self._stop_after > 0 and self._records_emitted >= self._stop_after):
-                self._stop_requested = True
-                logger.debug("Stop limit reached... preparing to halt the source.")
-                break
 
             if not self._controller.run_indefinitely:
                 self._stop_requested = True

--- a/tests/llm/conftest.py
+++ b/tests/llm/conftest.py
@@ -61,3 +61,51 @@ def mock_nemollm_fixture():
         mock_nemollm.post_process_generate_response.return_value = {"text": "test_output"}
 
         yield mock_nemollm
+
+
+@pytest.fixture(name="countries")
+def countries_fixture():
+    yield [
+        "Eldoria",
+        "Drakoria",
+        "Avaloria",
+        "Mystralia",
+        "Faerundor",
+        "Glimmerholme",
+        "Emberfell",
+        "Stormhaven",
+        "Frosthold",
+        "Celestria"
+    ]
+
+
+@pytest.fixture(name="capitals")
+def capitals_fixture():
+    yield [
+        "Thundertop",
+        "Dragonspire",
+        "Starhaven",
+        "Enigma Citadel",
+        "Moonshroud",
+        "Silverglade",
+        "Infernix",
+        "Skyreach",
+        "Icicle Keep",
+        "Seraphia"
+    ]
+
+
+@pytest.fixture(name="country_prompts")
+def country_prompts_fixture(countries: list[str]):
+    yield [f"What is the capital of {country}?" for country in countries]
+
+
+@pytest.fixture(name="capital_responses")
+def capital_responses_fixture(countries: list[str], capitals: list[str]):
+    assert len(countries) == len(capitals)
+
+    responses = []
+    for (i, country) in enumerate(countries):
+        responses.append(f"The capital of {country} is {capitals[i]}.")
+
+    yield responses

--- a/tests/llm/conftest.py
+++ b/tests/llm/conftest.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+import pytest
+
+from _utils import import_or_skip
+
+
+@pytest.fixture(name="nemollm", scope='session')
+def nemollm_fixture(fail_missing: bool):
+    """
+    Fixture to ensure nemollm is installed
+    """
+    skip_reason = ("Tests for the NeMoLLMService require the nemollm package to be installed, to install this run:\n"
+                   "`mamba env update -n ${CONDA_DEFAULT_ENV} --file docker/conda/environments/cuda11.8_examples.yml`")
+    yield import_or_skip("nemollm", reason=skip_reason, fail_missing=fail_missing)
+
+
+@pytest.fixture(name="openai", scope='session')
+def openai_fixture(fail_missing: bool):
+    """
+    Fixture to ensure openai is installed
+    """
+    skip_reason = ("Tests for the OpenAIChatService require the openai package to be installed, to install this run:\n"
+                   "`mamba env update -n ${CONDA_DEFAULT_ENV} --file docker/conda/environments/cuda11.8_examples.yml`")
+    yield import_or_skip("openai", reason=skip_reason, fail_missing=fail_missing)
+
+
+@pytest.mark.usefixtures("openai")
+@pytest.fixture(name="mock_chat_completion")
+def mock_chat_completion_fixture():
+    with mock.patch("openai.ChatCompletion") as mock_chat_completion:
+        mock_chat_completion.return_value = mock_chat_completion
+
+        response = {'choices': [{'message': {'content': 'test_output'}}]}
+        mock_chat_completion.create.return_value = response.copy()
+        mock_chat_completion.acreate = mock.AsyncMock(return_value=response.copy())
+        yield mock_chat_completion
+
+
+@pytest.mark.usefixtures("nemollm")
+@pytest.fixture(name="mock_nemollm")
+def mock_nemollm_fixture():
+    with mock.patch("nemollm.NemoLLM") as mock_nemollm:
+        mock_nemollm.return_value = mock_nemollm
+        mock_nemollm.generate_multiple.return_value = ["test_output"]
+        mock_nemollm.post_process_generate_response.return_value = {"text": "test_output"}
+
+        yield mock_nemollm

--- a/tests/llm/conftest.py
+++ b/tests/llm/conftest.py
@@ -18,6 +18,7 @@ from unittest import mock
 import pytest
 
 from _utils import import_or_skip
+from _utils import require_env_variable
 
 
 @pytest.fixture(name="nemollm", scope='session')
@@ -109,3 +110,23 @@ def capital_responses_fixture(countries: list[str], capitals: list[str]):
         responses.append(f"The capital of {country} is {capitals[i]}.")
 
     yield responses
+
+
+@pytest.fixture(name="ngc_api_key", scope='session')
+def ngc_api_key_fixture():
+    """
+    Integration tests require an NGC API key.
+    """
+    yield require_env_variable(
+        varname="NGC_API_KEY",
+        reason="nemo integration tests require the `NGC_API_KEY` environment variavble to be defined.")
+
+
+@pytest.fixture(name="openai_api_key", scope='session')
+def openai_api_key_fixture():
+    """
+    Integration tests require an NGC API key.
+    """
+    yield require_env_variable(
+        varname="OPENAI_API_KEY",
+        reason="openai integration tests require the `OPENAI_API_KEY` environment variavble to be defined.")

--- a/tests/llm/services/conftest.py
+++ b/tests/llm/services/conftest.py
@@ -17,51 +17,34 @@ from unittest import mock
 
 import pytest
 
-from _utils import import_or_skip
+# Override fixtures from parent setting autouse to True
 
 
 @pytest.fixture(name="nemollm", autouse=True, scope='session')
-def nemollm_fixture(fail_missing: bool):
+def nemollm_fixture(nemollm):
     """
     All of the tests in this subdir require nemollm
     """
-    skip_reason = ("Tests for the NeMoLLMService require the nemollm package to be installed, to install this run:\n"
-                   "`mamba env update -n ${CONDA_DEFAULT_ENV} --file docker/conda/environments/cuda11.8_examples.yml`")
-    yield import_or_skip("nemollm", reason=skip_reason, fail_missing=fail_missing)
+    yield nemollm
 
 
 @pytest.fixture(name="openai", autouse=True, scope='session')
-def openai_fixture(fail_missing: bool):
+def openai_fixture(openai):
     """
     All of the tests in this subdir require openai
     """
-    skip_reason = ("Tests for the OpenAIChatService require the openai package to be installed, to install this run:\n"
-                   "`mamba env update -n ${CONDA_DEFAULT_ENV} --file docker/conda/environments/cuda11.8_examples.yml`")
-    yield import_or_skip("openai", reason=skip_reason, fail_missing=fail_missing)
+    yield openai
 
 
-# Using autouse to ensure we never attempt to actually call either of these services
-@pytest.mark.usefixtures("openai")
 @pytest.fixture(name="mock_chat_completion", autouse=True)
-def mock_chat_completion_fixture():
-    with mock.patch("openai.ChatCompletion") as mock_chat_completion:
-        mock_chat_completion.return_value = mock_chat_completion
-
-        response = {'choices': [{'message': {'content': 'test_output'}}]}
-        mock_chat_completion.create.return_value = response.copy()
-        mock_chat_completion.acreate = mock.AsyncMock(return_value=response.copy())
-        yield mock_chat_completion
+def mock_chat_completion_fixture(mock_chat_completion):
+    yield mock_chat_completion
 
 
 @pytest.mark.usefixtures("nemollm")
 @pytest.fixture(name="mock_nemollm", autouse=True)
-def mock_nemollm_fixture():
-    with mock.patch("nemollm.NemoLLM") as mock_nemollm:
-        mock_nemollm.return_value = mock_nemollm
-        mock_nemollm.generate_multiple.return_value = ["test_output"]
-        mock_nemollm.post_process_generate_response.return_value = {"text": "test_output"}
-
-        yield mock_nemollm
+def mock_nemollm_fixture(mock_nemollm):
+    yield mock_nemollm
 
 
 @pytest.fixture(name="mock_nemo_service")

--- a/tests/llm/services/test_llm_service_pipe.py
+++ b/tests/llm/services/test_llm_service_pipe.py
@@ -35,48 +35,6 @@ from morpheus.stages.llm.llm_engine_stage import LLMEngineStage
 from morpheus.stages.output.compare_dataframe_stage import CompareDataFrameStage
 from morpheus.stages.preprocess.deserialize_stage import DeserializeStage
 
-COUNTRIES = [
-    "Eldoria",
-    "Drakoria",
-    "Avaloria",
-    "Mystralia",
-    "Faerundor",
-    "Glimmerholme",
-    "Emberfell",
-    "Stormhaven",
-    "Frosthold",
-    "Celestria"
-]
-
-CAPITALS = [
-    "Thundertop",
-    "Dragonspire",
-    "Starhaven",
-    "Enigma Citadel",
-    "Moonshroud",
-    "Silverglade",
-    "Infernix",
-    "Skyreach",
-    "Icicle Keep",
-    "Seraphia"
-]
-
-
-@pytest.fixture(name="country_prompts")
-def country_prompts_fixture():
-    yield [f"What is the capital of {country}?" for country in COUNTRIES]
-
-
-@pytest.fixture(name="capital_responses")
-def capital_responses_fixture():
-    assert len(COUNTRIES) == len(CAPITALS)
-
-    responses = []
-    for (i, country) in enumerate(COUNTRIES):
-        responses.append(f"The capital of {country} is {CAPITALS[i]}.")
-
-    yield responses
-
 
 def _build_engine(llm_service_cls: LLMService):
     llm_service = llm_service_cls()

--- a/tests/llm/test_completion_pipe.py
+++ b/tests/llm/test_completion_pipe.py
@@ -80,6 +80,7 @@ def _run_pipeline(config: Config,
     return sink.get_results()
 
 
+@pytest.mark.usefixtures("nemollm")
 @pytest.mark.use_python
 @mock.patch("asyncio.wrap_future")
 @mock.patch("asyncio.gather", new_callable=mock.AsyncMock)
@@ -96,6 +97,7 @@ def test_completion_pipe_nemo(
     assert_results(results)
 
 
+@pytest.mark.usefixtures("openai")
 @pytest.mark.use_python
 def test_completion_pipe_openai(config: Config,
                                 mock_chat_completion: mock.MagicMock,
@@ -113,9 +115,10 @@ def test_completion_pipe_openai(config: Config,
     assert_results(results)
 
 
+@pytest.mark.usefixtures("nemollm")
 @pytest.mark.usefixtures("ngc_api_key")
 @pytest.mark.use_python
-def test_completion_pipe_integration_ngc(config: Config, countries: list[str], capital_responses: list[str]):
+def test_completion_pipe_integration_nemo(config: Config, countries: list[str], capital_responses: list[str]):
     results = _run_pipeline(config,
                             NeMoLLMService,
                             countries=countries,
@@ -126,6 +129,7 @@ def test_completion_pipe_integration_ngc(config: Config, countries: list[str], c
     assert results['matching_rows'] + results['diff_rows'] == len(countries)
 
 
+@pytest.mark.usefixtures("openai")
 @pytest.mark.usefixtures("openai_api_key")
 @pytest.mark.use_python
 def test_completion_pipe_integration_openai(config: Config, countries: list[str], capital_responses: list[str]):

--- a/tests/llm/test_completion_pipe.py
+++ b/tests/llm/test_completion_pipe.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+import pytest
+
+import cudf
+
+from _utils import assert_results
+from morpheus.config import Config
+from morpheus.llm import LLMEngine
+from morpheus.llm.nodes.extracter_node import ExtracterNode
+from morpheus.llm.nodes.llm_generate_node import LLMGenerateNode
+from morpheus.llm.nodes.prompt_template_node import PromptTemplateNode
+from morpheus.llm.services.llm_service import LLMService
+from morpheus.llm.services.nemo_llm_service import NeMoLLMService
+from morpheus.llm.services.openai_chat_service import OpenAIChatService
+from morpheus.llm.task_handlers.simple_task_handler import SimpleTaskHandler
+from morpheus.messages import ControlMessage
+from morpheus.pipeline.linear_pipeline import LinearPipeline
+from morpheus.stages.input.in_memory_source_stage import InMemorySourceStage
+from morpheus.stages.llm.llm_engine_stage import LLMEngineStage
+from morpheus.stages.output.compare_dataframe_stage import CompareDataFrameStage
+from morpheus.stages.preprocess.deserialize_stage import DeserializeStage
+
+
+def _build_engine(llm_service_cls: LLMService):
+    llm_service = llm_service_cls()
+    llm_clinet = llm_service.get_client(model_name="test_model")
+
+    engine = LLMEngine()
+    engine.add_node("extracter", node=ExtracterNode())
+    engine.add_node("prompts",
+                    inputs=["/extracter"],
+                    node=PromptTemplateNode(template="What is the capital of {{country}}?", template_format="jinja"))
+    engine.add_node("completion", inputs=["/prompts"], node=LLMGenerateNode(llm_client=llm_clinet))
+    engine.add_task_handler(inputs=["/completion"], handler=SimpleTaskHandler())
+
+    return engine
+
+
+def _run_pipeline(config: Config, llm_service_cls: LLMService, countries: list[str], capital_responses: list[str]):
+    """
+    Loosely patterned after `examples/llm/completion`
+    """
+    source_df = cudf.DataFrame({"country": countries})
+    expected_df = cudf.DataFrame({"country": countries, "response": capital_responses})
+
+    completion_task = {"task_type": "completion", "task_dict": {"input_keys": ["country"]}}
+
+    pipe = LinearPipeline(config)
+
+    pipe.set_source(InMemorySourceStage(config, dataframes=[source_df]))
+
+    pipe.add_stage(
+        DeserializeStage(config, message_type=ControlMessage, task_type="llm_engine", task_payload=completion_task))
+
+    pipe.add_stage(LLMEngineStage(config, engine=_build_engine(llm_service_cls)))
+    sink = pipe.add_stage(CompareDataFrameStage(config, compare_df=expected_df))
+
+    pipe.run()
+
+    assert_results(sink.get_results())
+
+
+@pytest.mark.use_python
+@mock.patch("asyncio.wrap_future")
+@mock.patch("asyncio.gather", new_callable=mock.AsyncMock)
+def test_completion_pipe_nemo(
+        mock_asyncio_gather: mock.AsyncMock,
+        mock_asyncio_wrap_future: mock.MagicMock,  # pylint: disable=unused-argument
+        config: Config,
+        mock_nemollm: mock.MagicMock,
+        country_prompts: list[str],
+        capital_responses: list[str]):
+    mock_asyncio_gather.return_value = [mock.MagicMock() for _ in range(len(country_prompts))]
+    mock_nemollm.post_process_generate_response.side_effect = [{"text": response} for response in capital_responses]
+    _run_pipeline(config, NeMoLLMService, country_prompts, capital_responses)
+
+
+@pytest.mark.use_python
+def test_completion_pipe_openai(config: Config,
+                                mock_chat_completion: mock.MagicMock,
+                                country_prompts: list[str],
+                                capital_responses: list[str]):
+    mock_chat_completion.acreate.side_effect = [{
+        "choices": [{
+            'message': {
+                'content': response
+            }
+        }]
+    } for response in capital_responses]
+
+    _run_pipeline(config, OpenAIChatService, country_prompts, capital_responses)

--- a/tests/llm/test_rag_standalone_pipe.py
+++ b/tests/llm/test_rag_standalone_pipe.py
@@ -16,7 +16,6 @@
 
 import os
 import types
-import typing
 from unittest import mock
 
 import pytest
@@ -31,9 +30,6 @@ from morpheus.config import PipelineModes
 from morpheus.llm import LLMEngine
 from morpheus.llm.nodes.extracter_node import ExtracterNode
 from morpheus.llm.nodes.rag_node import RAGNode
-from morpheus.llm.services.llm_service import LLMService
-from morpheus.llm.services.nemo_llm_service import NeMoLLMService
-from morpheus.llm.services.openai_chat_service import OpenAIChatService
 from morpheus.llm.task_handlers.simple_task_handler import SimpleTaskHandler
 from morpheus.messages import ControlMessage
 from morpheus.pipeline.linear_pipeline import LinearPipeline

--- a/tests/llm/test_rag_standalone_pipe.py
+++ b/tests/llm/test_rag_standalone_pipe.py
@@ -1,0 +1,233 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Mimic the examples/llm/rag/standalone_pipeline.py example"""
+
+import os
+import types
+import typing
+from unittest import mock
+
+import pytest
+
+import cudf
+
+from _utils import TEST_DIRS
+from _utils import assert_results
+from _utils.dataset_manager import DatasetManager
+from morpheus.config import Config
+from morpheus.config import PipelineModes
+from morpheus.llm import LLMEngine
+from morpheus.llm.nodes.extracter_node import ExtracterNode
+from morpheus.llm.nodes.rag_node import RAGNode
+from morpheus.llm.services.llm_service import LLMService
+from morpheus.llm.services.nemo_llm_service import NeMoLLMService
+from morpheus.llm.services.openai_chat_service import OpenAIChatService
+from morpheus.llm.task_handlers.simple_task_handler import SimpleTaskHandler
+from morpheus.messages import ControlMessage
+from morpheus.pipeline.linear_pipeline import LinearPipeline
+from morpheus.service.vdb.milvus_vector_db_service import MilvusVectorDBService
+from morpheus.stages.input.in_memory_source_stage import InMemorySourceStage
+from morpheus.stages.llm.llm_engine_stage import LLMEngineStage
+from morpheus.stages.output.compare_dataframe_stage import CompareDataFrameStage
+from morpheus.stages.preprocess.deserialize_stage import DeserializeStage
+
+EMBEDDING_SIZE = 384
+QUESTION = "What are some new attacks discovered in the cyber security industry?"
+PROMPT = """You are a helpful assistant. Given the following background information:\n
+{% for c in contexts -%}
+Title: {{ c.title }}
+Summary: {{ c.summary }}
+Text: {{ c.page_content }}
+{% endfor %}
+
+Please answer the following question: \n{{ query }}"""
+EXPECTED_RESPONSE = "Ransomware, Phishing, Malware, Denial of Service, SQL injection, and Password Attacks"
+
+
+def _populate_milvus(milvus_server_uri: str, collection_name: str, resource_kwargs: dict, df: cudf.DataFrame):
+    milvus_service = MilvusVectorDBService(uri=milvus_server_uri)
+    milvus_service.create(collection_name, **resource_kwargs)
+    resource_service = milvus_service.load_resource(name=collection_name)
+    resource_service.insert_dataframe(name=collection_name, df=df, **resource_kwargs)
+
+
+def _build_engine(llm_service_name: str,
+                  model_name: str,
+                  milvus_server_uri: str,
+                  collection_name: str,
+                  utils_mod: types.ModuleType):
+    engine = LLMEngine()
+    engine.add_node("extracter", node=ExtracterNode())
+
+    vector_service = utils_mod.build_milvus_service(embedding_size=EMBEDDING_SIZE, uri=milvus_server_uri)
+    embeddings = utils_mod.build_huggingface_embeddings("sentence-transformers/all-MiniLM-L6-v2",
+                                                        model_kwargs={'device': 'cuda'},
+                                                        encode_kwargs={'batch_size': 100})
+
+    llm_service = utils_mod.build_llm_service(model_name=model_name,
+                                              llm_service=llm_service_name,
+                                              temperature=0.5,
+                                              tokens_to_generate=200)
+
+    # Async wrapper around embeddings
+    async def calc_embeddings(texts: list[str]) -> list[list[float]]:
+        return embeddings.embed_documents(texts)
+
+    engine.add_node("rag",
+                    inputs=["/extracter"],
+                    node=RAGNode(prompt=PROMPT,
+                                 vdb_service=vector_service.load_resource(collection_name),
+                                 embedding=calc_embeddings,
+                                 llm_client=llm_service))
+
+    engine.add_task_handler(inputs=["/rag"], handler=SimpleTaskHandler())
+
+    return engine
+
+
+def _run_pipeline(config: Config,
+                  llm_service_name: str,
+                  model_name: str,
+                  milvus_server_uri: str,
+                  collection_name: str,
+                  repeat_count: int,
+                  utils_mod: types.ModuleType) -> dict:
+
+    config.mode = PipelineModes.NLP
+    config.edge_buffer_size = 128
+    config.pipeline_batch_size = 1024
+    config.model_max_batch_size = 64
+
+    questions = [QUESTION] * repeat_count
+    source_df = cudf.DataFrame({"questions": questions})
+    expected_df = cudf.DataFrame({"questions": questions, "response": [EXPECTED_RESPONSE] * repeat_count})
+
+    completion_task = {"task_type": "completion", "task_dict": {"input_keys": ["questions"], }}
+    pipe = LinearPipeline(config)
+
+    pipe.set_source(InMemorySourceStage(config, dataframes=[source_df]))
+
+    pipe.add_stage(
+        DeserializeStage(config, message_type=ControlMessage, task_type="llm_engine", task_payload=completion_task))
+
+    pipe.add_stage(
+        LLMEngineStage(config,
+                       engine=_build_engine(llm_service_name=llm_service_name,
+                                            model_name=model_name,
+                                            milvus_server_uri=milvus_server_uri,
+                                            collection_name=collection_name,
+                                            utils_mod=utils_mod)))
+    sink = pipe.add_stage(CompareDataFrameStage(config, compare_df=expected_df))
+
+    pipe.run()
+
+    return sink.get_results()
+
+
+@pytest.mark.milvus
+@pytest.mark.use_python
+@pytest.mark.use_cudf
+@pytest.mark.parametrize("repeat_count", [5])
+@pytest.mark.import_mod(os.path.join(TEST_DIRS.examples_dir, 'llm/common/utils.py'))
+@mock.patch("asyncio.wrap_future")
+@mock.patch("asyncio.gather", new_callable=mock.AsyncMock)
+def test_rag_standalone_pipe_nemo(
+        mock_asyncio_gather: mock.AsyncMock,
+        mock_asyncio_wrap_future: mock.MagicMock,  # pylint: disable=unused-argument
+        config: Config,
+        mock_nemollm: mock.MagicMock,
+        dataset: DatasetManager,
+        milvus_server_uri: str,
+        repeat_count: int,
+        import_mod: types.ModuleType):
+    collection_name = "test_rag_standalone_pipe_nemo"
+    _populate_milvus(milvus_server_uri=milvus_server_uri,
+                     collection_name=collection_name,
+                     resource_kwargs=import_mod.build_milvus_config(embedding_size=EMBEDDING_SIZE),
+                     df=dataset["service/milvus_rss_data.json"])
+    mock_asyncio_gather.return_value = [mock.MagicMock() for _ in range(repeat_count)]
+    mock_nemollm.post_process_generate_response.side_effect = [{"text": EXPECTED_RESPONSE} for _ in range(repeat_count)]
+    results = _run_pipeline(
+        config=config,
+        llm_service_name="nemollm",
+        model_name="test_model",
+        milvus_server_uri=milvus_server_uri,
+        collection_name=collection_name,
+        repeat_count=repeat_count,
+        utils_mod=import_mod,
+    )
+    assert_results(results)
+
+
+@pytest.mark.milvus
+@pytest.mark.use_python
+@pytest.mark.use_cudf
+@pytest.mark.parametrize("repeat_count", [5])
+@pytest.mark.import_mod(os.path.join(TEST_DIRS.examples_dir, 'llm/common/utils.py'))
+def test_rag_standalone_pipe_openai(config: Config,
+                                    mock_chat_completion: mock.MagicMock,
+                                    dataset: DatasetManager,
+                                    milvus_server_uri: str,
+                                    repeat_count: int,
+                                    import_mod: types.ModuleType):
+    mock_chat_completion.acreate.side_effect = [{
+        "choices": [{
+            'message': {
+                'content': EXPECTED_RESPONSE
+            }
+        }]
+    } for _ in range(repeat_count)]
+
+    collection_name = "test_rag_standalone_pipe_openai"
+    _populate_milvus(milvus_server_uri=milvus_server_uri,
+                     collection_name=collection_name,
+                     resource_kwargs=import_mod.build_milvus_config(embedding_size=EMBEDDING_SIZE),
+                     df=dataset["service/milvus_rss_data.json"])
+
+    results = _run_pipeline(
+        config=config,
+        llm_service_name="openai",
+        model_name="test_model",
+        milvus_server_uri=milvus_server_uri,
+        collection_name=collection_name,
+        repeat_count=repeat_count,
+        utils_mod=import_mod,
+    )
+    assert_results(results)
+
+
+# @pytest.mark.usefixtures("ngc_api_key")
+# @pytest.mark.use_python
+# def test_rag_standalone_pipe_integration_ngc(config: Config, countries: list[str], capital_responses: list[str]):
+#     results = _run_pipeline(config,
+#                             NeMoLLMService,
+#                             countries=countries,
+#                             capital_responses=capital_responses,
+#                             model_name="gpt-43b-002")
+#     assert results['diff_cols'] == 0
+#     assert results['total_rows'] == len(countries)
+#     assert results['matching_rows'] + results['diff_rows'] == len(countries)
+
+# @pytest.mark.usefixtures("openai_api_key")
+# @pytest.mark.use_python
+# def test_rag_standalone_pipe_integration_openai(config: Config, countries: list[str], capital_responses: list[str]):
+#     results = _run_pipeline(config,
+#                             OpenAIChatService,
+#                             countries=countries,
+#                             capital_responses=capital_responses,
+#                             model_name="gpt-3.5-turbo")
+#     assert results['diff_cols'] == 0
+#     assert results['total_rows'] == len(countries)
+#     assert results['matching_rows'] + results['diff_rows'] == len(countries)

--- a/tests/llm/test_rag_standalone_pipe.py
+++ b/tests/llm/test_rag_standalone_pipe.py
@@ -136,6 +136,7 @@ def _run_pipeline(config: Config,
     return sink.get_results()
 
 
+@pytest.mark.usefixtures("nemollm")
 @pytest.mark.milvus
 @pytest.mark.use_python
 @pytest.mark.use_cudf
@@ -171,6 +172,7 @@ def test_rag_standalone_pipe_nemo(
     assert_results(results)
 
 
+@pytest.mark.usefixtures("openai")
 @pytest.mark.milvus
 @pytest.mark.use_python
 @pytest.mark.use_cudf
@@ -208,6 +210,7 @@ def test_rag_standalone_pipe_openai(config: Config,
     assert_results(results)
 
 
+@pytest.mark.usefixtures("nemollm")
 @pytest.mark.usefixtures("ngc_api_key")
 @pytest.mark.use_python
 @pytest.mark.use_cudf
@@ -238,6 +241,7 @@ def test_rag_standalone_pipe_integration_nemo(config: Config,
     assert results['matching_rows'] + results['diff_rows'] == repeat_count
 
 
+@pytest.mark.usefixtures("openai")
 @pytest.mark.usefixtures("openai_api_key")
 @pytest.mark.use_python
 @pytest.mark.use_cudf

--- a/tests/tests_data/service/milvus_rss_data.json
+++ b/tests/tests_data/service/milvus_rss_data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89782c824baa0223036c763e0af791442c18feb9495a9301c7d942204894b748
+size 860051


### PR DESCRIPTION
## Description
* Add end-to-end tests for completion and stand-alone rag pipelines
* Optionally support openai as a backend for the rag pipeline
* Add `--embedding_size` to stand-alone rag pipeline, removing previously hard-coded value
* Fix evaluation of `stop_after` argument in RSS source stage.
* Relocate some fixtures from `tests/llm/services/conftest.py` to `tests/llm/conftest.py`
* Currently checks are failing for `examples/llm/rag/persistant_pipeline.py`, due to `SplitStage` not being updated.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
