### PR TITLE
Fix the SID Viz workflow shutdown process with the new pipeline shutdown process

### DIFF
--- a/morpheus/pipeline/pipeline.py
+++ b/morpheus/pipeline/pipeline.py
@@ -79,6 +79,8 @@ class Pipeline():
 
         self._mrc_executor: mrc.Executor = None
 
+        self._loop: asyncio.AbstractEventLoop = None
+
     @property
     def is_built(self) -> bool:
         return self._is_built


### PR DESCRIPTION
Due to the changes in #1233, the pipeline shutdown process has been slightly altered. This updates the viz demo to shutdown correctly without error. Also added support for exiting on Ctrl+C

Fixes #1391 