### PR TITLE
Serialize datetime objects into the module config

### DIFF
--- a/examples/digital_fingerprinting/production/morpheus/dfp/utils/config_generator.py
+++ b/examples/digital_fingerprinting/production/morpheus/dfp/utils/config_generator.py
@@ -38,6 +38,8 @@ class ConfigGenerator:
         self._source_schema_str = pyobj2str(schema.source, encoding=encoding)
         self._preprocess_schema_str = pyobj2str(schema.preprocess, encoding=encoding)
         self._input_message_type = pyobj2str(MultiMessage, encoding)
+        self._start_time_str = self._dfp_arg_parser.time_fields.start_time.isoformat()
+        self._end_time_str = self._dfp_arg_parser.time_fields.end_time.isoformat()
 
     def get_module_conf(self):
         module_conf = {}
@@ -58,8 +60,8 @@ class ConfigGenerator:
             "cache_dir": self._dfp_arg_parser.cache_dir,
             "batching_options": {
                 "sampling_rate_s": self._dfp_arg_parser.sample_rate_s,
-                "start_time": self._dfp_arg_parser.time_fields.start_time,
-                "end_time": self._dfp_arg_parser.time_fields.end_time,
+                "start_time": self._start_time_str,
+                "end_time": self._end_time_str,
                 "iso_date_regex_pattern": iso_date_regex_pattern,
                 "parser_kwargs": {
                     "lines": False, "orient": "records"
@@ -112,8 +114,8 @@ class ConfigGenerator:
             "cache_dir": self._dfp_arg_parser.cache_dir,
             "batching_options": {
                 "sampling_rate_s": self._dfp_arg_parser.sample_rate_s,
-                "start_time": self._dfp_arg_parser.time_fields.start_time,
-                "end_time": self._dfp_arg_parser.time_fields.end_time,
+                "start_time": self._start_time_str,
+                "end_time": self._end_time_str,
                 "iso_date_regex_pattern": iso_date_regex_pattern,
                 "parser_kwargs": {
                     "lines": False, "orient": "records"

--- a/morpheus/modules/file_batcher.py
+++ b/morpheus/modules/file_batcher.py
@@ -157,10 +157,10 @@ def file_batcher(builder: mrc.Builder):
                 sampling = f"{sampling_rate_s}S"
 
             if (start_time is not None):
-                start_time = datetime.datetime.strptime(start_time, '%Y-%m-%d').replace(tzinfo=datetime.timezone.utc)
+                start_time = datetime.datetime.fromisoformat(start_time).replace(tzinfo=datetime.timezone.utc)
 
             if (end_time is not None):
-                end_time = datetime.datetime.strptime(end_time, '%Y-%m-%d').replace(tzinfo=datetime.timezone.utc)
+                end_time = datetime.datetime.fromisoformat(end_time).replace(tzinfo=datetime.timezone.utc)
 
         except Exception as exec_info:
             logger.error("Error parsing parameters: %s", (exec_info))

--- a/tests/examples/digital_fingerprinting/utils/test_config_generator.py
+++ b/tests/examples/digital_fingerprinting/utils/test_config_generator.py
@@ -48,7 +48,7 @@ def schema_fixture(config: Config):
     yield schema_builder.build_schema()
 
 
-def test_constructor(config: Config, dfp_arg_parser: "DFPArgParser", schema: "Schema"):
+def test_constructor(config: Config, dfp_arg_parser: "DFPArgParser", schema: "Schema"):  # noqa: F821
     from dfp.utils.config_generator import ConfigGenerator
 
     config_generator = ConfigGenerator(config=config, dfp_arg_parser=dfp_arg_parser, schema=schema, encoding="latin1")

--- a/tests/examples/digital_fingerprinting/utils/test_config_generator.py
+++ b/tests/examples/digital_fingerprinting/utils/test_config_generator.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from datetime import datetime
+
+import pytest
+
+from morpheus.config import Config
+
+
+@pytest.fixture(name="dfp_arg_parser")
+def dfp_arg_parser_fixture():
+    from dfp.utils.dfp_arg_parser import DFPArgParser
+    dfp_arg_parser = DFPArgParser(skip_user=["unittest-skip-user"],
+                                  only_user=["unittest-only-user"],
+                                  start_time=datetime(1993, 4, 5, 6, 7, 8),
+                                  log_level=logging.DEBUG,
+                                  cache_dir=".cache",
+                                  sample_rate_s="20",
+                                  duration="2days",
+                                  source="unittest",
+                                  tracking_uri="http://unittest",
+                                  silence_monitors=False,
+                                  mlflow_experiment_name_formatter="unittest-experiment",
+                                  mlflow_model_name_formatter="unittest-model",
+                                  train_users="unittest-train-users")
+    dfp_arg_parser.init()
+    yield dfp_arg_parser
+
+
+@pytest.fixture(name="schema")
+def schema_fixture(config: Config):
+    from dfp.utils.schema_utils import SchemaBuilder
+    schema_builder = SchemaBuilder(config, "duo")
+    yield schema_builder.build_schema()
+
+
+def test_constructor(config: Config, dfp_arg_parser: "DFPArgParser", schema: "Schema"):
+    from dfp.utils.config_generator import ConfigGenerator
+
+    config_generator = ConfigGenerator(config=config, dfp_arg_parser=dfp_arg_parser, schema=schema, encoding="latin1")
+
+    assert config_generator._config is config
+    assert config_generator._dfp_arg_parser is dfp_arg_parser
+    assert config_generator._encoding == "latin1"
+    assert config_generator._start_time_str == "1993-04-05T06:07:08+00:00"
+    assert config_generator._end_time_str == "1993-04-07T06:07:08+00:00"

--- a/tests/modules/test_file_batcher.py
+++ b/tests/modules/test_file_batcher.py
@@ -54,8 +54,8 @@ def default_module_config_fixture():
         "module_name": "file_batcher",
         "namespace": MORPHEUS_MODULE_NAMESPACE,
         "sampling_rate_s": 0,
-        "start_time": "2022-08-01",
-        "end_time": "2022-08-31",
+        "start_time": "2022-08-01T00:00:00",
+        "end_time": "2022-08-31T00:00:00",
         "parser_kwargs": None,
         "schema": {
             "schema_str": None, "encoding": None


### PR DESCRIPTION
## Description
* Fixes an issue where the `--start_time` flag was being ignored
* Prior to nv-morpheus/MRC#451 the `datetime` objects being stored in the config were being serialized to json null, after that change an exception was raised.

Closes #1590

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
