### PR TITLE
Fix memory leak in the mutable dataframe checkout/checkin code

### DIFF
--- a/morpheus/_lib/include/morpheus/objects/mutable_table_ctx_mgr.hpp
+++ b/morpheus/_lib/include/morpheus/objects/mutable_table_ctx_mgr.hpp
@@ -36,6 +36,7 @@ class MutableTableCtxMgr
 {
   public:
     MutableTableCtxMgr(MessageMeta& meta_msg);
+
     pybind11::object enter();
     void exit(const pybind11::object& type, const pybind11::object& value, const pybind11::object& traceback);
 

--- a/morpheus/_lib/include/morpheus/objects/mutable_table_ctx_mgr.hpp
+++ b/morpheus/_lib/include/morpheus/objects/mutable_table_ctx_mgr.hpp
@@ -36,7 +36,6 @@ class MutableTableCtxMgr
 {
   public:
     MutableTableCtxMgr(MessageMeta& meta_msg);
-
     pybind11::object enter();
     void exit(const pybind11::object& type, const pybind11::object& value, const pybind11::object& traceback);
 

--- a/morpheus/_lib/include/morpheus/objects/table_info.hpp
+++ b/morpheus/_lib/include/morpheus/objects/table_info.hpp
@@ -185,9 +185,9 @@ struct MORPHEUS_EXPORT MutableTableInfo : public TableInfoBase
      * lifetime of `MutableTableInfo`. Use this method when it is necessary to make changes to the python object using
      * the python API. The python object must be returned via `return_obj` before `MutableTableInfo` goes out of scope.
      *
-     * @return pybind11::object
+     * @return std::unique_ptr<pybind11::object>
      */
-    pybind11::object checkout_obj();
+    std::unique_ptr<pybind11::object> checkout_obj();
 
     /**
      * @brief Returns the checked out python object from `checkout_obj`. Each call to `checkout_obj` needs a
@@ -195,7 +195,7 @@ struct MORPHEUS_EXPORT MutableTableInfo : public TableInfoBase
      *
      * @param obj
      */
-    void return_obj(pybind11::object&& obj);
+    void return_obj(std::unique_ptr<pybind11::object>&& obj);
 
     /**
      * @brief Replaces the index in the underlying dataframe if the existing one is not unique and monotonic. The old

--- a/morpheus/_lib/include/morpheus/stages/preprocess_fil.hpp
+++ b/morpheus/_lib/include/morpheus/stages/preprocess_fil.hpp
@@ -22,19 +22,12 @@
 #include "morpheus/objects/table_info.hpp"
 
 #include <boost/fiber/context.hpp>
-#include <boost/fiber/future/future.hpp>
-#include <mrc/node/rx_sink_base.hpp>
-#include <mrc/node/rx_source_base.hpp>
-#include <mrc/node/sink_properties.hpp>
-#include <mrc/node/source_properties.hpp>
 #include <mrc/segment/builder.hpp>
 #include <mrc/segment/object.hpp>
-#include <mrc/types.hpp>
 #include <pymrc/node.hpp>
 #include <rxcpp/rx.hpp>  // for apply, make_subscriber, observable_member, is_on_error<>::not_void, is_on_next_of<>::not_void, from
 // IWYU pragma: no_include "rxcpp/sources/rx-iterate.hpp"
 
-#include <map>
 #include <memory>
 #include <string>
 #include <thread>

--- a/morpheus/_lib/src/messages/multi.cpp
+++ b/morpheus/_lib/src/messages/multi.cpp
@@ -377,7 +377,8 @@ void MultiMessageInterfaceProxy::set_meta(MultiMessage& self, pybind11::object c
     // Need the GIL for the remainder
     pybind11::gil_scoped_acquire gil;
 
-    auto df = mutable_info.checkout_obj();
+    auto pdf = mutable_info.checkout_obj();
+    auto& df = *pdf;
 
     auto [row_indexer, column_indexer] = get_indexers(self, df, columns);
 
@@ -427,7 +428,7 @@ void MultiMessageInterfaceProxy::set_meta(MultiMessage& self, pybind11::object c
         }
     }
 
-    mutable_info.return_obj(std::move(df));
+    mutable_info.return_obj(std::move(pdf));
 }
 
 std::shared_ptr<MultiMessage> MultiMessageInterfaceProxy::get_slice(MultiMessage& self,

--- a/morpheus/_lib/src/messages/multi.cpp
+++ b/morpheus/_lib/src/messages/multi.cpp
@@ -32,21 +32,17 @@
 #include <cudf/types.hpp>
 #include <glog/logging.h>       // for CHECK
 #include <mrc/cuda/common.hpp>  // for MRC_CHECK_CUDA
-#include <pybind11/cast.h>
+#include <pybind11/cast.h>      // IWYU pragma: keep
 #include <pybind11/gil.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
-#include <rmm/cuda_stream_view.hpp>
-#include <rmm/mr/device/per_device_resource.hpp>  // for get_current_device_resource
 
 #include <algorithm>  // for transform
-#include <array>      // needed for pybind11::make_tuple
 #include <cstddef>    // for size_t
 #include <cstdint>    // for uint8_t
 #include <sstream>
 #include <stdexcept>  // for runtime_error
 #include <tuple>
-#include <type_traits>
 #include <utility>
 // IWYU pragma: no_include <unordered_map>
 

--- a/morpheus/_lib/src/objects/mutable_table_ctx_mgr.cpp
+++ b/morpheus/_lib/src/objects/mutable_table_ctx_mgr.cpp
@@ -19,7 +19,6 @@
 
 #include "morpheus/utilities/string_util.hpp"
 
-#include <glog/logging.h>  // for DCHECK
 #include <pybind11/gil.h>
 #include <pybind11/pytypes.h>
 
@@ -49,8 +48,6 @@ void MutableTableCtxMgr::exit(const py::object& type, const py::object& value, c
 {
     std::unique_ptr<pybind11::object> ptr{nullptr};
     m_py_table.swap(ptr);
-    DCHECK(m_py_table == nullptr);
-    DCHECK_NOTNULL(ptr);
 
     m_table->return_obj(std::move(ptr));
     m_table.reset(nullptr);

--- a/morpheus/_lib/src/objects/mutable_table_ctx_mgr.cpp
+++ b/morpheus/_lib/src/objects/mutable_table_ctx_mgr.cpp
@@ -19,9 +19,11 @@
 
 #include "morpheus/utilities/string_util.hpp"
 
+#include <glog/logging.h>  // for DCHECK
 #include <pybind11/gil.h>
 #include <pybind11/pytypes.h>
 
+#include <memory>
 #include <utility>
 
 namespace morpheus {
@@ -39,13 +41,18 @@ py::object MutableTableCtxMgr::enter()
     // Release the GIL
     py::gil_scoped_release no_gil;
     m_table    = std::make_unique<MutableTableInfo>(std::move(m_meta_msg.get_mutable_info()));
-    m_py_table = std::make_unique<py::object>(std::move(m_table->checkout_obj()));
+    m_py_table = m_table->checkout_obj();
     return *m_py_table;
 }
 
 void MutableTableCtxMgr::exit(const py::object& type, const py::object& value, const py::object& traceback)
 {
-    m_table->return_obj(std::move(*m_py_table.release()));
+    std::unique_ptr<pybind11::object> ptr{nullptr};
+    m_py_table.swap(ptr);
+    DCHECK(m_py_table == nullptr);
+    DCHECK_NOTNULL(ptr);
+
+    m_table->return_obj(std::move(ptr));
     m_table.reset(nullptr);
 }
 

--- a/morpheus/_lib/src/stages/preprocess_fil.cpp
+++ b/morpheus/_lib/src/stages/preprocess_fil.cpp
@@ -17,12 +17,7 @@
 
 #include "morpheus/stages/preprocess_fil.hpp"
 
-#include "mrc/node/rx_sink_base.hpp"
-#include "mrc/node/rx_source_base.hpp"
-#include "mrc/node/sink_properties.hpp"
-#include "mrc/node/source_properties.hpp"
 #include "mrc/segment/object.hpp"
-#include "mrc/types.hpp"
 
 #include "morpheus/messages/memory/inference_memory_fil.hpp"
 #include "morpheus/messages/meta.hpp"         // for MessageMeta
@@ -41,7 +36,6 @@
 #include <cudf/unary.hpp>
 #include <mrc/cuda/common.hpp>  // for MRC_CHECK_CUDA
 #include <mrc/segment/builder.hpp>
-#include <pybind11/cast.h>  // for object_api::operator(), operator""_a
 #include <pybind11/gil.h>
 #include <pybind11/pybind11.h>  // for str_attr_accessor, arg
 #include <pybind11/pytypes.h>
@@ -49,10 +43,9 @@
 #include <rmm/cuda_stream_view.hpp>  // for cuda_stream_per_thread
 #include <rmm/device_buffer.hpp>     // for device_buffer
 
-#include <array>
+#include <algorithm>  // for std::find
 #include <cstddef>
 #include <exception>
-#include <functional>
 #include <memory>
 #include <utility>
 

--- a/morpheus/_lib/src/stages/preprocess_fil.cpp
+++ b/morpheus/_lib/src/stages/preprocess_fil.cpp
@@ -184,7 +184,8 @@ TableInfo PreprocessFILStage::fix_bad_columns(sink_type_t x)
             pybind11::gil_scoped_acquire gil;
 
             // pybind11::object df = x->meta->get_py_table();
-            auto df = mutable_info.checkout_obj();
+            auto pdf = mutable_info.checkout_obj();
+            auto& df = *pdf;
 
             std::string regex = R"((\d+))";
 
@@ -196,7 +197,7 @@ TableInfo PreprocessFILStage::fix_bad_columns(sink_type_t x)
                                            .attr("astype")(pybind11::str("float32"));
             }
 
-            mutable_info.return_obj(std::move(df));
+            mutable_info.return_obj(std::move(pdf));
         }
     }
 

--- a/morpheus/_lib/tests/messages/test_dev_doc_ex3.cpp
+++ b/morpheus/_lib/tests/messages/test_dev_doc_ex3.cpp
@@ -23,12 +23,10 @@
 #include "morpheus/utilities/cudf_util.hpp"  // for CudfHelper
 
 #include <gtest/gtest.h>
-#include <pybind11/cast.h>      // for cast
 #include <pybind11/gil.h>       // for gil_scoped_release, gil_scoped_acquire
 #include <pybind11/pybind11.h>  // IWYU pragma: keep
 #include <pybind11/pytypes.h>   // for object, object_api, literals
 
-#include <array>    // for array
 #include <memory>   // for shared_ptr
 #include <utility>  // for move
 

--- a/morpheus/_lib/tests/messages/test_dev_doc_ex3.cpp
+++ b/morpheus/_lib/tests/messages/test_dev_doc_ex3.cpp
@@ -68,7 +68,7 @@ TEST_F(TestDevDocEx3, TestPyObjFromMultiMesg)
             auto df = mutable_info.checkout_obj();
 
             // Maka a copy of the original DataFrame
-            auto copied_df = df.attr("copy")("deep"_a = true);
+            auto copied_df = df->attr("copy")("deep"_a = true);
 
             // Now that we are done with `df` return it to the owner
             mutable_info.return_obj(std::move(df));
@@ -94,7 +94,7 @@ TEST_F(TestDevDocEx3, TestPyObjFromMultiMesg)
         auto result_df = result_mutable_info.checkout_obj();
 
         // orig_df.eq(result_df).all().all()
-        auto is_true = orig_df.attr("eq")(result_df).attr("all")().attr("all")();
+        auto is_true = orig_df->attr("eq")(*result_df).attr("all")().attr("all")();
         EXPECT_TRUE(is_true.cast<bool>());
 
         orig_mutable_info.return_obj(std::move(orig_df));


### PR DESCRIPTION
## Description
* Switch to using a `unique_ptr` to hold the python object
* Random IWYU fixes.

Closes #1533

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
