### PR TITLE
Update MLflow in Production DFP example to use Python 3.10

### DIFF
--- a/examples/digital_fingerprinting/production/mlflow/Dockerfile
+++ b/examples/digital_fingerprinting/production/mlflow/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.8-slim-buster
+FROM python:3.10-slim-buster
 
 # Install curl for health check
 RUN apt update && \

--- a/examples/digital_fingerprinting/production/morpheus/dfp/utils/config_generator.py
+++ b/examples/digital_fingerprinting/production/morpheus/dfp/utils/config_generator.py
@@ -156,7 +156,7 @@ class ConfigGenerator:
                 "timestamp_column_name": self._config.ae.timestamp_column_name,
                 "conda_env": {
                     'channels': ['defaults', 'conda-forge'],
-                    'dependencies': ['python=3.8', 'pip'],
+                    'dependencies': ['python=3.10', 'pip'],
                     'pip': ['mlflow', 'dfencoder'],
                     'name': 'mlflow-env'
                 }


### PR DESCRIPTION
## Description
- Update `mlflow_writer_options` in DFP config generator to use Python 3.10 (from 3.8) for model's conda environment.
- Update base image of MLflow container to Python 3.10.

Closes #1565

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
