### PR TITLE
Update minimum compute requirements to Volta

### DIFF
--- a/docs/source/cloud_deployment_guide.md
+++ b/docs/source/cloud_deployment_guide.md
@@ -725,7 +725,7 @@ On your AWS EC2 G4 instance, follow the instructions in the linked document to i
 
 ### Prerequisites
 1.  NVIDIA-Certified System
-2.  NVIDIA Pascal GPU or newer (Compute Capability >= 6.0)
+2.  NVIDIA Volta GPU or newer (Compute Capability >= 7.0)
 3.  Ubuntu 20.04 LTS or newer
 
 ## Installing Cloud Native Core Stack on NVIDIA Certified Systems

--- a/docs/source/developer_guide/contributing.md
+++ b/docs/source/developer_guide/contributing.md
@@ -174,8 +174,7 @@ Note: These instructions assume the user is using `mamba` instead of `conda` sin
 #### Prerequisites
 
 - Volta architecture GPU or better
-- NVIDIA driver `525.60.13` or higher
-- [CUDA 12.1](https://developer.nvidia.com/cuda-12-1-1-download-archive)
+- [CUDA 12.1](https://developer.nvidia.com/cuda-12-1-0-download-archive)
 - `conda` and `mamba`
   - Refer to the [Getting Started Guide](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) if `conda` is not already installed
   - Install `mamba`:

--- a/docs/source/developer_guide/contributing.md
+++ b/docs/source/developer_guide/contributing.md
@@ -68,7 +68,7 @@ All of the following instructions assume several variables have been set:
  - `PYTHON_VER`: The desired Python version. Minimum required is `3.10`
  - `RAPIDS_VER`: The desired RAPIDS version for all RAPIDS libraries including cuDF and RMM. If in doubt use `23.06`
  - `TRITONCLIENT_VERSION`: The desired Triton client. If in doubt use `22.10`
- - `CUDA_VER`: The desired CUDA version to use. If in doubt use `11.8`
+ - `CUDA_VER`: The desired CUDA version to use. If in doubt use `12.1`
 
 
 ### Clone the repository and pull large file data from Git LFS
@@ -77,7 +77,7 @@ All of the following instructions assume several variables have been set:
 export PYTHON_VER=3.10
 export RAPIDS_VER=23.06
 export TRITONCLIENT_VERSION=22.10
-export CUDA_VER=11.8
+export CUDA_VER=12.1
 export MORPHEUS_ROOT=$(pwd)/morpheus
 git clone https://github.com/nv-morpheus/Morpheus.git $MORPHEUS_ROOT
 cd $MORPHEUS_ROOT
@@ -175,7 +175,7 @@ Note: These instructions assume the user is using `mamba` instead of `conda` sin
 
 - Volta architecture GPU or better
 - NVIDIA driver `525.60.13` or higher
-- [CUDA 11.8](https://developer.nvidia.com/cuda-11-8-0-download-archive)
+- [CUDA 12.1](https://developer.nvidia.com/cuda-12-1-1-download-archive)
 - `conda` and `mamba`
   - Refer to the [Getting Started Guide](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) if `conda` is not already installed
   - Install `mamba`:
@@ -191,7 +191,7 @@ Note: These instructions assume the user is using `mamba` instead of `conda` sin
    ```bash
    export PYTHON_VER=3.10
    export RAPIDS_VER=23.06
-   export CUDA_VER=11.8
+   export CUDA_VER=12.1
    export MORPHEUS_ROOT=$(pwd)/morpheus
    git clone https://github.com/nv-morpheus/Morpheus.git $MORPHEUS_ROOT
    cd $MORPHEUS_ROOT

--- a/docs/source/developer_guide/contributing.md
+++ b/docs/source/developer_guide/contributing.md
@@ -173,8 +173,8 @@ Note: These instructions assume the user is using `mamba` instead of `conda` sin
 
 #### Prerequisites
 
-- Pascal architecture GPU or better
-- NVIDIA driver `520.61.05` or higher
+- Volta architecture GPU or better
+- NVIDIA driver `525.60.13` or higher
 - [CUDA 11.8](https://developer.nvidia.com/cuda-11-8-0-download-archive)
 - `conda` and `mamba`
   - Refer to the [Getting Started Guide](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) if `conda` is not already installed

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -27,8 +27,8 @@ The [pre-built Docker containers](#using-pre-built-docker-containers) are the ea
 More advanced users, or those who are interested in using the latest pre-release features, will need to [build the Morpheus container](#building-the-morpheus-container) or [build from source](./developer_guide/contributing.md#building-from-source).
 
 ## Requirements
-- Pascal architecture GPU or better
-- NVIDIA driver `520.61.05` or higher
+- Volta architecture GPU or better
+- NVIDIA driver `525.60.13` or higher
 - [Docker](https://docs.docker.com/get-docker/)
 - [The NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
 - [NVIDIA Triton Inference Server](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tritonserver) `23.06` or higher

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -28,7 +28,7 @@ More advanced users, or those who are interested in using the latest pre-release
 
 ## Requirements
 - Volta architecture GPU or better
-- NVIDIA driver `525.60.13` or higher
+- [CUDA 12.1](https://developer.nvidia.com/cuda-12-1-0-download-archive)
 - [Docker](https://docs.docker.com/get-docker/)
 - [The NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
 - [NVIDIA Triton Inference Server](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tritonserver) `23.06` or higher

--- a/examples/gnn_fraud_detection_pipeline/README.md
+++ b/examples/gnn_fraud_detection_pipeline/README.md
@@ -21,7 +21,7 @@ limitations under the License.
 Prior to running the GNN fraud detection pipeline, additional requirements must be installed in to your Conda environment. A supplemental requirements file has been provided in this example directory.
 
 ```bash
-export CUDA_VER=11.8
+export CUDA_VER=12.1
 mamba env update \
   -n ${CONDA_DEFAULT_ENV} \
   --file ./conda/environments/examples_cuda-121_arch-x86_64.yaml

--- a/examples/llm/vdb_upload/README.md
+++ b/examples/llm/vdb_upload/README.md
@@ -441,7 +441,7 @@ using `sentence-transformers/paraphrase-multilingual-mpnet-base-v2` as an exampl
     | pinned_memory_pool_byte_size     | 268435456                                                                                |
     | cuda_memory_pool_byte_size{0}    | 67108864                                                                                 |
     | cuda_memory_pool_byte_size{1}    | 67108864                                                                                 |
-    | min_supported_compute_capability | 6.0                                                                                      |
+    | min_supported_compute_capability | 7.0                                                                                      |
     | strict_readiness                 | 1                                                                                        |
     | exit_timeout                     | 30                                                                                       |
     | cache_enabled                    | 0                                                                                        |

--- a/examples/llm/vdb_upload/README.md
+++ b/examples/llm/vdb_upload/README.md
@@ -441,7 +441,7 @@ using `sentence-transformers/paraphrase-multilingual-mpnet-base-v2` as an exampl
     | pinned_memory_pool_byte_size     | 268435456                                                                                |
     | cuda_memory_pool_byte_size{0}    | 67108864                                                                                 |
     | cuda_memory_pool_byte_size{1}    | 67108864                                                                                 |
-    | min_supported_compute_capability | 7.0                                                                                      |
+    | min_supported_compute_capability | 6.0                                                                                      |
     | strict_readiness                 | 1                                                                                        |
     | exit_timeout                     | 30                                                                                       |
     | cache_enabled                    | 0                                                                                        |


### PR DESCRIPTION
## Description
* Set new minimums to Volta (compute 7), cuda-12.1
* Remove minimum driver version, and instead just document our cuda version.

Closes #1464

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
