### PR TITLE
Updating `nlohman_json` to 3.11 to match MRC

### DIFF
--- a/conda/environments/all_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-121_arch-x86_64.yaml
@@ -63,7 +63,7 @@ dependencies:
 - networkx=2.8.8
 - newspaper3k=0.2
 - ninja=1.11
-- nlohmann_json=3.9
+- nlohmann_json=3.11
 - nodejs=18.*
 - numexpr
 - numpydoc=1.5

--- a/conda/environments/dev_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/dev_cuda-121_arch-x86_64.yaml
@@ -51,7 +51,7 @@ dependencies:
 - nbsphinx
 - networkx=2.8.8
 - ninja=1.11
-- nlohmann_json=3.9
+- nlohmann_json=3.11
 - nodejs=18.*
 - numpydoc=1.5
 - nvtabular=23.08.00

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -182,7 +182,7 @@ dependencies:
           - librdkafka>=1.9.2,<1.10.0a0
           - mrc=24.03
           - ninja=1.11
-          - nlohmann_json=3.9
+          - nlohmann_json=3.11
           - pkg-config=0.29 # for mrc cmake
           - protobuf=4.24
           - pybind11-stubgen=0.10.5


### PR DESCRIPTION
## Description
This PR update `nlohmann_json` to 3.11 to match MRC.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
