### PR TITLE
Update phishing validation fix to match label changes made in PR #1215

### DIFF
--- a/scripts/validation/val-run-pipeline.sh
+++ b/scripts/validation/val-run-pipeline.sh
@@ -107,7 +107,7 @@ function run_pipeline_phishing_email(){
       preprocess --vocab_hash_file=${MORPHEUS_ROOT}/morpheus/data/bert-base-uncased-hash.txt --truncation=True --do_lower_case=True --add_special_tokens=False \
       ${INFERENCE_STAGE} \
       monitor --description "Inference Rate" --smoothing=0.001 --unit inf \
-      add-class --label=pred --threshold=0.7 \
+      add-class --label=is_phishing --threshold=0.7 \
       validate --val_file_name=${VAL_FILE} --results_file_name=${VAL_OUTPUT} --overwrite \
       serialize \
       to-file --filename=${OUTPUT_FILE} --overwrite


### PR DESCRIPTION
## Description
* This PR updated the phishing validation script to match the improvements to the phishing pipeline as documented in the developer guide in PR #1215.


Closes #1395

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
