### PR TITLE
Switch to kafka 3.5.2

### DIFF
--- a/ci/scripts/download_kafka.py
+++ b/ci/scripts/download_kafka.py
@@ -20,8 +20,8 @@ import os
 import pytest_kafka
 from pytest_kafka.install import set_up_kafka
 
-DEFAULT_KAFKA_URL = 'https://downloads.apache.org/kafka/3.4.1/kafka_2.13-3.4.1.tgz'
-DEFAULT_KAFKA_TAR_ROOTDIR = 'kafka_2.13-3.4.1/'
+DEFAULT_KAFKA_URL = 'https://downloads.apache.org/kafka/3.5.2/kafka_2.13-3.5.2.tgz'
+DEFAULT_KAFKA_TAR_ROOTDIR = 'kafka_2.13-3.5.2/'
 
 
 def main():


### PR DESCRIPTION
## Description
* The download for kafka 3.4.1 has been removed.
* This doesn't impact Morpheus itself, but impacts developers wishing to run Kafka integration tests. 

Closes #1613

Note: The CI runner images have our previous version of kafka pre-downloaded, such that this change isn't actually tested in CI. I did test this locally in a fresh conda env.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
