### PR TITLE
Fix for databricks_cli import error

### DIFF
--- a/conda/environments/all_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-121_arch-x86_64.yaml
@@ -53,6 +53,7 @@ dependencies:
 - isort
 - jsonpatch>=1.33
 - kfp
+- libarrow
 - librdkafka>=1.9.2,<1.10.0a0
 - libtool
 - libwebp=1.3.2
@@ -118,6 +119,7 @@ dependencies:
   - --find-links https://data.dgl.ai/wheels-test/repo.html
   - --find-links https://data.dgl.ai/wheels/cu121/repo.html
   - PyMuPDF==1.23.21
+  - databricks-cli < 0.100
   - databricks-connect
   - dgl==2.0.0
   - dglgo

--- a/conda/environments/all_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-121_arch-x86_64.yaml
@@ -99,7 +99,6 @@ dependencies:
 - scikit-build=0.17.6
 - scikit-learn=1.3.2
 - sentence-transformers
-- snappy=1.1.10
 - sphinx
 - sphinx_rtd_theme
 - sqlalchemy

--- a/conda/environments/all_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-121_arch-x86_64.yaml
@@ -99,6 +99,7 @@ dependencies:
 - scikit-build=0.17.6
 - scikit-learn=1.3.2
 - sentence-transformers
+- snappy=1.1.10
 - sphinx
 - sphinx_rtd_theme
 - sqlalchemy

--- a/conda/environments/all_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-121_arch-x86_64.yaml
@@ -53,7 +53,6 @@ dependencies:
 - isort
 - jsonpatch>=1.33
 - kfp
-- libarrow
 - librdkafka>=1.9.2,<1.10.0a0
 - libtool
 - libwebp=1.3.2

--- a/conda/environments/dev_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/dev_cuda-121_arch-x86_64.yaml
@@ -43,7 +43,6 @@ dependencies:
 - include-what-you-use=0.20
 - ipython
 - isort
-- libarrow
 - librdkafka>=1.9.2,<1.10.0a0
 - libtool
 - mlflow=2.9.2

--- a/conda/environments/dev_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/dev_cuda-121_arch-x86_64.yaml
@@ -80,6 +80,7 @@ dependencies:
 - requests-toolbelt
 - scikit-build=0.17.6
 - scikit-learn=1.3.2
+- snappy=1.1.10
 - sphinx
 - sphinx_rtd_theme
 - sqlalchemy

--- a/conda/environments/dev_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/dev_cuda-121_arch-x86_64.yaml
@@ -80,7 +80,6 @@ dependencies:
 - requests-toolbelt
 - scikit-build=0.17.6
 - scikit-learn=1.3.2
-- snappy=1.1.10
 - sphinx
 - sphinx_rtd_theme
 - sqlalchemy

--- a/conda/environments/dev_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/dev_cuda-121_arch-x86_64.yaml
@@ -43,6 +43,7 @@ dependencies:
 - include-what-you-use=0.20
 - ipython
 - isort
+- libarrow
 - librdkafka>=1.9.2,<1.10.0a0
 - libtool
 - mlflow=2.9.2
@@ -96,6 +97,7 @@ dependencies:
 - zlib=1.2.13
 - pip:
   - PyMuPDF==1.23.21
+  - databricks-cli < 0.100
   - databricks-connect
   - milvus==2.3.5
   - pymilvus==2.3.6

--- a/conda/environments/examples_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/examples_cuda-121_arch-x86_64.yaml
@@ -62,6 +62,7 @@ dependencies:
   - --find-links https://data.dgl.ai/wheels-test/repo.html
   - --find-links https://data.dgl.ai/wheels/cu121/repo.html
   - PyMuPDF==1.23.21
+  - databricks-cli < 0.100
   - databricks-connect
   - dgl==2.0.0
   - dglgo

--- a/conda/environments/examples_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/examples_cuda-121_arch-x86_64.yaml
@@ -51,7 +51,6 @@ dependencies:
 - s3fs=2023.12.2
 - scikit-learn=1.3.2
 - sentence-transformers
-- snappy=1.1.10
 - sqlalchemy
 - tqdm=4
 - transformers=4.36.2

--- a/conda/environments/examples_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/examples_cuda-121_arch-x86_64.yaml
@@ -51,6 +51,7 @@ dependencies:
 - s3fs=2023.12.2
 - scikit-learn=1.3.2
 - sentence-transformers
+- snappy=1.1.10
 - sqlalchemy
 - tqdm=4
 - transformers=4.36.2

--- a/conda/environments/runtime_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/runtime_cuda-121_arch-x86_64.yaml
@@ -38,6 +38,7 @@ dependencies:
 - watchdog=3.0
 - websockets
 - pip:
+  - databricks-cli < 0.100
   - databricks-connect
   - milvus==2.3.5
   - pymilvus==2.3.6

--- a/conda/environments/runtime_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/runtime_cuda-121_arch-x86_64.yaml
@@ -31,6 +31,7 @@ dependencies:
 - requests-cache=1.1
 - requests-toolbelt
 - scikit-learn=1.3.2
+- snappy=1.1.10
 - sqlalchemy
 - tqdm=4
 - typing_utils=0.1

--- a/conda/environments/runtime_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/runtime_cuda-121_arch-x86_64.yaml
@@ -31,7 +31,6 @@ dependencies:
 - requests-cache=1.1
 - requests-toolbelt
 - scikit-learn=1.3.2
-- snappy=1.1.10
 - sqlalchemy
 - tqdm=4
 - typing_utils=0.1

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -273,6 +273,7 @@ dependencies:
           - websockets
           - pip
           - pip:
+            - databricks-cli < 0.100
             - databricks-connect
             - milvus==2.3.5 # update to match pymilvus when available
             - pymilvus==2.3.6

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -264,7 +264,7 @@ dependencies:
           - requests
           - requests-cache=1.1
           - requests-toolbelt # Transitive dep needed by nemollm, specified here to ensure we get a compatible version
-          - snappy=1.1.10
+          #- snappy=1.1.10
           - sqlalchemy
           - tqdm=4
           - typing_utils=0.1

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -264,6 +264,7 @@ dependencies:
           - requests
           - requests-cache=1.1
           - requests-toolbelt # Transitive dep needed by nemollm, specified here to ensure we get a compatible version
+          - snappy=1.1.10
           - sqlalchemy
           - tqdm=4
           - typing_utils=0.1

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -179,7 +179,6 @@ dependencies:
           - gcc_linux-64=11.2
           - glog=0.6
           - gxx_linux-64=11.2
-          - libarrow
           - librdkafka>=1.9.2,<1.10.0a0
           - mrc=24.03
           - ninja=1.11

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -264,7 +264,6 @@ dependencies:
           - requests
           - requests-cache=1.1
           - requests-toolbelt # Transitive dep needed by nemollm, specified here to ensure we get a compatible version
-          #- snappy=1.1.10
           - sqlalchemy
           - tqdm=4
           - typing_utils=0.1

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -179,6 +179,7 @@ dependencies:
           - gcc_linux-64=11.2
           - glog=0.6
           - gxx_linux-64=11.2
+          - libarrow
           - librdkafka>=1.9.2,<1.10.0a0
           - mrc=24.03
           - ninja=1.11


### PR DESCRIPTION
## Description
* Fixes `ModuleNotFoundError: No module named 'databricks_cli'` issue

Closes #1600

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
