### PR TITLE
Catch and log exceptions occurring while executing a langchain agentnode

### DIFF
--- a/morpheus/llm/nodes/langchain_agent_node.py
+++ b/morpheus/llm/nodes/langchain_agent_node.py
@@ -66,7 +66,10 @@ class LangChainAgentNode(LLMNodeBase):
             return results
 
         # We are not dealing with a list, so run single
-        return await self._agent_executor.arun(**kwargs)
+        try:
+            return await self._agent_executor.arun(**kwargs)
+        except Exception as e:
+            logger.exception("Error running agent: %s: %s", kwargs, e)
 
     async def execute(self, context: LLMContext) -> LLMContext:
 

--- a/morpheus/utils/http_utils.py
+++ b/morpheus/utils/http_utils.py
@@ -141,7 +141,7 @@ def request_with_retry(
                          request_kwargs['method'],
                          request_kwargs['url'],
                          e)
-            logger.debug("Sleeping for %s seconds before retrying request again", sleep_time)
+            logger.debug("Sleeping for %s seconds before retrying request again", sleep_time_)
             time.sleep(sleep_time_)
 
 


### PR DESCRIPTION
## Description
Currently an uncaught exception occurring in the langchain agent node isn't handled well. Specifically we don't know which tool cause the error, and if left un-caught this is not handled well by Morpheus/MRC often leading to a segfault.

This is a short-term work-around.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
