### PR TITLE
Add missing milvus mark for two tests which require milvus

### DIFF
--- a/tests/llm/test_rag_standalone_pipe.py
+++ b/tests/llm/test_rag_standalone_pipe.py
@@ -208,6 +208,7 @@ def test_rag_standalone_pipe_openai(config: Config,
 
 @pytest.mark.usefixtures("nemollm")
 @pytest.mark.usefixtures("ngc_api_key")
+@pytest.mark.milvus
 @pytest.mark.use_python
 @pytest.mark.use_cudf
 @pytest.mark.parametrize("repeat_count", [5])
@@ -239,6 +240,7 @@ def test_rag_standalone_pipe_integration_nemo(config: Config,
 
 @pytest.mark.usefixtures("openai")
 @pytest.mark.usefixtures("openai_api_key")
+@pytest.mark.milvus
 @pytest.mark.use_python
 @pytest.mark.use_cudf
 @pytest.mark.parametrize("repeat_count", [5])


### PR DESCRIPTION
## Description
* The two end-to-end integration tests for the RAG pipeline required a running Milvus instance, but didn't have the `milvus` test marker.


## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
