### PR TITLE
Remove the defaults channel from `dependencies.yml`

### DIFF
--- a/conda/environments/all_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-121_arch-x86_64.yaml
@@ -8,7 +8,6 @@ channels:
 - nvidia
 - nvidia/label/dev
 - pytorch
-- defaults
 dependencies:
 - anyio>=3.7
 - appdirs

--- a/conda/environments/dev_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/dev_cuda-121_arch-x86_64.yaml
@@ -8,7 +8,6 @@ channels:
 - nvidia
 - nvidia/label/dev
 - pytorch
-- defaults
 dependencies:
 - appdirs
 - benchmark=1.8.3

--- a/conda/environments/examples_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/examples_cuda-121_arch-x86_64.yaml
@@ -8,7 +8,6 @@ channels:
 - nvidia
 - nvidia/label/dev
 - pytorch
-- defaults
 dependencies:
 - anyio>=3.7
 - appdirs
@@ -70,5 +69,4 @@ dependencies:
   - milvus==2.3.5
   - nemollm
   - pymilvus==2.3.6
-  - python-logging-loki
 name: examples_cuda-121_arch-x86_64

--- a/conda/environments/model-utils_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/model-utils_cuda-121_arch-x86_64.yaml
@@ -8,7 +8,6 @@ channels:
 - nvidia
 - nvidia/label/dev
 - pytorch
-- defaults
 dependencies:
 - cuml=24.02.*
 - jupyterlab

--- a/conda/environments/runtime_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/runtime_cuda-121_arch-x86_64.yaml
@@ -8,7 +8,6 @@ channels:
 - nvidia
 - nvidia/label/dev
 - pytorch
-- defaults
 dependencies:
 - appdirs
 - click >=8

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -161,7 +161,6 @@ channels:
   - nvidia
   - nvidia/label/dev
   - pytorch
-  - defaults
 
 dependencies:
 


### PR DESCRIPTION
## Description
This removes the `defaults` channel from `dependencies.yml` to use only `conda-forge`

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
