### PR TITLE
Add retry logic and proxy support to the NeMo LLM Service

### DIFF
--- a/morpheus.code-workspace
+++ b/morpheus.code-workspace
@@ -83,7 +83,7 @@
                 "program": "${workspaceFolder}/morpheus/cli/run.py",
                 "request": "launch",
                 "subProcess": true,
-                "type": "python"
+                "type": "debugpy"
             },
             {
                 "args": [
@@ -139,7 +139,7 @@
                 "program": "${workspaceFolder}/morpheus/cli/run.py",
                 "request": "launch",
                 "subProcess": true,
-                "type": "python"
+                "type": "debugpy"
             },
             {
                 "args": [
@@ -201,7 +201,7 @@
                 "program": "${workspaceFolder}/morpheus/cli/run.py",
                 "request": "launch",
                 "subProcess": true,
-                "type": "python"
+                "type": "debugpy"
             },
             {
                 "args": [
@@ -266,7 +266,7 @@
                 "program": "${workspaceFolder}/morpheus/cli/run.py",
                 "request": "launch",
                 "subProcess": true,
-                "type": "python"
+                "type": "debugpy"
             },
             {
                 "args": [
@@ -285,7 +285,7 @@
                 "name": "Python: Anomaly Detection Example",
                 "program": "${workspaceFolder}/examples/abp_pcap_detection/run.py",
                 "request": "launch",
-                "type": "python"
+                "type": "debugpy"
             },
             {
                 "args": [
@@ -303,7 +303,7 @@
                 "module": "sphinx.cmd.build",
                 "name": "Python: Sphinx",
                 "request": "launch",
-                "type": "python"
+                "type": "debugpy"
             },
             {
                 "MIMode": "gdb",
@@ -598,7 +598,7 @@
                 "name": "Python: GNN DGL inference",
                 "program": "${workspaceFolder}/examples/gnn_fraud_detection_pipeline/run.py",
                 "request": "launch",
-                "type": "python"
+                "type": "debugpy"
             },
             {
                 "args": [
@@ -614,7 +614,7 @@
                 "name": "Python: GNN model training",
                 "program": "${workspaceFolder}/models/training-tuning-scripts/fraud-detection-models/training.py",
                 "request": "launch",
-                "type": "python"
+                "type": "debugpy"
             }
         ]
     },

--- a/morpheus/llm/services/llm_service.py
+++ b/morpheus/llm/services/llm_service.py
@@ -33,7 +33,7 @@ class LLMClient(ABC):
         pass
 
     @abstractmethod
-    def generate(self, input_dict: dict[str, str]) -> str:
+    def generate(self, **input_dict) -> str:
         """
         Issue a request to generate a response based on a given prompt.
 
@@ -45,7 +45,7 @@ class LLMClient(ABC):
         pass
 
     @abstractmethod
-    async def generate_async(self, input_dict: dict[str, str]) -> str:
+    async def generate_async(self, **input_dict) -> str:
         """
         Issue an asynchronous request to generate a response based on a given prompt.
 
@@ -57,7 +57,7 @@ class LLMClient(ABC):
         pass
 
     @abstractmethod
-    def generate_batch(self, inputs: dict[str, list[str]]) -> list[str]:
+    def generate_batch(self, inputs: dict[str, list]) -> list[str | BaseException]:
         """
         Issue a request to generate a list of responses based on a list of prompts.
 
@@ -69,7 +69,7 @@ class LLMClient(ABC):
         pass
 
     @abstractmethod
-    async def generate_batch_async(self, inputs: dict[str, list[str]]) -> list[str]:
+    async def generate_batch_async(self, inputs: dict[str, list]) -> list[str | BaseException]:
         """
         Issue an asynchronous request to generate a list of responses based on a list of prompts.
 

--- a/morpheus/llm/services/llm_service.py
+++ b/morpheus/llm/services/llm_service.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import typing
 from abc import ABC
 from abc import abstractmethod
 
@@ -56,8 +57,20 @@ class LLMClient(ABC):
         """
         pass
 
+    @typing.overload
     @abstractmethod
-    def generate_batch(self, inputs: dict[str, list]) -> list[str | BaseException]:
+    def generate_batch(self,
+                       inputs: dict[str, list],
+                       return_exceptions: typing.Literal[True] = True) -> list[str | BaseException]:
+        ...
+
+    @typing.overload
+    @abstractmethod
+    def generate_batch(self, inputs: dict[str, list], return_exceptions: typing.Literal[False] = False) -> list[str]:
+        ...
+
+    @abstractmethod
+    def generate_batch(self, inputs: dict[str, list], return_exceptions=False) -> list[str] | list[str | BaseException]:
         """
         Issue a request to generate a list of responses based on a list of prompts.
 
@@ -65,11 +78,29 @@ class LLMClient(ABC):
         ----------
         inputs : dict
             Inputs containing prompt data.
+        return_exceptions : bool
+            Whether to return exceptions in the output list or raise them immediately.
         """
         pass
 
+    @typing.overload
     @abstractmethod
-    async def generate_batch_async(self, inputs: dict[str, list]) -> list[str | BaseException]:
+    async def generate_batch_async(self,
+                                   inputs: dict[str, list],
+                                   return_exceptions: typing.Literal[True] = True) -> list[str | BaseException]:
+        ...
+
+    @typing.overload
+    @abstractmethod
+    async def generate_batch_async(self,
+                                   inputs: dict[str, list],
+                                   return_exceptions: typing.Literal[False] = False) -> list[str]:
+        ...
+
+    @abstractmethod
+    async def generate_batch_async(self,
+                                   inputs: dict[str, list],
+                                   return_exceptions=False) -> list[str] | list[str | BaseException]:
         """
         Issue an asynchronous request to generate a list of responses based on a list of prompts.
 
@@ -77,6 +108,8 @@ class LLMClient(ABC):
         ----------
         inputs : dict
             Inputs containing prompt data.
+        return_exceptions : bool
+            Whether to return exceptions in the output list or raise them immediately.
         """
         pass
 

--- a/morpheus/llm/services/nemo_llm_service.py
+++ b/morpheus/llm/services/nemo_llm_service.py
@@ -186,17 +186,6 @@ class NeMoLLMClient(LLMClient):
 class NeMoLLMService(LLMService):
     """
     A service for interacting with NeMo LLM models, this class should be used to create a client for a specific model.
-
-    Parameters
-    ----------
-    api_key : str, optional
-        The API key for the LLM service, by default None. If `None` the API key will be read from the `NGC_API_KEY`
-        environment variable. If neither are present an error will be raised.
-
-    org_id : str, optional
-        The organization ID for the LLM service, by default None. If `None` the organization ID will be read from the
-        `NGC_ORG_ID` environment variable. This value is only required if the account associated with the `api_key` is
-        a member of multiple NGC organizations.
     """
 
     def __init__(self, *, api_key: str = None, org_id: str = None, retry_count=5) -> None:
@@ -209,9 +198,9 @@ class NeMoLLMService(LLMService):
             The API key for the LLM service, by default None. If `None` the API key will be read from the `NGC_API_KEY`
             environment variable. If neither are present an error will be raised., by default None
         org_id : str, optional
-            The organization ID for the LLM service, by default None. If `None` the organization ID will be read from the
-            `NGC_ORG_ID` environment variable. This value is only required if the account associated with the `api_key` is
-            a member of multiple NGC organizations., by default None
+            The organization ID for the LLM service, by default None. If `None` the organization ID will be read from
+            the `NGC_ORG_ID` environment variable. This value is only required if the account associated with the
+            `api_key` is a member of multiple NGC organizations., by default None
         retry_count : int, optional
             The number of times to retry a request before raising an exception, by default 5
 

--- a/morpheus/llm/services/nemo_llm_service.py
+++ b/morpheus/llm/services/nemo_llm_service.py
@@ -180,7 +180,7 @@ class NeMoLLMClient(LLMClient):
 
         futures = [self._process_one_async(p) for p in prompts]
 
-        results = await asyncio.gather(*futures, return_exceptions=False)
+        results = await asyncio.gather(*futures, return_exceptions=return_exceptions)
 
         return results
 

--- a/morpheus/llm/services/nemo_llm_service.py
+++ b/morpheus/llm/services/nemo_llm_service.py
@@ -147,7 +147,9 @@ class NeMoLLMClient(LLMClient):
 
             return result['text']
 
-        raise RuntimeError(f"Failed to generate response for prompt '{prompt}' after 3 attempts. Errors: {errors}")
+        raise RuntimeError(
+            f"Failed to generate response for prompt '{prompt}' after {self._parent._retry_count} attempts. "
+            f"Errors: {errors}")
 
     @typing.overload
     async def generate_batch_async(self,

--- a/morpheus/llm/services/openai_chat_service.py
+++ b/morpheus/llm/services/openai_chat_service.py
@@ -164,13 +164,32 @@ class OpenAIChatClient(LLMClient):
 
         return content
 
-    def _generate(self, prompt: str, assistant: str = None) -> str:
-        messages = self._create_messages(prompt, assistant)
+    @typing.overload
+    def _generate(self,
+                  prompt: str,
+                  assistant: str = None,
+                  return_exceptions: typing.Literal[True] = True) -> str | BaseException:
+        ...
 
-        output: openai.types.chat.chat_completion.ChatCompletion = self._client.chat.completions.create(
-            model=self._model_name, messages=messages, **self._model_kwargs)
+    @typing.overload
+    def _generate(self, prompt: str, assistant: str = None, return_exceptions: typing.Literal[False] = False) -> str:
+        ...
 
-        return self._extract_completion(output)
+    def _generate(self, prompt: str, assistant: str = None, return_exceptions: bool = False):
+
+        try:
+            messages = self._create_messages(prompt, assistant)
+
+            output: openai.types.chat.chat_completion.ChatCompletion = self._client.chat.completions.create(
+                model=self._model_name, messages=messages, **self._model_kwargs)
+
+            return self._extract_completion(output)
+        except BaseException as e:
+
+            if return_exceptions:
+                return e
+
+            raise
 
     def generate(self, **input_dict) -> str:
         """
@@ -181,7 +200,9 @@ class OpenAIChatClient(LLMClient):
         input_dict : dict
             Input containing prompt data.
         """
-        return self._generate(input_dict[self._prompt_key], input_dict.get(self._assistant_key))
+        return self._generate(input_dict[self._prompt_key],
+                              input_dict.get(self._assistant_key),
+                              return_exceptions=False)
 
     async def _generate_async(self, prompt: str, assistant: str = None) -> str:
 
@@ -212,7 +233,17 @@ class OpenAIChatClient(LLMClient):
         """
         return await self._generate_async(input_dict[self._prompt_key], input_dict.get(self._assistant_key))
 
-    def generate_batch(self, inputs: dict[str, list]) -> list[str | BaseException]:
+    @typing.overload
+    def generate_batch(self,
+                       inputs: dict[str, list],
+                       return_exceptions: typing.Literal[True] = True) -> list[str | BaseException]:
+        ...
+
+    @typing.overload
+    def generate_batch(self, inputs: dict[str, list], return_exceptions: typing.Literal[False] = False) -> list[str]:
+        ...
+
+    def generate_batch(self, inputs: dict[str, list], return_exceptions=False) -> list[str] | list[str | BaseException]:
         """
         Issue a request to generate a list of responses based on a list of prompts.
 
@@ -220,6 +251,8 @@ class OpenAIChatClient(LLMClient):
         ----------
         inputs : dict
             Inputs containing prompt data.
+        return_exceptions : bool
+            Whether to return exceptions in the output list or raise them immediately.
         """
         prompts = inputs[self._prompt_key]
         assistants = None
@@ -231,11 +264,28 @@ class OpenAIChatClient(LLMClient):
         results = []
         for (i, prompt) in enumerate(prompts):
             assistant = assistants[i] if assistants is not None else None
-            results.append(self._generate(prompt, assistant))
+            if (return_exceptions):
+                results.append(self._generate(prompt, assistant, return_exceptions=True))
+            else:
+                results.append(self._generate(prompt, assistant, return_exceptions=False))
 
         return results
 
-    async def generate_batch_async(self, inputs: dict[str, list]) -> list[str | BaseException]:
+    @typing.overload
+    async def generate_batch_async(self,
+                                   inputs: dict[str, list],
+                                   return_exceptions: typing.Literal[True] = True) -> list[str | BaseException]:
+        ...
+
+    @typing.overload
+    async def generate_batch_async(self,
+                                   inputs: dict[str, list],
+                                   return_exceptions: typing.Literal[False] = False) -> list[str]:
+        ...
+
+    async def generate_batch_async(self,
+                                   inputs: dict[str, list],
+                                   return_exceptions=False) -> list[str] | list[str | BaseException]:
         """
         Issue an asynchronous request to generate a list of responses based on a list of prompts.
 
@@ -243,6 +293,8 @@ class OpenAIChatClient(LLMClient):
         ----------
         inputs : dict
             Inputs containing prompt data.
+        return_exceptions : bool
+            Whether to return exceptions in the output list or raise them immediately.
         """
         prompts = inputs[self._prompt_key]
         assistants = None
@@ -256,7 +308,7 @@ class OpenAIChatClient(LLMClient):
             assistant = assistants[i] if assistants is not None else None
             coros.append(self._generate_async(prompt, assistant))
 
-        return await asyncio.gather(*coros, return_exceptions=True)
+        return await asyncio.gather(*coros, return_exceptions=return_exceptions)
 
 
 class OpenAIChatService(LLMService):

--- a/morpheus/llm/services/openai_chat_service.py
+++ b/morpheus/llm/services/openai_chat_service.py
@@ -172,7 +172,7 @@ class OpenAIChatClient(LLMClient):
 
         return self._extract_completion(output)
 
-    def generate(self, input_dict: dict[str, str]) -> str:
+    def generate(self, **input_dict) -> str:
         """
         Issue a request to generate a response based on a given prompt.
 
@@ -201,7 +201,7 @@ class OpenAIChatClient(LLMClient):
 
         return self._extract_completion(output)
 
-    async def generate_async(self, input_dict: dict[str, str]) -> str:
+    async def generate_async(self, **input_dict) -> str:
         """
         Issue an asynchronous request to generate a response based on a given prompt.
 
@@ -212,7 +212,7 @@ class OpenAIChatClient(LLMClient):
         """
         return await self._generate_async(input_dict[self._prompt_key], input_dict.get(self._assistant_key))
 
-    def generate_batch(self, inputs: dict[str, list[str]]) -> list[str]:
+    def generate_batch(self, inputs: dict[str, list]) -> list[str | BaseException]:
         """
         Issue a request to generate a list of responses based on a list of prompts.
 
@@ -235,7 +235,7 @@ class OpenAIChatClient(LLMClient):
 
         return results
 
-    async def generate_batch_async(self, inputs: dict[str, list[str]]) -> list[str]:
+    async def generate_batch_async(self, inputs: dict[str, list]) -> list[str | BaseException]:
         """
         Issue an asynchronous request to generate a list of responses based on a list of prompts.
 
@@ -256,7 +256,7 @@ class OpenAIChatClient(LLMClient):
             assistant = assistants[i] if assistants is not None else None
             coros.append(self._generate_async(prompt, assistant))
 
-        return await asyncio.gather(*coros)
+        return await asyncio.gather(*coros, return_exceptions=True)
 
 
 class OpenAIChatService(LLMService):

--- a/tests/_utils/environment.py
+++ b/tests/_utils/environment.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utilities for modifying the environment for testing Morpheus"""
+
+import contextlib
+import os
+
+
+@contextlib.contextmanager
+def set_env(**env_vars):
+    """
+    Temporarily updates the ``os.environ`` dictionary in-place.
+
+    The ``os.environ`` dictionary is updated in-place so that the modification
+    is sure to work in all situations.
+
+    Setting a value to ``None`` will cause the key to be removed from the environment.
+    """
+    # Taken from https://stackoverflow.com/a/34333710
+    env = os.environ
+
+    # Remove any which are set to None
+    remove = [k for k, v in env_vars.items() if v is None]
+
+    # Save the remaining environment variables to set
+    update = {k: v for k, v in env_vars.items() if v is not None}
+
+    # List of environment variables being updated or removed.
+    stomped = (set(update.keys()) | set(remove)) & set(env.keys())
+    # Environment variables and values to restore on exit.
+    update_after = {k: env[k] for k in stomped}
+    # Environment variables and values to remove on exit.
+    remove_after = frozenset(k for k in update if k not in env)
+
+    try:
+        env.update(update)
+
+        for k in remove:
+            env.pop(k, None)
+
+        yield
+    finally:
+        env.update(update_after)
+
+        for k in remove_after:
+            env.pop(k)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1065,8 +1065,9 @@ def mock_chat_completion_fixture():
 @pytest.mark.usefixtures("nemollm")
 @pytest.fixture(name="mock_nemollm")
 def mock_nemollm_fixture():
-    with mock.patch("nemollm.NemoLLM") as mock_nemollm:
+    with mock.patch("nemollm.NemoLLM", autospec=True) as mock_nemollm:
         mock_nemollm.return_value = mock_nemollm
+        mock_nemollm.generate_multiple.return_value = ["test_output"]
         mock_nemollm.post_process_generate_response.return_value = {"text": "test_output"}
 
         yield mock_nemollm

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1067,7 +1067,6 @@ def mock_chat_completion_fixture():
 def mock_nemollm_fixture():
     with mock.patch("nemollm.NemoLLM") as mock_nemollm:
         mock_nemollm.return_value = mock_nemollm
-        mock_nemollm.generate_multiple.return_value = ["test_output"]
         mock_nemollm.post_process_generate_response.return_value = {"text": "test_output"}
 
         yield mock_nemollm

--- a/tests/llm/conftest.py
+++ b/tests/llm/conftest.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
-import typing
 from unittest import mock
 
 import pytest
@@ -106,7 +104,7 @@ def mock_nemollm_fixture(mock_nemollm: mock.MagicMock):
 
     from concurrent.futures import Future
 
-    def generate_mock(*args, **kwargs):
+    def generate_mock(*_, **kwargs):
 
         fut = Future()
 
@@ -116,13 +114,13 @@ def mock_nemollm_fixture(mock_nemollm: mock.MagicMock):
 
     mock_nemollm.generate.side_effect = generate_mock
 
-    def generate_multiple_mock(*args, **kwargs):
+    def generate_multiple_mock(*_, **kwargs):
 
         assert kwargs["return_type"] == "text", "Only text return type is supported for mocking."
 
         prompts: list[str] = kwargs["prompts"]
 
-        return [prompt for prompt in prompts]
+        return list(prompts)
 
     mock_nemollm.generate_multiple.side_effect = generate_multiple_mock
 

--- a/tests/llm/services/test_llm_service_pipe.py
+++ b/tests/llm/services/test_llm_service_pipe.py
@@ -35,7 +35,7 @@ from morpheus.stages.output.compare_dataframe_stage import CompareDataFrameStage
 from morpheus.stages.preprocess.deserialize_stage import DeserializeStage
 
 
-def _build_engine(llm_service_cls: LLMService):
+def _build_engine(llm_service_cls: type[LLMService]):
     llm_service = llm_service_cls()
     llm_clinet = llm_service.get_client(model_name="test_model")
 
@@ -47,7 +47,9 @@ def _build_engine(llm_service_cls: LLMService):
     return engine
 
 
-def _run_pipeline(config: Config, llm_service_cls: LLMService, country_prompts: list[str],
+def _run_pipeline(config: Config,
+                  llm_service_cls: type[LLMService],
+                  country_prompts: list[str],
                   capital_responses: list[str]):
     """
     Loosely patterned after `examples/llm/completion`
@@ -72,16 +74,10 @@ def _run_pipeline(config: Config, llm_service_cls: LLMService, country_prompts: 
     assert_results(sink.get_results())
 
 
-@mock.patch("asyncio.wrap_future")
-@mock.patch("asyncio.gather", new_callable=mock.AsyncMock)
-def test_completion_pipe_nemo(
-        mock_asyncio_gather: mock.AsyncMock,
-        mock_asyncio_wrap_future: mock.MagicMock,  # pylint: disable=unused-argument
-        config: Config,
-        mock_nemollm: mock.MagicMock,
-        country_prompts: list[str],
-        capital_responses: list[str]):
-    mock_asyncio_gather.return_value = [mock.MagicMock() for _ in range(len(country_prompts))]
+def test_completion_pipe_nemo(config: Config,
+                              mock_nemollm: mock.MagicMock,
+                              country_prompts: list[str],
+                              capital_responses: list[str]):
     mock_nemollm.post_process_generate_response.side_effect = [{"text": response} for response in capital_responses]
     _run_pipeline(config, NeMoLLMService, country_prompts, capital_responses)
 

--- a/tests/llm/services/test_nemo_llm_client.py
+++ b/tests/llm/services/test_nemo_llm_client.py
@@ -15,93 +15,107 @@
 
 import asyncio
 from unittest import mock
+from unittest.mock import ANY
 
 import pytest
 
 from morpheus.llm.services.llm_service import LLMClient
 from morpheus.llm.services.nemo_llm_service import NeMoLLMClient
+from morpheus.llm.services.nemo_llm_service import NeMoLLMService
 
 
-def test_constructor(mock_nemollm: mock.MagicMock, mock_nemo_service: mock.MagicMock):
-    client = NeMoLLMClient(mock_nemo_service, model_name="test_model", additional_arg="test_arg")
+def test_constructor():
+    client = NeMoLLMService(api_key="dummy").get_client(model_name="test_model", additional_arg="test_arg")
+
     assert isinstance(client, LLMClient)
-    mock_nemollm.assert_not_called()
 
 
-def test_get_input_names(mock_nemollm: mock.MagicMock, mock_nemo_service: mock.MagicMock):
-    client = NeMoLLMClient(mock_nemo_service, model_name="test_model", additional_arg="test_arg")
+def test_get_input_names():
+    client = NeMoLLMService(api_key="dummy").get_client(model_name="test_model", additional_arg="test_arg")
+
     assert client.get_input_names() == ["prompt"]
-    mock_nemollm.assert_not_called()
 
 
-def test_generate(mock_nemollm: mock.MagicMock, mock_nemo_service: mock.MagicMock):
-    client = NeMoLLMClient(mock_nemo_service, model_name="test_model", additional_arg="test_arg")
-    assert client.generate(prompt="test_prompt") == "test_output"
+def test_generate(mock_nemollm: mock.MagicMock):
+
+    client = NeMoLLMService(api_key="dummy").get_client(model_name="test_model", customization_id="test_custom_id")
+
+    assert client.generate(prompt="test_prompt") == "test_prompt"
+
+    _, kwargs = mock_nemollm.generate_multiple.call_args_list[-1]
+
     mock_nemollm.generate_multiple.assert_called_once_with(model="test_model",
                                                            prompts=["test_prompt"],
                                                            return_type="text",
-                                                           additional_arg="test_arg")
+                                                           customization_id="test_custom_id")
 
 
-def test_generate_batch(mock_nemollm: mock.MagicMock, mock_nemo_service: mock.MagicMock):
-    mock_nemollm.generate_multiple.return_value = ["output1", "output2"]
+def test_generate_batch(mock_nemollm: mock.MagicMock):
 
-    client = NeMoLLMClient(mock_nemo_service, model_name="test_model", additional_arg="test_arg")
-    assert client.generate_batch({'prompt': ["prompt1", "prompt2"]}) == ["output1", "output2"]
+    client = NeMoLLMService(api_key="dummy").get_client(model_name="test_model", customization_id="test_custom_id")
+
+    assert client.generate_batch({'prompt': ["prompt1", "prompt2"]}) == ["prompt1", "prompt2"]
+
     mock_nemollm.generate_multiple.assert_called_once_with(model="test_model",
                                                            prompts=["prompt1", "prompt2"],
                                                            return_type="text",
-                                                           additional_arg="test_arg")
+                                                           customization_id="test_custom_id")
 
 
-@mock.patch("asyncio.wrap_future")
-@mock.patch("asyncio.gather", new_callable=mock.AsyncMock)
-def test_generate_async(
-        mock_asyncio_gather: mock.AsyncMock,
-        mock_asyncio_wrap_future: mock.MagicMock,  # pylint: disable=unused-argument
-        mock_nemollm: mock.MagicMock,
-        mock_nemo_service: mock.MagicMock):
-    mock_asyncio_gather.return_value = [mock.MagicMock()]
+async def test_generate_async(mock_nemollm: mock.MagicMock):
 
-    client = NeMoLLMClient(mock_nemo_service, model_name="test_model", additional_arg="test_arg")
-    results = asyncio.run(client.generate_async(prompt="test_prompt"))
+    client = NeMoLLMService(api_key="dummy").get_client(model_name="test_model", customization_id="test_custom_id")
+
+    results = await client.generate_async(prompt="test_prompt")
+
     assert results == "test_output"
+
     mock_nemollm.generate.assert_called_once_with("test_model",
                                                   "test_prompt",
                                                   return_type="async",
-                                                  additional_arg="test_arg")
+                                                  customization_id="test_custom_id")
 
 
-@mock.patch("asyncio.wrap_future")
-@mock.patch("asyncio.gather", new_callable=mock.AsyncMock)
-def test_generate_batch_async(
-        mock_asyncio_gather: mock.AsyncMock,
-        mock_asyncio_wrap_future: mock.MagicMock,  # pylint: disable=unused-argument
-        mock_nemollm: mock.MagicMock,
-        mock_nemo_service: mock.MagicMock):
-    mock_asyncio_gather.return_value = [mock.MagicMock(), mock.MagicMock()]
-    mock_nemollm.post_process_generate_response.side_effect = [{"text": "output1"}, {"text": "output2"}]
+async def test_generate_batch_async(mock_nemollm: mock.MagicMock):
+    # mock_nemollm.post_process_generate_response.side_effect = [{"text": "output1"}, {"text": "output2"}]
 
-    client = NeMoLLMClient(mock_nemo_service, model_name="test_model", additional_arg="test_arg")
-    results = asyncio.run(client.generate_batch_async({'prompt': ["prompt1", "prompt2"]}))
-    assert results == ["output1", "output2"]
+    client = NeMoLLMService(api_key="dummy").get_client(model_name="test_model", customization_id="test_custom_id")
+
+    results = await client.generate_batch_async({'prompt': ["prompt1", "prompt2"]})
+
+    assert results == ["test_output", "test_output"]
+
     mock_nemollm.generate.assert_has_calls([
-        mock.call("test_model", "prompt1", return_type="async", additional_arg="test_arg"),
-        mock.call("test_model", "prompt2", return_type="async", additional_arg="test_arg")
+        mock.call("test_model", "prompt1", return_type="async", customization_id="test_custom_id"),
+        mock.call("test_model", "prompt2", return_type="async", customization_id="test_custom_id")
     ])
 
 
-@mock.patch("asyncio.wrap_future")
-@mock.patch("asyncio.gather", new_callable=mock.AsyncMock)
-def test_generate_batch_async_error(
-        mock_asyncio_gather: mock.AsyncMock,
-        mock_asyncio_wrap_future: mock.MagicMock,  # pylint: disable=unused-argument
-        mock_nemollm: mock.MagicMock,
-        mock_nemo_service: mock.MagicMock):
-    mock_asyncio_gather.return_value = [mock.MagicMock(), mock.MagicMock()]
+async def test_generate_batch_async_error(mock_nemollm: mock.MagicMock):
     mock_nemollm.post_process_generate_response.return_value = {"status": "fail", "msg": "unittest"}
 
-    client = NeMoLLMClient(mock_nemo_service, model_name="test_model", additional_arg="test_arg")
+    client = NeMoLLMService(api_key="dummy").get_client(model_name="test_model", customization_id="test_custom_id")
 
     with pytest.raises(RuntimeError, match="unittest"):
-        asyncio.run(client.generate_batch_async({'prompt': ["prompt1", "prompt2"]}))
+        await client.generate_batch_async({'prompt': ["prompt1", "prompt2"]})
+
+
+async def test_generate_batch_async_error_retry(mock_nemollm: mock.MagicMock):
+
+    count = 0
+
+    def mock_post_process_generate_response(*args, **kwargs):
+        nonlocal count
+        if count < 2:
+            count += 1
+            return {"status": "fail", "msg": "unittest"}
+        return {"status": "success", "text": args[0]}
+
+    mock_nemollm.post_process_generate_response.side_effect = mock_post_process_generate_response
+
+    client = NeMoLLMService(api_key="dummy", retry_count=2).get_client(model_name="test_model",
+                                                                       customization_id="test_custom_id")
+
+    results = await client.generate_batch_async({'prompt': ["prompt1", "prompt2"]})
+
+    assert results == ["prompt1", "prompt2"]

--- a/tests/llm/services/test_nemo_llm_client.py
+++ b/tests/llm/services/test_nemo_llm_client.py
@@ -13,14 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 from unittest import mock
-from unittest.mock import ANY
 
 import pytest
 
 from morpheus.llm.services.llm_service import LLMClient
-from morpheus.llm.services.nemo_llm_service import NeMoLLMClient
 from morpheus.llm.services.nemo_llm_service import NeMoLLMService
 
 
@@ -41,8 +38,6 @@ def test_generate(mock_nemollm: mock.MagicMock):
     client = NeMoLLMService(api_key="dummy").get_client(model_name="test_model", customization_id="test_custom_id")
 
     assert client.generate(prompt="test_prompt") == "test_prompt"
-
-    _, kwargs = mock_nemollm.generate_multiple.call_args_list[-1]
 
     mock_nemollm.generate_multiple.assert_called_once_with(model="test_model",
                                                            prompts=["test_prompt"],
@@ -104,7 +99,7 @@ async def test_generate_batch_async_error_retry(mock_nemollm: mock.MagicMock):
 
     count = 0
 
-    def mock_post_process_generate_response(*args, **kwargs):
+    def mock_post_process_generate_response(*args, **_):
         nonlocal count
         if count < 2:
             count += 1

--- a/tests/llm/services/test_nemo_llm_client.py
+++ b/tests/llm/services/test_nemo_llm_client.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import asyncio
-from concurrent.futures import Future
 from unittest import mock
 
 import pytest
@@ -53,20 +52,6 @@ def test_generate_batch(mock_nemollm: mock.MagicMock, mock_nemo_service: mock.Ma
                                                            prompts=["prompt1", "prompt2"],
                                                            return_type="text",
                                                            additional_arg="test_arg")
-
-
-@mock.patch("nemollm.NemoLLM", autospec=True)
-def test_generate_batch_error(mock_nemollm_client: mock.MagicMock, mock_nemo_service: mock.MagicMock):
-
-    bad_future = Future()
-    bad_future.set_result({"status": "fail", "msg": "unittest"})
-
-    mock_nemo_service._conn.generate.return_value = bad_future
-
-    client = NeMoLLMClient(mock_nemo_service, model_name="test_model", additional_arg="test_arg")
-
-    with pytest.raises(RuntimeError, match="unittest"):
-        result = client.generate_batch({'prompt': ["prompt1", "prompt2"]})
 
 
 @mock.patch("asyncio.wrap_future")

--- a/tests/llm/services/test_nemo_llm_service.py
+++ b/tests/llm/services/test_nemo_llm_service.py
@@ -38,7 +38,10 @@ def test_constructor(mock_nemollm: mock.MagicMock, api_key: str, org_id: str):
     expected_org_id = org_id or env_org_id
 
     NeMoLLMService(api_key=api_key, org_id=org_id)
-    mock_nemollm.assert_called_once_with(api_key=expected_api_key, org_id=expected_org_id)
+    _, kwargs = mock_nemollm.call_args_list[-1]
+
+    assert kwargs["api_key"] == expected_api_key
+    assert kwargs["org_id"] == expected_org_id
 
 
 def test_get_client():

--- a/tests/llm/services/test_openai_chat_client.py
+++ b/tests/llm/services/test_openai_chat_client.py
@@ -61,14 +61,14 @@ def test_generate(mock_chat_completion: tuple[mock.MagicMock, mock.MagicMock],
                               set_assistant=set_assistant,
                               temperature=temperature)
     if use_async:
-        results = asyncio.run(client.generate_async(input_dict))
+        results = asyncio.run(client.generate_async(**input_dict))
         mock_async_client.chat.completions.create.assert_called_once_with(model="test_model",
                                                                           messages=expected_messages,
                                                                           temperature=temperature)
         mock_client.chat.completions.create.assert_not_called()
 
     else:
-        results = client.generate(input_dict)
+        results = client.generate(**input_dict)
         mock_client.chat.completions.create.assert_called_once_with(model="test_model",
                                                                     messages=expected_messages,
                                                                     temperature=temperature)

--- a/tests/llm/test_completion_pipe.py
+++ b/tests/llm/test_completion_pipe.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import logging
-import os
 from unittest import mock
 
 import pytest

--- a/tests/llm/test_completion_pipe.py
+++ b/tests/llm/test_completion_pipe.py
@@ -22,6 +22,7 @@ import pytest
 import cudf
 
 from _utils import assert_results
+from _utils.environment import set_env
 from _utils.llm import mk_mock_openai_response
 from morpheus.config import Config
 from morpheus.llm import LLMEngine
@@ -97,11 +98,11 @@ def test_completion_pipe_nemo(config: Config,
                               capital_responses: list[str]):
 
     # Set a dummy key to bypass the API key check
-    os.environ["NGC_API_KEY"] = "test"
+    with set_env(NGC_API_KEY="test"):
 
-    mock_nemollm.post_process_generate_response.side_effect = [{"text": response} for response in capital_responses]
-    results = _run_pipeline(config, NeMoLLMService, countries=countries, capital_responses=capital_responses)
-    assert_results(results)
+        mock_nemollm.post_process_generate_response.side_effect = [{"text": response} for response in capital_responses]
+        results = _run_pipeline(config, NeMoLLMService, countries=countries, capital_responses=capital_responses)
+        assert_results(results)
 
 
 @pytest.mark.usefixtures("openai")


### PR DESCRIPTION
## Description

- Adds the ability to retry NeMo failures more than one time
- Adds an argument to configure the retry count
- Adds support for proxying requests to the NeMo service using the `NGC_API_BASE` environment variable
- Changes the API for the base `LLMService` to improve the type hints and allow arguments other than strings to be used.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
