### PR TITLE
Make `start_async()` available to source stages

### DIFF
--- a/morpheus/pipeline/pipeline.py
+++ b/morpheus/pipeline/pipeline.py
@@ -471,8 +471,7 @@ class Pipeline():
     async def _async_start(self, stages: networkx.classes.reportviews.NodeView):
         # This method is called once for each segment in the pipeline executed on this host
         for stage in stages:
-            if (isinstance(stage, StageBase)):
-                await stage.start_async()
+            await stage.start_async()
 
     def visualize(self, filename: str = None, **graph_kwargs):
         """

--- a/morpheus/pipeline/pipeline.py
+++ b/morpheus/pipeline/pipeline.py
@@ -471,7 +471,7 @@ class Pipeline():
     async def _async_start(self, stages: networkx.classes.reportviews.NodeView):
         # This method is called once for each segment in the pipeline executed on this host
         for stage in stages:
-            if (isinstance(stage, Stage)):
+            if (isinstance(stage, StageBase)):
                 await stage.start_async()
 
     def visualize(self, filename: str = None, **graph_kwargs):

--- a/morpheus/pipeline/stage.py
+++ b/morpheus/pipeline/stage.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import logging
-import warnings
 
 import mrc
 
@@ -39,18 +38,6 @@ class Stage(_pipeline.StageBase):
 
     def _start(self):
         pass
-
-    async def start_async(self):
-        """
-        This function is called along with on_start during stage initialization. Allows stages to utilize the
-        asyncio loop if needed.
-        """
-        if (hasattr(self, 'on_start')):
-            warnings.warn(
-                "The on_start method is deprecated and may be removed in the future. "
-                "Please use start_async instead.",
-                DeprecationWarning)
-            self.on_start()
 
     def _on_complete(self, node):  # pylint: disable=unused-argument
         logger.info("Stage Complete: %s", self.name)

--- a/morpheus/pipeline/stage_base.py
+++ b/morpheus/pipeline/stage_base.py
@@ -18,9 +18,9 @@ import functools
 import inspect
 import logging
 import typing
+import warnings
 from abc import ABC
 from abc import abstractmethod
-import warnings
 
 import mrc
 
@@ -75,6 +75,8 @@ class StageBase(ABC, collections.abc.Hashable):
         Pipeline configuration instance.
 
     """
+
+    # pylint:disable=too-many-public-methods
 
     __ID_COUNTER = AtomicInteger(0)
 

--- a/morpheus/pipeline/stage_base.py
+++ b/morpheus/pipeline/stage_base.py
@@ -20,6 +20,7 @@ import logging
 import typing
 from abc import ABC
 from abc import abstractmethod
+import warnings
 
 import mrc
 
@@ -494,3 +495,15 @@ class StageBase(ABC, collections.abc.Hashable):
         `compute_schema` being called.
         """
         pass
+
+    async def start_async(self):
+        """
+        This function is called along with on_start during stage initialization. Allows stages to utilize the
+        asyncio loop if needed.
+        """
+        if (hasattr(self, 'on_start')):
+            warnings.warn(
+                "The on_start method is deprecated and may be removed in the future. "
+                "Please use start_async instead.",
+                DeprecationWarning)
+            self.on_start()

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -163,8 +163,8 @@ def test_startup_cb_called(filter_probs_df: DataFrameType):
 
     _run_pipeline(filter_probs_df, source_callbacks=source_callbacks, sink_callbacks=sink_callbacks)
 
-    # assert state_dict["source_on_start"]
-    # assert state_dict["source_start_async"]
+    assert state_dict["source_on_start"]
+    assert state_dict["source_start_async"]
     assert state_dict["sink_on_start"]
     assert state_dict["sink_start_async"]
 

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -47,14 +47,27 @@ class SourceTestStage(InMemorySourceStage):
     def __init__(self,
                  config,
                  dataframes: typing.List[DataFrameType],
+                 on_start_cb: typing.Callable[[], None] = None,
+                 start_async_cb: typing.Callable[[], None] = None,
                  destructor_cb: typing.Callable[[], None] = None,
                  repeat: int = 1):
         super().__init__(config, dataframes, repeat)
+        self._on_start_cb = on_start_cb
+        self._start_async_cb = start_async_cb
         self._destructor_cb = destructor_cb
 
     @property
     def name(self) -> str:
         return "test-source"
+
+    def on_start(self):
+        if self._on_start_cb is not None:
+            self._on_start_cb()
+
+    async def start_async(self):
+        await super().start_async()
+        if self._start_async_cb is not None:
+            self._start_async_cb()
 
     def __del__(self):
         if self._destructor_cb is not None:
@@ -130,21 +143,30 @@ def test_startup_cb_called(filter_probs_df: DataFrameType):
     """
     Test to ensure that the destructors of stages are called (issue #1114).
     """
-    state_dict = {"on_start": False, "start_async": False}
+    state_dict = {
+        "source_on_start": False, "source_start_async": False, "sink_on_start": False, "sink_start_async": False
+    }
 
     def update_state_dict(key: str):
         nonlocal state_dict
         state_dict[key] = True
 
-    sink_callbacks = {
-        'on_start_cb': lambda: update_state_dict("on_start"),
-        'start_async_cb': lambda: update_state_dict("start_async")
+    source_callbacks = {
+        'on_start_cb': lambda: update_state_dict("source_on_start"),
+        'start_async_cb': lambda: update_state_dict("source_start_async")
     }
 
-    _run_pipeline(filter_probs_df, source_callbacks={}, sink_callbacks=sink_callbacks)
+    sink_callbacks = {
+        'on_start_cb': lambda: update_state_dict("sink_on_start"),
+        'start_async_cb': lambda: update_state_dict("sink_start_async")
+    }
 
-    assert state_dict["on_start"]
-    assert state_dict["start_async"]
+    _run_pipeline(filter_probs_df, source_callbacks=source_callbacks, sink_callbacks=sink_callbacks)
+
+    # assert state_dict["source_on_start"]
+    # assert state_dict["source_start_async"]
+    assert state_dict["sink_on_start"]
+    assert state_dict["sink_start_async"]
 
 
 @pytest.mark.use_cudf


### PR DESCRIPTION
## Description
- Moves `start_async` from `Stage` to `StageBase` to make it available to source stages.
- Adds tests for source stage `start_async` and `on_start`. 

Closes #1522

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
