### PR TITLE
CVE-2023-47248 Mitigation

### DIFF
--- a/docker/conda/environments/cuda11.8_dev.yml
+++ b/docker/conda/environments/cuda11.8_dev.yml
@@ -121,6 +121,7 @@ dependencies:
     - pip:
         # Add additional dev dependencies here
         - databricks-connect
-        - pytest-kafka==0.6.0
-        - pymilvus==2.3.2
         - milvus==2.3.2
+        - pyarrow_hotfix # CVE-2023-47248. See morpheus/__init__.py for more details
+        - pymilvus==2.3.2
+        - pytest-kafka==0.6.0

--- a/morpheus/__init__.py
+++ b/morpheus/__init__.py
@@ -12,6 +12,12 @@
 # limitations under the License.
 """Root module for the Morpheus library."""
 
+############################ CVE-2023-47248 Mitigation ############################
+# Import pyarrow_hotfix as early as possible to ensure that the pyarrow hotfix is applied before any code can use it
+# Can be removed after upgrading to pyarrow 14.0.1 or later (which is dictated by cudf)
+import pyarrow_hotfix
+###################################################################################
+
 import logging
 import os
 

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
     packages=find_packages(include=["morpheus*"], exclude=['tests']),
     install_requires=[
         # Only list the packages which cannot be installed via conda here.
+        "pyarrow_hotfix",  # CVE-2023-47248. See morpheus/__init__.py for more details
     ],
     license="Apache",
     python_requires='>=3.10, <4',


### PR DESCRIPTION
This PR mitigates CVE-2023-47248 by importing `pyarrow_hotfix` as early as possible to ensure that the pyarrow hotfix is applied before any code can use it.

Can be removed after upgrading to pyarrow 14.0.1 or later (which is dictated by cudf)