### PR TITLE
Fix expected JSON config file extension in logger

### DIFF
--- a/morpheus/utils/logger.py
+++ b/morpheus/utils/logger.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/morpheus/utils/logger.py
+++ b/morpheus/utils/logger.py
@@ -81,7 +81,7 @@ def _configure_from_log_file(log_config_file: str):
 
     ext = os.path.splitext(log_config_file)[1].lower()
 
-    if (ext == "json"):
+    if (ext == ".json"):
 
         dict_config: dict = None
 


### PR DESCRIPTION
## Description
- Fixes bug in logger where it was looking for `json` instead of `.json` when passing JSON config file.

Fixes #1470

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
