### PR TITLE
Fix test_vdb_upload_pipe

### DIFF
--- a/tests/tests_data/service/milvus_rss_data.json
+++ b/tests/tests_data/service/milvus_rss_data.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8809aa4c1ec2e2a58b31dbe236fa92f2c579a17f6c55d26ff9885b08243ed657
-size 855471
+oid sha256:959c504e3fbd7fd796a49035885d6631220c81a298163b37ac7fb6c1f3a901b9
+size 862424


### PR DESCRIPTION
## Description
* Update mocks to reflect that When caching is disabled web-scraper uses requests not requests_cache.
* Revert accidental change to `tests/tests_data/service/milvus_rss_data.json` during merge conflicts

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
