### PR TITLE
Create a base mixin class for ingress & egress stages

### DIFF
--- a/morpheus/pipeline/boundary_stage_mixin.py
+++ b/morpheus/pipeline/boundary_stage_mixin.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from abc import ABC
 
 

--- a/morpheus/pipeline/boundary_stage_mixin.py
+++ b/morpheus/pipeline/boundary_stage_mixin.py
@@ -1,0 +1,8 @@
+from abc import ABC
+
+
+class BoundaryStageMixin(ABC):
+    """
+    Mixin intended to be added to both ingress and egress boundary stages, currently this only adds the ability to
+    identify boundary stages.
+    """

--- a/morpheus/pipeline/pipeline.py
+++ b/morpheus/pipeline/pipeline.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/morpheus/pipeline/pipeline.py
+++ b/morpheus/pipeline/pipeline.py
@@ -27,6 +27,7 @@ import networkx
 from tqdm import tqdm
 
 from morpheus.config import Config
+from morpheus.pipeline.boundary_stage_mixin import BoundaryStageMixin
 from morpheus.pipeline.preallocator_mixin import PreallocatorMixin
 from morpheus.pipeline.receiver import Receiver
 from morpheus.pipeline.sender import Sender
@@ -175,9 +176,9 @@ class Pipeline():
                                end_port_idx=end_port.port_number)
 
     def add_segment_edge(self,
-                         egress_stage: Stage,
+                         egress_stage: BoundaryStageMixin,
                          egress_segment: str,
-                         ingress_stage: Stage,
+                         ingress_stage: BoundaryStageMixin,
                          ingress_segment: str,
                          port_pair: typing.Union[str, typing.Tuple[str, typing.Type, bool]]):
         """
@@ -205,6 +206,7 @@ class Pipeline():
                 * bool: If the type is a shared pointer (typically should be `False`)
         """
         self._assert_not_built()
+        assert isinstance(egress_stage, BoundaryStageMixin), "Egress stage must be a BoundaryStageMixin"
         egress_edges = self._segments[egress_segment]["egress_ports"]
         egress_edges.append({
             "port_pair": port_pair,
@@ -213,6 +215,7 @@ class Pipeline():
             "receiver_segment": ingress_segment
         })
 
+        assert isinstance(ingress_stage, BoundaryStageMixin), "Ingress stage must be a BoundaryStageMixin"
         ingress_edges = self._segments[ingress_segment]["ingress_ports"]
         ingress_edges.append({
             "port_pair": port_pair,

--- a/morpheus/stages/boundary/linear_boundary_stage.py
+++ b/morpheus/stages/boundary/linear_boundary_stage.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/morpheus/stages/boundary/linear_boundary_stage.py
+++ b/morpheus/stages/boundary/linear_boundary_stage.py
@@ -19,6 +19,7 @@ import mrc
 from mrc.core import operators as ops
 
 from morpheus.config import Config
+from morpheus.pipeline.boundary_stage_mixin import BoundaryStageMixin
 from morpheus.pipeline.pass_thru_type_mixin import PassThruTypeMixin
 from morpheus.pipeline.preallocator_mixin import PreallocatorMixin
 from morpheus.pipeline.single_output_source import SingleOutputSource
@@ -28,7 +29,7 @@ from morpheus.pipeline.stage_schema import StageSchema
 logger = logging.getLogger(__name__)
 
 
-class LinearBoundaryEgressStage(PassThruTypeMixin, SinglePortStage):
+class LinearBoundaryEgressStage(BoundaryStageMixin, PassThruTypeMixin, SinglePortStage):
     """
     The LinearBoundaryEgressStage acts as an egress point from one linear segment to another. Given an existing linear
     pipeline that we want to connect to another segment, a linear boundary egress stage would be added, in conjunction
@@ -81,7 +82,7 @@ class LinearBoundaryEgressStage(PassThruTypeMixin, SinglePortStage):
         return input_node
 
 
-class LinearBoundaryIngressStage(PreallocatorMixin, SingleOutputSource):
+class LinearBoundaryIngressStage(BoundaryStageMixin, PreallocatorMixin, SingleOutputSource):
     """
     The LinearBoundaryIngressStage acts as source ingress point from a corresponding egress in another linear segment.
     Given an existing linear pipeline that we want to connect to another segment, a linear boundary egress stage would

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
## Description
* Creates a new `BoundaryStageMixin` class 
* Allowing `LinearBoundaryEgressStage` and `LinearBoundaryIngressStage` to share a common class and be distinguished from other stages

Closes #638 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
