### PR TITLE
Expose max_retries parameter to OpenAIChatService & OpenAIChatClient

### DIFF
--- a/morpheus/llm/services/openai_chat_service.py
+++ b/morpheus/llm/services/openai_chat_service.py
@@ -325,6 +325,9 @@ class OpenAIChatService(LLMService):
         set_assistant: bool, optional default=False
             When `True`, a second input field named `assistant` will be used to proide additional context to the model.
 
+        max_retries: int, optional default=10
+            The maximum number of retries to attempt when making a request to the OpenAI API.
+
         model_kwargs : dict[str, typing.Any]
             Additional keyword arguments to pass to the model when generating text. Arguments specified here will
             overwrite the `default_model_kwargs` set in the service constructor

--- a/morpheus/llm/services/openai_chat_service.py
+++ b/morpheus/llm/services/openai_chat_service.py
@@ -90,6 +90,7 @@ class OpenAIChatClient(LLMClient):
                  *,
                  model_name: str,
                  set_assistant: bool = False,
+                 max_retries: int = 10,
                  **model_kwargs) -> None:
         if IMPORT_EXCEPTION is not None:
             raise ImportError(IMPORT_ERROR_MESSAGE) from IMPORT_EXCEPTION
@@ -109,8 +110,8 @@ class OpenAIChatClient(LLMClient):
         self._model_kwargs = copy.deepcopy(model_kwargs)
 
         # Create the client objects for both sync and async
-        self._client = openai.OpenAI()
-        self._client_async = openai.AsyncOpenAI()
+        self._client = openai.OpenAI(max_retries=max_retries)
+        self._client_async = openai.AsyncOpenAI(max_retries=max_retries)
 
     def get_input_names(self) -> list[str]:
         input_names = [self._prompt_key]
@@ -307,7 +308,12 @@ class OpenAIChatService(LLMService):
 
         return self._message_count
 
-    def get_client(self, *, model_name: str, set_assistant: bool = False, **model_kwargs) -> OpenAIChatClient:
+    def get_client(self,
+                   *,
+                   model_name: str,
+                   set_assistant: bool = False,
+                   max_retries: int = 10,
+                   **model_kwargs) -> OpenAIChatClient:
         """
         Returns a client for interacting with a specific model. This method is the preferred way to create a client.
 
@@ -326,4 +332,8 @@ class OpenAIChatService(LLMService):
 
         final_model_kwargs = {**self._default_model_kwargs, **model_kwargs}
 
-        return OpenAIChatClient(self, model_name=model_name, set_assistant=set_assistant, **final_model_kwargs)
+        return OpenAIChatClient(self,
+                                model_name=model_name,
+                                set_assistant=set_assistant,
+                                max_retries=max_retries,
+                                **final_model_kwargs)

--- a/morpheus/llm/services/openai_chat_service.py
+++ b/morpheus/llm/services/openai_chat_service.py
@@ -78,6 +78,9 @@ class OpenAIChatClient(LLMClient):
     set_assistant: bool, optional default=False
         When `True`, a second input field named `assistant` will be used to proide additional context to the model.
 
+    max_retries: int, optional default=10
+        The maximum number of retries to attempt when making a request to the OpenAI API.
+
     model_kwargs : dict[str, typing.Any]
         Additional keyword arguments to pass to the model when generating text.
     """

--- a/tests/llm/services/test_openai_chat_client.py
+++ b/tests/llm/services/test_openai_chat_client.py
@@ -24,12 +24,13 @@ from morpheus.llm.services.openai_chat_service import OpenAIChatClient
 from morpheus.llm.services.openai_chat_service import OpenAIChatService
 
 
-def test_constructor(mock_chat_completion: tuple[mock.MagicMock, mock.MagicMock]):
-    client = OpenAIChatClient(OpenAIChatService(), model_name="test_model")
+@pytest.mark.parametrize("max_retries", [5, 10])
+def test_constructor(mock_chat_completion: tuple[mock.MagicMock, mock.MagicMock], max_retries: int):
+    client = OpenAIChatClient(OpenAIChatService(), model_name="test_model", max_retries=max_retries)
     assert isinstance(client, LLMClient)
 
     for mock_client in mock_chat_completion:
-        mock_client.assert_called()
+        mock_client.assert_called_once_with(max_retries=max_retries)
 
 
 @pytest.mark.parametrize("use_async", [True, False])

--- a/tests/llm/services/test_openai_chat_service.py
+++ b/tests/llm/services/test_openai_chat_service.py
@@ -36,14 +36,20 @@ def test_get_client():
 
 @pytest.mark.parametrize("set_assistant", [True, False])
 @pytest.mark.parametrize("temperature", [0, 1, 2])
+@pytest.mark.parametrize("max_retries", [5, 10])
 @mock.patch("morpheus.llm.services.openai_chat_service.OpenAIChatClient")
-def test_get_client_passed_args(mock_client: mock.MagicMock, set_assistant: bool, temperature: int):
+def test_get_client_passed_args(mock_client: mock.MagicMock, set_assistant: bool, temperature: int, max_retries: int):
     service = OpenAIChatService()
-    service.get_client(model_name="test_model", set_assistant=set_assistant, temperature=temperature, test='this')
+    service.get_client(model_name="test_model",
+                       set_assistant=set_assistant,
+                       temperature=temperature,
+                       test='this',
+                       max_retries=max_retries)
 
     # Ensure the get_client method passed on the set_assistant and model kwargs
     mock_client.assert_called_once_with(service,
                                         model_name="test_model",
                                         set_assistant=set_assistant,
                                         temperature=temperature,
-                                        test='this')
+                                        test='this',
+                                        max_retries=max_retries)


### PR DESCRIPTION
## Description
* Avoids momentary rate limit errors

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
