### PR TITLE
Move MemoryDescriptor to the morpheus namespace

### DIFF
--- a/morpheus/_lib/include/morpheus/objects/memory_descriptor.hpp
+++ b/morpheus/_lib/include/morpheus/objects/memory_descriptor.hpp
@@ -23,6 +23,13 @@
 
 #include "cuda/memory_resource"
 
+namespace morpheus {
+/**
+ * @addtogroup objects
+ * @{
+ * @file
+ */
+
 /**
  * @brief Struct describing device memory resources.
  *
@@ -47,3 +54,6 @@ struct MORPHEUS_EXPORT MemoryDescriptor
     // Memory resource
     cuda::mr::async_resource_ref<cuda::mr::device_accessible> memory_resource;
 };
+
+/** @} */  // end of group
+}  // namespace morpheus

--- a/morpheus/_lib/src/objects/memory_descriptor.cpp
+++ b/morpheus/_lib/src/objects/memory_descriptor.cpp
@@ -21,8 +21,12 @@
 
 #include <utility>  // for move
 
+namespace morpheus {
+
 MemoryDescriptor::MemoryDescriptor(rmm::cuda_stream_view stream,
                                    cuda::mr::async_resource_ref<cuda::mr::device_accessible> mem_resource) :
   cuda_stream(std::move(stream)),
   memory_resource(mem_resource)
 {}
+
+}  // namespace morpheus


### PR DESCRIPTION
## Description
* Move `MemoryDescriptor` to the morpheus namespace
* Technically a C++ API breaking change, although I can't imagine this impacting any users.

Closes #1601

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
