### PR TITLE
Fix `cupy_to_tensor` to also infer `uint8` and `int8` dtypes

### DIFF
--- a/morpheus/_lib/include/morpheus/objects/dtype.hpp
+++ b/morpheus/_lib/include/morpheus/objects/dtype.hpp
@@ -173,6 +173,7 @@ struct DType
     }
 
   private:
+    char byte_order_char() const;
     char type_char() const;
 
     TypeId m_type_id;

--- a/morpheus/_lib/src/objects/dtype.cpp
+++ b/morpheus/_lib/src/objects/dtype.cpp
@@ -206,7 +206,7 @@ DType DType::from_cudf(cudf::type_id tid)
     case cudf::type_id::EMPTY:
     case cudf::type_id::NUM_TYPE_IDS:
     default:
-        throw std::runtime_error("Not supported");
+        throw std::invalid_argument("Not supported");
     }
 }
 
@@ -300,7 +300,7 @@ DType DType::from_triton(const std::string& type_str)
     }
     else
     {
-        throw std::runtime_error("Not supported");
+        throw std::invalid_argument("Not supported");
     }
 }
 

--- a/morpheus/_lib/src/objects/dtype.cpp
+++ b/morpheus/_lib/src/objects/dtype.cpp
@@ -20,7 +20,6 @@
 #include "morpheus/utilities/string_util.hpp"  // for MORPHEUS_CONCAT_STR
 
 #include <cudf/types.hpp>
-#include <glog/logging.h>  // for CHECK
 
 #include <map>
 #include <sstream>  // Needed by MORPHEUS_CONCAT_STR
@@ -30,7 +29,7 @@
 
 namespace {
 const std::map<char, std::map<size_t, morpheus::TypeId>> StrToTypeId = {
-    {'?', {{1, morpheus::TypeId::BOOL8}}},
+    {'b', {{1, morpheus::TypeId::BOOL8}}},
 
     {'i',
      {{1, morpheus::TypeId::INT8},
@@ -100,14 +99,7 @@ std::string DType::name() const
 
 std::string DType::type_str() const
 {
-    if (m_type_id != TypeId::BOOL8 && m_type_id != TypeId::STRING)
-    {
-        return MORPHEUS_CONCAT_STR("<" << this->type_char() << this->item_size());
-    }
-    else
-    {
-        return std::string{this->type_char()};
-    }
+    return MORPHEUS_CONCAT_STR(this->byte_order_char() << this->type_char() << this->item_size());
 }
 
 // Cudf representation
@@ -220,7 +212,10 @@ DType DType::from_cudf(cudf::type_id tid)
 
 DType DType::from_numpy(const std::string& numpy_str)
 {
-    CHECK(!numpy_str.empty()) << "Cannot create DataType from empty string";
+    if (numpy_str.empty())
+    {
+        throw std::invalid_argument("Cannot create DataType from empty string");
+    }
 
     char type_char    = numpy_str[0];
     size_t size_start = 1;
@@ -241,11 +236,17 @@ DType DType::from_numpy(const std::string& numpy_str)
     // Now lookup in the map
     auto found_type = StrToTypeId.find(type_char);
 
-    CHECK(found_type != StrToTypeId.end()) << "Type char '" << type_char << "' not supported";
+    if (found_type == StrToTypeId.end())
+    {
+        throw std::invalid_argument(MORPHEUS_CONCAT_STR("Type char '" << type_char << "' not supported"));
+    }
 
     auto found_enum = found_type->second.find(dtype_size);
 
-    CHECK(found_enum != found_type->second.end()) << "Type str '" << type_char << dtype_size << "' not supported";
+    if (found_enum == found_type->second.end())
+    {
+        throw std::invalid_argument(MORPHEUS_CONCAT_STR("Type str '" << type_char << dtype_size << "' not supported"));
+    }
 
     return {found_enum->second};
 }
@@ -303,6 +304,31 @@ DType DType::from_triton(const std::string& type_str)
     }
 }
 
+char DType::byte_order_char() const
+{
+    switch (m_type_id)
+    {
+    case TypeId::BOOL8:
+    case TypeId::INT8:
+    case TypeId::UINT8:
+        return '|';
+    case TypeId::INT16:
+    case TypeId::UINT16:
+    case TypeId::INT32:
+    case TypeId::UINT32:
+    case TypeId::INT64:
+    case TypeId::UINT64:
+    case TypeId::FLOAT32:
+    case TypeId::FLOAT64:
+        return '<';
+    case TypeId::EMPTY:
+    case TypeId::NUM_TYPE_IDS:
+    case TypeId::STRING:
+    default:
+        throw std::runtime_error("Not supported");
+    }
+}
+
 char DType::type_char() const
 {
     switch (m_type_id)
@@ -318,7 +344,7 @@ char DType::type_char() const
     case TypeId::UINT64:
         return 'u';
     case TypeId::BOOL8:
-        return '?';
+        return 'b';
     case TypeId::FLOAT32:
     case TypeId::FLOAT64:
         return 'f';

--- a/morpheus/_lib/src/objects/dtype.cpp
+++ b/morpheus/_lib/src/objects/dtype.cpp
@@ -225,8 +225,8 @@ DType DType::from_numpy(const std::string& numpy_str)
     char type_char    = numpy_str[0];
     size_t size_start = 1;
 
-    // Can start with < or > or none
-    if (numpy_str[0] == '<' || numpy_str[0] == '>')
+    // Can start with <, >, | or none
+    if (numpy_str[0] == '<' || numpy_str[0] == '>' || numpy_str[0] == '|')
     {
         type_char  = numpy_str[1];
         size_start = 2;

--- a/morpheus/_lib/tests/CMakeLists.txt
+++ b/morpheus/_lib/tests/CMakeLists.txt
@@ -114,6 +114,12 @@ add_morpheus_test(
 )
 
 add_morpheus_test(
+  NAME objects
+  FILES
+    objects/test_dtype.cpp
+)
+
+add_morpheus_test(
   NAME deserializers
   FILES
     test_deserializers.cpp

--- a/morpheus/_lib/tests/objects/test_dtype.cpp
+++ b/morpheus/_lib/tests/objects/test_dtype.cpp
@@ -17,10 +17,11 @@
 
 #include "../test_utils/common.hpp"  // IWYU pragma: associated
 
-#include <gtest/gtest.h>
-#include <stdexcept>
+#include "morpheus/objects/dtype.hpp"  // for DType
 
-#include "morpheus/objects/dtype.hpp"   // for DType
+#include <gtest/gtest.h>
+
+#include <stdexcept>
 
 using namespace morpheus;
 using namespace morpheus::test;
@@ -85,8 +86,8 @@ TEST_F(TestDType, FromNumpyValidStr)
     ASSERT_EQ(dtype.type_str(), "<f8");
 }
 
-TEST_F(TestDType, FromNumpyInValidStr) {
-
+TEST_F(TestDType, FromNumpyInValidStr)
+{
     // invalid byte order char
     EXPECT_THROW(DType::from_numpy("{i2"), std::invalid_argument);
 

--- a/morpheus/_lib/tests/objects/test_dtype.cpp
+++ b/morpheus/_lib/tests/objects/test_dtype.cpp
@@ -86,7 +86,7 @@ TEST_F(TestDType, FromNumpyValidStr)
     ASSERT_EQ(dtype.type_str(), "<f8");
 }
 
-TEST_F(TestDType, FromNumpyInValidStr)
+TEST_F(TestDType, FromNumpyInvalidStr)
 {
     // invalid byte order char
     EXPECT_THROW(DType::from_numpy("{i2"), std::invalid_argument);

--- a/morpheus/_lib/tests/objects/test_dtype.cpp
+++ b/morpheus/_lib/tests/objects/test_dtype.cpp
@@ -19,6 +19,7 @@
 
 #include "morpheus/objects/dtype.hpp"  // for DType
 
+#include <cudf/types.hpp>
 #include <gtest/gtest.h>
 
 #include <stdexcept>
@@ -105,4 +106,183 @@ TEST_F(TestDType, FromNumpyInvalidStr)
 
     // empty string
     EXPECT_THROW(DType::from_numpy(""), std::invalid_argument);
+}
+
+TEST_F(TestDType, FromTritonValidStr)
+{
+    DType dtype = DType::from_triton("INT8");
+    ASSERT_EQ(dtype.type_id(), TypeId::INT8);
+    ASSERT_EQ(dtype.triton_str(), "INT8");
+    ASSERT_EQ(dtype.item_size(), 1);
+    ASSERT_EQ(dtype.type_str(), "|i1");
+
+    dtype = DType::from_triton("INT16");
+    ASSERT_EQ(dtype.type_id(), TypeId::INT16);
+    ASSERT_EQ(dtype.triton_str(), "INT16");
+    ASSERT_EQ(dtype.item_size(), 2);
+    ASSERT_EQ(dtype.type_str(), "<i2");
+
+    dtype = DType::from_triton("INT32");
+    ASSERT_EQ(dtype.type_id(), TypeId::INT32);
+    ASSERT_EQ(dtype.triton_str(), "INT32");
+    ASSERT_EQ(dtype.item_size(), 4);
+    ASSERT_EQ(dtype.type_str(), "<i4");
+
+    dtype = DType::from_triton("INT64");
+    ASSERT_EQ(dtype.type_id(), TypeId::INT64);
+    ASSERT_EQ(dtype.triton_str(), "INT64");
+    ASSERT_EQ(dtype.item_size(), 8);
+    ASSERT_EQ(dtype.type_str(), "<i8");
+
+    dtype = DType::from_triton("UINT8");
+    ASSERT_EQ(dtype.type_id(), TypeId::UINT8);
+    ASSERT_EQ(dtype.triton_str(), "UINT8");
+    ASSERT_EQ(dtype.item_size(), 1);
+    ASSERT_EQ(dtype.type_str(), "|u1");
+
+    dtype = DType::from_triton("UINT16");
+    ASSERT_EQ(dtype.type_id(), TypeId::UINT16);
+    ASSERT_EQ(dtype.triton_str(), "UINT16");
+    ASSERT_EQ(dtype.item_size(), 2);
+    ASSERT_EQ(dtype.type_str(), "<u2");
+
+    dtype = DType::from_triton("UINT32");
+    ASSERT_EQ(dtype.type_id(), TypeId::UINT32);
+    ASSERT_EQ(dtype.triton_str(), "UINT32");
+    ASSERT_EQ(dtype.item_size(), 4);
+    ASSERT_EQ(dtype.type_str(), "<u4");
+
+    dtype = DType::from_triton("UINT64");
+    ASSERT_EQ(dtype.type_id(), TypeId::UINT64);
+    ASSERT_EQ(dtype.triton_str(), "UINT64");
+    ASSERT_EQ(dtype.item_size(), 8);
+    ASSERT_EQ(dtype.type_str(), "<u8");
+
+    dtype = DType::from_triton("BOOL");
+    ASSERT_EQ(dtype.type_id(), TypeId::BOOL8);
+    ASSERT_EQ(dtype.triton_str(), "BOOL");
+    ASSERT_EQ(dtype.item_size(), 1);
+    ASSERT_EQ(dtype.type_str(), "|b1");
+
+    dtype = DType::from_triton("FP32");
+    ASSERT_EQ(dtype.type_id(), TypeId::FLOAT32);
+    ASSERT_EQ(dtype.triton_str(), "FP32");
+    ASSERT_EQ(dtype.item_size(), 4);
+    ASSERT_EQ(dtype.type_str(), "<f4");
+
+    dtype = DType::from_triton("FP64");
+    ASSERT_EQ(dtype.type_id(), TypeId::FLOAT64);
+    ASSERT_EQ(dtype.triton_str(), "FP64");
+    ASSERT_EQ(dtype.item_size(), 8);
+    ASSERT_EQ(dtype.type_str(), "<f8");
+}
+
+TEST_F(TestDType, FromTritonInvalidStr)
+{
+    EXPECT_THROW(DType::from_triton("BOOL8"), std::invalid_argument);
+    EXPECT_THROW(DType::from_triton("FLOAT32"), std::invalid_argument);
+    EXPECT_THROW(DType::from_triton("FLOAT64"), std::invalid_argument);
+    EXPECT_THROW(DType::from_triton("uint8"), std::invalid_argument);
+    EXPECT_THROW(DType::from_triton("zzzzz"), std::invalid_argument);
+    EXPECT_THROW(DType::from_triton("123456"), std::invalid_argument);
+    EXPECT_THROW(DType::from_triton("*&()#%"), std::invalid_argument);
+
+    // empty string
+    EXPECT_THROW(DType::from_triton(""), std::invalid_argument);
+}
+
+TEST_F(TestDType, FromCudfSupported)
+{
+    DType dtype = DType::from_cudf(cudf::type_id::INT8);
+    ASSERT_EQ(dtype.type_id(), TypeId::INT8);
+    ASSERT_EQ(dtype.cudf_type_id(), cudf::type_id::INT8);
+    ASSERT_EQ(dtype.item_size(), 1);
+    ASSERT_EQ(dtype.type_str(), "|i1");
+
+    dtype = DType::from_cudf(cudf::type_id::INT16);
+    ASSERT_EQ(dtype.type_id(), TypeId::INT16);
+    ASSERT_EQ(dtype.cudf_type_id(), cudf::type_id::INT16);
+    ASSERT_EQ(dtype.item_size(), 2);
+    ASSERT_EQ(dtype.type_str(), "<i2");
+
+    dtype = DType::from_cudf(cudf::type_id::INT32);
+    ASSERT_EQ(dtype.type_id(), TypeId::INT32);
+    ASSERT_EQ(dtype.cudf_type_id(), cudf::type_id::INT32);
+    ASSERT_EQ(dtype.item_size(), 4);
+    ASSERT_EQ(dtype.type_str(), "<i4");
+
+    dtype = DType::from_cudf(cudf::type_id::INT64);
+    ASSERT_EQ(dtype.type_id(), TypeId::INT64);
+    ASSERT_EQ(dtype.cudf_type_id(), cudf::type_id::INT64);
+    ASSERT_EQ(dtype.item_size(), 8);
+    ASSERT_EQ(dtype.type_str(), "<i8");
+
+    dtype = DType::from_cudf(cudf::type_id::UINT8);
+    ASSERT_EQ(dtype.type_id(), TypeId::UINT8);
+    ASSERT_EQ(dtype.cudf_type_id(), cudf::type_id::UINT8);
+    ASSERT_EQ(dtype.item_size(), 1);
+    ASSERT_EQ(dtype.type_str(), "|u1");
+
+    dtype = DType::from_cudf(cudf::type_id::UINT16);
+    ASSERT_EQ(dtype.type_id(), TypeId::UINT16);
+    ASSERT_EQ(dtype.cudf_type_id(), cudf::type_id::UINT16);
+    ASSERT_EQ(dtype.item_size(), 2);
+    ASSERT_EQ(dtype.type_str(), "<u2");
+
+    dtype = DType::from_cudf(cudf::type_id::UINT32);
+    ASSERT_EQ(dtype.type_id(), TypeId::UINT32);
+    ASSERT_EQ(dtype.cudf_type_id(), cudf::type_id::UINT32);
+    ASSERT_EQ(dtype.item_size(), 4);
+    ASSERT_EQ(dtype.type_str(), "<u4");
+
+    dtype = DType::from_cudf(cudf::type_id::UINT64);
+    ASSERT_EQ(dtype.type_id(), TypeId::UINT64);
+    ASSERT_EQ(dtype.cudf_type_id(), cudf::type_id::UINT64);
+    ASSERT_EQ(dtype.item_size(), 8);
+    ASSERT_EQ(dtype.type_str(), "<u8");
+
+    dtype = DType::from_cudf(cudf::type_id::BOOL8);
+    ASSERT_EQ(dtype.type_id(), TypeId::BOOL8);
+    ASSERT_EQ(dtype.cudf_type_id(), cudf::type_id::BOOL8);
+    ASSERT_EQ(dtype.item_size(), 1);
+    ASSERT_EQ(dtype.type_str(), "|b1");
+
+    dtype = DType::from_cudf(cudf::type_id::FLOAT32);
+    ASSERT_EQ(dtype.type_id(), TypeId::FLOAT32);
+    ASSERT_EQ(dtype.cudf_type_id(), cudf::type_id::FLOAT32);
+    ASSERT_EQ(dtype.item_size(), 4);
+    ASSERT_EQ(dtype.type_str(), "<f4");
+
+    dtype = DType::from_cudf(cudf::type_id::FLOAT64);
+    ASSERT_EQ(dtype.type_id(), TypeId::FLOAT64);
+    ASSERT_EQ(dtype.cudf_type_id(), cudf::type_id::FLOAT64);
+    ASSERT_EQ(dtype.item_size(), 8);
+    ASSERT_EQ(dtype.type_str(), "<f8");
+
+    dtype = DType::from_cudf(cudf::type_id::STRING);
+    ASSERT_EQ(dtype.type_id(), TypeId::STRING);
+    ASSERT_EQ(dtype.cudf_type_id(), cudf::type_id::STRING);
+    ASSERT_EQ(dtype.item_size(), 1);
+    // numpy typestr for string not supported
+    EXPECT_THROW(dtype.type_str(), std::runtime_error);
+}
+
+TEST_F(TestDType, FromCudfNotSupported)
+{
+    EXPECT_THROW(DType::from_cudf(cudf::type_id::TIMESTAMP_DAYS), std::invalid_argument);
+    EXPECT_THROW(DType::from_cudf(cudf::type_id::TIMESTAMP_SECONDS), std::invalid_argument);
+    EXPECT_THROW(DType::from_cudf(cudf::type_id::TIMESTAMP_MILLISECONDS), std::invalid_argument);
+    EXPECT_THROW(DType::from_cudf(cudf::type_id::TIMESTAMP_MICROSECONDS), std::invalid_argument);
+    EXPECT_THROW(DType::from_cudf(cudf::type_id::TIMESTAMP_NANOSECONDS), std::invalid_argument);
+    EXPECT_THROW(DType::from_cudf(cudf::type_id::DURATION_DAYS), std::invalid_argument);
+    EXPECT_THROW(DType::from_cudf(cudf::type_id::DURATION_SECONDS), std::invalid_argument);
+    EXPECT_THROW(DType::from_cudf(cudf::type_id::DURATION_MILLISECONDS), std::invalid_argument);
+    EXPECT_THROW(DType::from_cudf(cudf::type_id::DURATION_NANOSECONDS), std::invalid_argument);
+    EXPECT_THROW(DType::from_cudf(cudf::type_id::DICTIONARY32), std::invalid_argument);
+    EXPECT_THROW(DType::from_cudf(cudf::type_id::LIST), std::invalid_argument);
+    EXPECT_THROW(DType::from_cudf(cudf::type_id::DECIMAL32), std::invalid_argument);
+    EXPECT_THROW(DType::from_cudf(cudf::type_id::DECIMAL64), std::invalid_argument);
+    EXPECT_THROW(DType::from_cudf(cudf::type_id::DECIMAL128), std::invalid_argument);
+    EXPECT_THROW(DType::from_cudf(cudf::type_id::STRUCT), std::invalid_argument);
+    EXPECT_THROW(DType::from_cudf(cudf::type_id::NUM_TYPE_IDS), std::invalid_argument);
 }

--- a/morpheus/_lib/tests/objects/test_dtype.cpp
+++ b/morpheus/_lib/tests/objects/test_dtype.cpp
@@ -186,8 +186,6 @@ TEST_F(TestDType, FromTritonInvalidStr)
     EXPECT_THROW(DType::from_triton("zzzzz"), std::invalid_argument);
     EXPECT_THROW(DType::from_triton("123456"), std::invalid_argument);
     EXPECT_THROW(DType::from_triton("*&()#%"), std::invalid_argument);
-
-    // empty string
     EXPECT_THROW(DType::from_triton(""), std::invalid_argument);
 }
 

--- a/morpheus/_lib/tests/objects/test_dtype.cpp
+++ b/morpheus/_lib/tests/objects/test_dtype.cpp
@@ -1,0 +1,107 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../test_utils/common.hpp"  // IWYU pragma: associated
+
+#include <gtest/gtest.h>
+#include <stdexcept>
+
+#include "morpheus/objects/dtype.hpp"   // for DType
+
+using namespace morpheus;
+using namespace morpheus::test;
+
+TEST_CLASS(DType);
+
+TEST_F(TestDType, FromNumpyValidStr)
+{
+    DType dtype = DType::from_numpy("|i1");
+    ASSERT_EQ(dtype.type_id(), TypeId::INT8);
+    ASSERT_EQ(dtype.item_size(), 1);
+    ASSERT_EQ(dtype.type_str(), "|i1");
+
+    dtype = DType::from_numpy("<i2");
+    ASSERT_EQ(dtype.type_id(), TypeId::INT16);
+    ASSERT_EQ(dtype.item_size(), 2);
+    ASSERT_EQ(dtype.type_str(), "<i2");
+
+    dtype = DType::from_numpy("<i4");
+    ASSERT_EQ(dtype.type_id(), TypeId::INT32);
+    ASSERT_EQ(dtype.item_size(), 4);
+    ASSERT_EQ(dtype.type_str(), "<i4");
+
+    dtype = DType::from_numpy("<i8");
+    ASSERT_EQ(dtype.type_id(), TypeId::INT64);
+    ASSERT_EQ(dtype.item_size(), 8);
+    ASSERT_EQ(dtype.type_str(), "<i8");
+
+    dtype = DType::from_numpy("|u1");
+    ASSERT_EQ(dtype.type_id(), TypeId::UINT8);
+    ASSERT_EQ(dtype.item_size(), 1);
+    ASSERT_EQ(dtype.type_str(), "|u1");
+
+    dtype = DType::from_numpy("<u2");
+    ASSERT_EQ(dtype.type_id(), TypeId::UINT16);
+    ASSERT_EQ(dtype.item_size(), 2);
+    ASSERT_EQ(dtype.type_str(), "<u2");
+
+    dtype = DType::from_numpy("<u4");
+    ASSERT_EQ(dtype.type_id(), TypeId::UINT32);
+    ASSERT_EQ(dtype.item_size(), 4);
+    ASSERT_EQ(dtype.type_str(), "<u4");
+
+    dtype = DType::from_numpy("<u8");
+    ASSERT_EQ(dtype.type_id(), TypeId::UINT64);
+    ASSERT_EQ(dtype.item_size(), 8);
+    ASSERT_EQ(dtype.type_str(), "<u8");
+
+    dtype = DType::from_numpy("|b1");
+    ASSERT_EQ(dtype.type_id(), TypeId::BOOL8);
+    ASSERT_EQ(dtype.item_size(), 1);
+    ASSERT_EQ(dtype.type_str(), "|b1");
+
+    dtype = DType::from_numpy("<f4");
+    ASSERT_EQ(dtype.type_id(), TypeId::FLOAT32);
+    ASSERT_EQ(dtype.item_size(), 4);
+    ASSERT_EQ(dtype.type_str(), "<f4");
+
+    dtype = DType::from_numpy("<f8");
+    ASSERT_EQ(dtype.type_id(), TypeId::FLOAT64);
+    ASSERT_EQ(dtype.item_size(), 8);
+    ASSERT_EQ(dtype.type_str(), "<f8");
+}
+
+TEST_F(TestDType, FromNumpyInValidStr) {
+
+    // invalid byte order char
+    EXPECT_THROW(DType::from_numpy("{i2"), std::invalid_argument);
+
+    // invalid type char
+    EXPECT_THROW(DType::from_numpy("<x2"), std::invalid_argument);
+
+    // invalid byte size
+    EXPECT_THROW(DType::from_numpy("<i9"), std::invalid_argument);
+
+    // all invalid
+    EXPECT_THROW(DType::from_numpy("{x9"), std::invalid_argument);
+    EXPECT_THROW(DType::from_numpy("zzzzz"), std::invalid_argument);
+    EXPECT_THROW(DType::from_numpy("123456"), std::invalid_argument);
+    EXPECT_THROW(DType::from_numpy("*&()#%"), std::invalid_argument);
+
+    // empty string
+    EXPECT_THROW(DType::from_numpy(""), std::invalid_argument);
+}


### PR DESCRIPTION
## Description
- Update to `DType::from_numpy` to handle strings that identify `uint8` and `int8` dtypes
- Add unit tests for DType
- Update to throw invalid argument exceptions on invalid numpy typestr's.

Closes #1619

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
