### PR TITLE
Truncate strings exceeding max_length when inserting to Milvus

### DIFF
--- a/docs/source/extra_info/known_issues.md
+++ b/docs/source/extra_info/known_issues.md
@@ -19,7 +19,5 @@ limitations under the License.
 
 - TrainAEStage fails with a Segmentation fault ([#1641](https://github.com/nv-morpheus/Morpheus/pull/1641))
 - vdb_upload example pipeline triggers an internal error in Triton ([#1649](https://github.com/nv-morpheus/Morpheus/pull/1649))
-- vdb_upload example pipeline error on inserting large strings ([#1650](https://github.com/nv-morpheus/Morpheus/pull/1650))
-- vdb_upload example pipeline only works with C++ mode disabled ([#1651](https://github.com/nv-morpheus/Morpheus/pull/1651))
 
 Refer to [open issues in the Morpheus project](https://github.com/nv-morpheus/Morpheus/issues)

--- a/examples/llm/cli.py
+++ b/examples/llm/cli.py
@@ -32,7 +32,7 @@ from morpheus.cli.utils import parse_log_level
               callback=parse_log_level,
               help="Specify the logging level to use.")
 @click.option('--use_cpp',
-              default=False,
+              default=True,
               type=bool,
               help=("Whether or not to use C++ node and message types or to prefer python. "
                     "Only use as a last resort if bugs are encountered"))

--- a/examples/llm/vdb_upload/pipeline.py
+++ b/examples/llm/vdb_upload/pipeline.py
@@ -92,7 +92,7 @@ def pipeline(pipeline_config: Config,
 
         return message
 
-    embedding_tensor_to_df_stage = pipe.add_stage(embedding_tensor_to_df(config=pipeline_config))
+    embedding_tensor_to_df_stage = pipe.add_stage(embedding_tensor_to_df(pipeline_config))
 
     vector_db = pipe.add_stage(WriteToVectorDBStage(pipeline_config, **vdb_config))
 

--- a/examples/llm/vdb_upload/pipeline.py
+++ b/examples/llm/vdb_upload/pipeline.py
@@ -19,7 +19,9 @@ import typing
 from vdb_upload.helper import process_vdb_sources
 
 from morpheus.config import Config
+from morpheus.messages import ControlMessage
 from morpheus.pipeline.pipeline import Pipeline
+from morpheus.pipeline.stage_decorator import stage
 from morpheus.stages.general.monitor_stage import MonitorStage
 from morpheus.stages.general.trigger_stage import TriggerStage
 from morpheus.stages.inference.triton_inference_stage import TritonInferenceStage
@@ -78,6 +80,20 @@ def pipeline(pipeline_config: Config,
     monitor_2 = pipe.add_stage(
         MonitorStage(pipeline_config, description="Inference rate", unit="events", delayed_start=True))
 
+    @stage
+    def embedding_tensor_to_df(message: ControlMessage, *, embedding_tensor_name='probs') -> ControlMessage:
+        """
+        Copies the probs tensor to the 'embedding' field of the dataframe.
+        """
+        msg_meta = message.payload()
+        with msg_meta.mutable_dataframe() as df:
+            embedding_tensor = message.tensors().get_tensor(embedding_tensor_name)
+            df['embedding'] = embedding_tensor.tolist()
+
+        return message
+
+    embedding_tensor_to_df_stage = pipe.add_stage(embedding_tensor_to_df(config=pipeline_config))
+
     vector_db = pipe.add_stage(WriteToVectorDBStage(pipeline_config, **vdb_config))
 
     monitor_3 = pipe.add_stage(
@@ -96,7 +112,8 @@ def pipeline(pipeline_config: Config,
     pipe.add_edge(nlp_stage, monitor_1)
     pipe.add_edge(monitor_1, embedding_stage)
     pipe.add_edge(embedding_stage, monitor_2)
-    pipe.add_edge(monitor_2, vector_db)
+    pipe.add_edge(monitor_2, embedding_tensor_to_df_stage)
+    pipe.add_edge(embedding_tensor_to_df_stage, vector_db)
     pipe.add_edge(vector_db, monitor_3)
 
     start_time = time.time()

--- a/examples/llm/vdb_upload/vdb_utils.py
+++ b/examples/llm/vdb_upload/vdb_utils.py
@@ -315,14 +315,15 @@ def build_cli_configs(source_type,
     cli_vdb_conf = {
         # Vector db upload has some significant transaction overhead, batch size here should be as large as possible
         'batch_size': 16384,
-        'resource_name': vector_db_resource_name,
         'embedding_size': embedding_size,
         'recreate': True,
+        'resource_name': vector_db_resource_name,
         'resource_schemas': {
             vector_db_resource_name:
                 build_defualt_milvus_config(embedding_size) if (vector_db_service == 'milvus') else None,
         },
         'service': vector_db_service,
+        'truncate_long_strings': True,
         'uri': vector_db_uri,
     }
 

--- a/morpheus/io/utils.py
+++ b/morpheus/io/utils.py
@@ -14,11 +14,15 @@
 # limitations under the License.
 """IO utilities."""
 
+import logging
+
 import pandas as pd
 
 import cudf
 
 from morpheus.utils.type_aliases import DataFrameType
+
+logger = logging.getLogger(__name__)
 
 
 def filter_null_data(x: DataFrameType):
@@ -50,7 +54,7 @@ def _cudf_needs_truncate(df: cudf.DataFrame, max_bytes: int) -> bool:
     return False
 
 
-def truncate_string_cols_by_bytes(df: DataFrameType, max_bytes: int) -> DataFrameType:
+def truncate_string_cols_by_bytes(df: DataFrameType, max_bytes: int, warn_on_truncate: bool = True) -> DataFrameType:
     """
     Truncates all string columns in a dataframe to a maximum number of bytes.
 
@@ -83,6 +87,9 @@ def truncate_string_cols_by_bytes(df: DataFrameType, max_bytes: int) -> DataFram
         if series.dtype == 'object':
             encoded_series = series.str.encode(encoding='utf-8', errors='strict')
             if encoded_series.str.len().max() > max_bytes:
+                if warn_on_truncate:
+                    logger.warning("Truncating column '%s' to %d bytes", col, max_bytes)
+
                 sliced_series = encoded_series.str.slice(0, max_bytes)
 
                 # There is a possibility that slicing by max_len will slice a multi-byte character in half setting

--- a/morpheus/io/utils.py
+++ b/morpheus/io/utils.py
@@ -71,6 +71,8 @@ def truncate_string_cols_by_bytes(df: DataFrameType,
         The dataframe to truncate.
     column_max_bytes: dict[str, int]
         A mapping of string column names to the maximum number of bytes for each column.
+    warn_on_truncate: bool, default True
+        Whether to log a warning when truncating a column.
 
     Returns
     -------

--- a/morpheus/io/utils.py
+++ b/morpheus/io/utils.py
@@ -14,6 +14,10 @@
 # limitations under the License.
 """IO utilities."""
 
+import pandas as pd
+
+import cudf
+
 from morpheus.utils.type_aliases import DataFrameType
 
 
@@ -31,3 +35,58 @@ def filter_null_data(x: DataFrameType):
         return x
 
     return x[~x['data'].isna()]
+
+
+def _cudf_needs_truncate(df: cudf.DataFrame, max_bytes: int) -> bool:
+    """
+    Optimization, cudf contains a byte_count() method that pandas lacks.
+    """
+    for col in df.columns:
+        series: cudf.Series = df[col]
+        if series.dtype == 'object':
+            if series.str.byte_count().max() > max_bytes:
+                return True
+
+    return False
+
+
+def truncate_string_cols_by_bytes(df: DataFrameType, max_bytes: int) -> DataFrameType:
+    """
+    Truncates all string columns in a dataframe to a maximum number of bytes.
+
+    If truncation is not needed, the original dataframe is returned. If `df` is a cudf.DataFrame, and truncating is
+    needed this function will convert to a pandas DataFrame to perform the truncation.
+
+    Parameters
+    ----------
+    df : DataFrameType
+        The dataframe to truncate.
+    max_bytes : int
+        The maximum number of bytes to truncate the strings to.
+
+    Returns
+    -------
+    DataFrameType
+        The truncated dataframe, if needed.
+    """
+
+    if isinstance(df, cudf.DataFrame):
+        # cudf specific optimization
+        if not _cudf_needs_truncate(df, max_bytes):
+            return df
+
+        # If truncating is needed we need to convert to pandas to use the str.encode() method
+        df = df.to_pandas()
+
+    for col in df.columns:
+        series: pd.Series = df[col]
+        if series.dtype == 'object':
+            encoded_series = series.str.encode(encoding='utf-8', errors='strict')
+            if encoded_series.str.len().max() > max_bytes:
+                sliced_series = encoded_series.str.slice(0, max_bytes)
+
+                # There is a possibility that slicing by max_len will slice a multi-byte character in half setting
+                # errors='ignore' will cause the resulting string to be truncated after the last full character
+                df[col] = sliced_series.str.decode(encoding='utf-8', errors='ignore')
+
+    return df

--- a/morpheus/service/vdb/milvus_vector_db_service.py
+++ b/morpheus/service/vdb/milvus_vector_db_service.py
@@ -20,8 +20,6 @@ import time
 import typing
 from functools import wraps
 
-import pandas as pd
-
 import cudf
 
 from morpheus.io.utils import truncate_string_cols_by_bytes
@@ -752,7 +750,7 @@ class MilvusVectorDBService(VectorDBService):
         ----------
         name : str
             Name of the collection.
-        df : Union[cudf.DataFrame, pd.DataFrame]
+        df : DataFrameType
             The dataframe to create the collection from.
         overwrite : bool, optional
             Whether to overwrite the collection if it already exists. Default is False.

--- a/morpheus/service/vdb/milvus_vector_db_service.py
+++ b/morpheus/service/vdb/milvus_vector_db_service.py
@@ -327,7 +327,7 @@ class MilvusVectorDBResourceService(VectorDBResourceService):
                 logger.info("Skipped checking 'None' in the field: %s, with datatype: %s", field_name, dtype)
 
         needs_truncate = self._truncate_long_strings
-        if isinstance(df, cudf.DataFrame):
+        if needs_truncate and isinstance(df, cudf.DataFrame):
             # Cudf specific optimization, we can avoid a costly call to truncate_string_cols_by_bytes if all of the
             # string columns are already below the max length
             needs_truncate = cudf_string_cols_exceed_max_bytes(df, self._fields_max_length)

--- a/morpheus/service/vdb/milvus_vector_db_service.py
+++ b/morpheus/service/vdb/milvus_vector_db_service.py
@@ -591,6 +591,8 @@ class MilvusVectorDBService(VectorDBService):
         The port number for connecting to the Milvus server.
     alias : str, optional
         Alias for the Milvus connection, by default "default".
+    truncate_long_strings : bool, optional
+        When true, truncate strings values that are longer than the max length of the field
     **kwargs : dict
         Additional keyword arguments specific to the Milvus connection configuration.
     """

--- a/morpheus/service/vdb/milvus_vector_db_service.py
+++ b/morpheus/service/vdb/milvus_vector_db_service.py
@@ -248,7 +248,9 @@ class MilvusVectorDBResourceService(VectorDBResourceService):
             if field.dtype == pymilvus.DataType.FLOAT_VECTOR:
                 self._vector_field = field.name
             else:
-                if field.dtype in (pymilvus.DataType.VARCHAR, pymilvus.DataType.STRING):
+                # Intentionally excluding pymilvus.DataType.STRING, in our current version it isn't supported, and in
+                # some database systems string types don't have a max length.
+                if field.dtype == pymilvus.DataType.VARCHAR:
                     max_length = field.params.get('max_length')
                     if max_length is not None:
                         self._fields_max_length[field.name] = max_length

--- a/morpheus/service/vdb/milvus_vector_db_service.py
+++ b/morpheus/service/vdb/milvus_vector_db_service.py
@@ -605,13 +605,17 @@ class MilvusVectorDBService(VectorDBService):
                  password: str = "",
                  db_name: str = "",
                  token: str = "",
+                 truncate_long_strings: bool = False,
                  **kwargs: dict[str, typing.Any]):
 
+        self._truncate_long_strings = truncate_long_strings
         self._client = MilvusClient(uri=uri, user=user, password=password, db_name=db_name, token=token, **kwargs)
 
     def load_resource(self, name: str, **kwargs: dict[str, typing.Any]) -> MilvusVectorDBResourceService:
-
-        return MilvusVectorDBResourceService(name=name, client=self._client, **kwargs)
+        return MilvusVectorDBResourceService(name=name,
+                                             client=self._client,
+                                             truncate_long_strings=self._truncate_long_strings,
+                                             **kwargs)
 
     def has_store_object(self, name: str) -> bool:
         """

--- a/morpheus/service/vdb/milvus_vector_db_service.py
+++ b/morpheus/service/vdb/milvus_vector_db_service.py
@@ -33,6 +33,11 @@ logger = logging.getLogger(__name__)
 IMPORT_EXCEPTION = None
 IMPORT_ERROR_MESSAGE = "MilvusVectorDBResourceService requires the milvus and pymilvus packages to be installed."
 
+# Milvus has a max string length in bytes of 65,535. Multi-byte characters like "ñ" will have a string length of 1, the
+# byte length encoded as UTF-8 will be 2
+# https://milvus.io/docs/limitations.md#Length-of-a-string
+MAX_STRING_LENGTH_BYTES = 65_535
+
 try:
     import pymilvus
     from pymilvus.orm.mutation import MutationResult
@@ -737,7 +742,7 @@ class MilvusVectorDBService(VectorDBService):
             }
 
             if (field_dict["dtype"] == pymilvus.DataType.VARCHAR):
-                field_dict["max_length"] = 65_535
+                field_dict["max_length"] = MAX_STRING_LENGTH_BYTES
 
             if (field_dict["dtype"] == pymilvus.DataType.FLOAT_VECTOR
                     or field_dict["dtype"] == pymilvus.DataType.BINARY_VECTOR):

--- a/morpheus/service/vdb/milvus_vector_db_service.py
+++ b/morpheus/service/vdb/milvus_vector_db_service.py
@@ -27,6 +27,7 @@ import cudf
 from morpheus.io.utils import truncate_string_cols_by_bytes
 from morpheus.service.vdb.vector_db_service import VectorDBResourceService
 from morpheus.service.vdb.vector_db_service import VectorDBService
+from morpheus.utils.type_aliases import DataFrameType
 
 logger = logging.getLogger(__name__)
 
@@ -287,13 +288,13 @@ class MilvusVectorDBResourceService(VectorDBResourceService):
 
         return self._insert_result_to_dict(result=result)
 
-    def insert_dataframe(self, df: typing.Union[cudf.DataFrame, pd.DataFrame], **kwargs: dict[str, typing.Any]) -> dict:
+    def insert_dataframe(self, df: DataFrameType, **kwargs: dict[str, typing.Any]) -> dict:
         """
         Insert a dataframe entires into the vector database.
 
         Parameters
         ----------
-        df : typing.Union[cudf.DataFrame, pd.DataFrame]
+        df : DataFrameType
             Dataframe to be inserted into the collection.
         **kwargs : dict[str, typing.Any]
             Extra keyword arguments specific to the vector database implementation.
@@ -703,7 +704,7 @@ class MilvusVectorDBService(VectorDBService):
                 for part in partition_conf["partitions"]:
                     self._client.create_partition(collection_name=name, partition_name=part["name"], timeout=timeout)
 
-    def _build_schema_conf(self, df: typing.Union[cudf.DataFrame, pd.DataFrame]) -> list[dict]:
+    def _build_schema_conf(self, df: DataFrameType) -> list[dict]:
         fields = []
 
         # Always add a primary key
@@ -741,7 +742,7 @@ class MilvusVectorDBService(VectorDBService):
 
     def create_from_dataframe(self,
                               name: str,
-                              df: typing.Union[cudf.DataFrame, pd.DataFrame],
+                              df: DataFrameType,
                               overwrite: bool = False,
                               **kwargs: dict[str, typing.Any]) -> None:
         """
@@ -812,10 +813,7 @@ class MilvusVectorDBService(VectorDBService):
         return resource.insert(data, **kwargs)
 
     @with_collection_lock
-    def insert_dataframe(self,
-                         name: str,
-                         df: typing.Union[cudf.DataFrame, pd.DataFrame],
-                         **kwargs: dict[str, typing.Any]) -> dict[str, typing.Any]:
+    def insert_dataframe(self, name: str, df: DataFrameType, **kwargs: dict[str, typing.Any]) -> dict[str, typing.Any]:
         """
         Converts dataframe to rows and insert to a collection in the Milvus vector database.
 
@@ -823,7 +821,7 @@ class MilvusVectorDBService(VectorDBService):
         ----------
         name : str
             Name of the collection to be inserted.
-        df : typing.Union[cudf.DataFrame, pd.DataFrame]
+        df : DataFrameType
             Dataframe to be inserted in the collection.
         **kwargs : dict[str, typing.Any]
             Additional keyword arguments containing collection configuration.

--- a/morpheus/stages/inference/inference_stage.py
+++ b/morpheus/stages/inference/inference_stage.py
@@ -287,7 +287,7 @@ class InferenceStage(MultiMessageStage):
                         _message_meta = CppMessageMeta(df=_df)
                         _message.payload(_message_meta)
                         _message.tensors().set_tensor("probs", output_message.get_probs_tensor())
-                        print(_df)
+
                     output_message = _message
 
                 return output_message

--- a/morpheus/stages/inference/inference_stage.py
+++ b/morpheus/stages/inference/inference_stage.py
@@ -286,7 +286,11 @@ class InferenceStage(MultiMessageStage):
                     if (_df is not None and not _df.empty):
                         _message_meta = CppMessageMeta(df=_df)
                         _message.payload(_message_meta)
-                        _message.tensors().set_tensor("probs", output_message.get_probs_tensor())
+
+                        response_tensors = output_message.tensors
+                        cm_tensors = _message.tensors()
+                        for (name, tensor) in response_tensors.items():
+                            cm_tensors.set_tensor(name, tensor)
 
                     output_message = _message
 

--- a/morpheus/utils/type_aliases.py
+++ b/morpheus/utils/type_aliases.py
@@ -20,3 +20,4 @@ import pandas as pd
 import cudf
 
 DataFrameType = typing.Union[pd.DataFrame, cudf.DataFrame]
+SeriesType = typing.Union[pd.Series, cudf.Series]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1035,6 +1035,12 @@ def simple_collection_config_fixture():
     yield load_json_file(filename="service/milvus_simple_collection_conf.json")
 
 
+@pytest.fixture(scope="session", name="string_collection_config")
+def string_collection_config_fixture():
+    from _utils import load_json_file
+    yield load_json_file(filename="service/milvus_string_collection_conf.json")
+
+
 @pytest.fixture(name="nemollm", scope='session')
 def nemollm_fixture(fail_missing: bool):
     """

--- a/tests/io/test_io_utils.py
+++ b/tests/io/test_io_utils.py
@@ -52,6 +52,7 @@ def test_cudf_needs_truncate(data: list[str], max_bytes: int, expected: bool):
     assert io_utils._cudf_needs_truncate(df, max_bytes) is expected
 
 
+@pytest.mark.parametrize("warn_on_truncate", [True, False])
 @pytest.mark.parametrize(
     "data, max_bytes, expected_data",
     [(MULTI_BYTE_STRINGS[:], 4, ["ñä", "Moρ", "río"]), (MULTI_BYTE_STRINGS[:], 5, ["ñä", "Moρ", "río"]),
@@ -61,7 +62,8 @@ def test_cudf_needs_truncate(data: list[str], max_bytes: int, expected: bool):
 def test_truncate_string_cols_by_bytes(dataset: DatasetManager,
                                        data: list[str],
                                        max_bytes: int,
-                                       expected_data: list[str]):
+                                       expected_data: list[str],
+                                       warn_on_truncate: bool):
     input_df = _mk_df(dataset.df_class, data)
 
     if data == expected_data:
@@ -71,7 +73,7 @@ def test_truncate_string_cols_by_bytes(dataset: DatasetManager,
 
     expected_df = _mk_df(expected_df_class, expected_data)
 
-    result_df = io_utils.truncate_string_cols_by_bytes(input_df, max_bytes)
+    result_df = io_utils.truncate_string_cols_by_bytes(input_df, max_bytes, warn_on_truncate=warn_on_truncate)
 
     assert isinstance(result_df, expected_df_class)
     dataset.assert_df_equal(result_df, expected_df)

--- a/tests/io/test_io_utils.py
+++ b/tests/io/test_io_utils.py
@@ -16,7 +16,6 @@
 
 from collections.abc import Callable
 
-import pandas as pd
 import pytest
 
 import cudf

--- a/tests/io/test_io_utils.py
+++ b/tests/io/test_io_utils.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Callable
+
+import pandas as pd
+import pytest
+
+import cudf
+
+from _utils.dataset_manager import DatasetManager
+from morpheus.io import utils as io_utils
+from morpheus.utils.type_aliases import DataFrameType
+
+MULTI_BYTE_STRINGS = ["ñäμɛ", "Moρφευσ", "río"]
+
+
+def _mk_df(df_class: Callable[..., DataFrameType], data: list[str]) -> DataFrameType:
+    """
+    Create a dataframe with a 'data' column containing the given data, and some other columns with different data types
+    """
+    float_col = []
+    int_col = []
+    short_str_col = []
+    for i in range(len(data)):
+        float_col.append(i)
+        int_col.append(i)
+        short_str_col.append(f"{i}"[0:3])
+
+    return df_class({"data": data, "float_col": float_col, "int_col": int_col, "short_str_col": short_str_col})
+
+
+@pytest.mark.parametrize("data, max_bytes, expected",
+                         [(MULTI_BYTE_STRINGS[:], 8, True), (MULTI_BYTE_STRINGS[:], 12, False),
+                          (MULTI_BYTE_STRINGS[:], 20, False), (["." * 20], 19, True), (["." * 20], 20, False),
+                          (["." * 20], 21, False)])
+def test_cudf_needs_truncate(data: list[str], max_bytes: int, expected: bool):
+    df = _mk_df(cudf.DataFrame, data)
+    assert io_utils._cudf_needs_truncate(df, max_bytes) is expected
+
+
+@pytest.mark.parametrize(
+    "data, max_bytes, expected_data",
+    [(MULTI_BYTE_STRINGS[:], 4, ["ñä", "Moρ", "río"]), (MULTI_BYTE_STRINGS[:], 5, ["ñä", "Moρ", "río"]),
+     (MULTI_BYTE_STRINGS[:], 8, ["ñäμɛ", "Moρφε", "río"]), (MULTI_BYTE_STRINGS[:], 9, ["ñäμɛ", "Moρφε", "río"]),
+     (MULTI_BYTE_STRINGS[:], 12, MULTI_BYTE_STRINGS[:]), (MULTI_BYTE_STRINGS[:], 20, MULTI_BYTE_STRINGS[:]),
+     (["." * 20], 19, ["." * 19]), (["." * 20], 20, ["." * 20]), (["." * 20], 21, ["." * 20])])
+def test_truncate_string_cols_by_bytes(dataset: DatasetManager,
+                                       data: list[str],
+                                       max_bytes: int,
+                                       expected_data: list[str]):
+    input_df = _mk_df(dataset.df_class, data)
+
+    if data == expected_data:
+        expected_df_class = dataset.df_class
+    else:
+        expected_df_class = pd.DataFrame
+
+    expected_df = _mk_df(expected_df_class, expected_data)
+
+    result_df = io_utils.truncate_string_cols_by_bytes(input_df, max_bytes)
+
+    assert isinstance(result_df, expected_df_class)
+    dataset.assert_df_equal(result_df, expected_df)

--- a/tests/io/test_io_utils.py
+++ b/tests/io/test_io_utils.py
@@ -44,21 +44,45 @@ def _mk_df(df_class: Callable[..., DataFrameType], data: list[str]) -> DataFrame
 
 
 @pytest.mark.parametrize("data, max_bytes, expected",
-                         [(MULTI_BYTE_STRINGS[:], 8, True), (MULTI_BYTE_STRINGS[:], 12, False),
-                          (MULTI_BYTE_STRINGS[:], 20, False), (["." * 20], 19, True), (["." * 20], 20, False),
-                          (["." * 20], 21, False)])
+                         [(MULTI_BYTE_STRINGS[:], {
+                             "data": 8
+                         }, True), (MULTI_BYTE_STRINGS[:], {
+                             "data": 12
+                         }, False), (MULTI_BYTE_STRINGS[:], {
+                             "data": 20
+                         }, False), (["." * 20], {
+                             "data": 19
+                         }, True), (["." * 20], {
+                             "data": 20
+                         }, False), (["." * 20], {
+                             "data": 21
+                         }, False)])
 def test_cudf_needs_truncate(data: list[str], max_bytes: int, expected: bool):
     df = _mk_df(cudf.DataFrame, data)
     assert io_utils._cudf_needs_truncate(df, max_bytes) is expected
 
 
 @pytest.mark.parametrize("warn_on_truncate", [True, False])
-@pytest.mark.parametrize(
-    "data, max_bytes, expected_data",
-    [(MULTI_BYTE_STRINGS[:], 4, ["ñä", "Moρ", "río"]), (MULTI_BYTE_STRINGS[:], 5, ["ñä", "Moρ", "río"]),
-     (MULTI_BYTE_STRINGS[:], 8, ["ñäμɛ", "Moρφε", "río"]), (MULTI_BYTE_STRINGS[:], 9, ["ñäμɛ", "Moρφε", "río"]),
-     (MULTI_BYTE_STRINGS[:], 12, MULTI_BYTE_STRINGS[:]), (MULTI_BYTE_STRINGS[:], 20, MULTI_BYTE_STRINGS[:]),
-     (["." * 20], 19, ["." * 19]), (["." * 20], 20, ["." * 20]), (["." * 20], 21, ["." * 20])])
+@pytest.mark.parametrize("data, max_bytes, expected_data",
+                         [(MULTI_BYTE_STRINGS[:], {
+                             "data": 4
+                         }, ["ñä", "Moρ", "río"]), (MULTI_BYTE_STRINGS[:], {
+                             "data": 5
+                         }, ["ñä", "Moρ", "río"]), (MULTI_BYTE_STRINGS[:], {
+                             "data": 8
+                         }, ["ñäμɛ", "Moρφε", "río"]), (MULTI_BYTE_STRINGS[:], {
+                             "data": 9
+                         }, ["ñäμɛ", "Moρφε", "río"]), (MULTI_BYTE_STRINGS[:], {
+                             "data": 12
+                         }, MULTI_BYTE_STRINGS[:]), (MULTI_BYTE_STRINGS[:], {
+                             "data": 20
+                         }, MULTI_BYTE_STRINGS[:]), (["." * 20], {
+                             "data": 19
+                         }, ["." * 19]), (["." * 20], {
+                             "data": 20
+                         }, ["." * 20]), (["." * 20], {
+                             "data": 21
+                         }, ["." * 20])])
 def test_truncate_string_cols_by_bytes(dataset: DatasetManager,
                                        data: list[str],
                                        max_bytes: int,

--- a/tests/test_milvus_vector_db_service.py
+++ b/tests/test_milvus_vector_db_service.py
@@ -592,8 +592,8 @@ def test_insert_dataframe(milvus_server_uri: str,
             milvus_service.insert_dataframe(collection_name, df)
 
         return  # Skip the rest of the test if the string column exceeds the maximum length.
-    else:
-        milvus_service.insert_dataframe(collection_name, df)
+
+    milvus_service.insert_dataframe(collection_name, df)
 
     # Retrieve inserted data by primary keys.
     retrieved_data = milvus_service.retrieve_by_keys(collection_name, ids)

--- a/tests/test_milvus_vector_db_service.py
+++ b/tests/test_milvus_vector_db_service.py
@@ -16,14 +16,18 @@
 
 import json
 import random
+import string
 
 import numpy as np
 import pymilvus
 import pytest
 from pymilvus import DataType
+from pymilvus import MilvusException
 
 import cudf
 
+from _utils.dataset_manager import DatasetManager
+from morpheus.service.vdb.milvus_vector_db_service import MAX_STRING_LENGTH_BYTES
 from morpheus.service.vdb.milvus_vector_db_service import FieldSchemaEncoder
 from morpheus.service.vdb.milvus_vector_db_service import MilvusVectorDBService
 
@@ -69,6 +73,38 @@ def test_has_store_object(milvus_service: MilvusVectorDBService):
 @pytest.fixture(scope="module", name="sample_field")
 def sample_field_fixture():
     return pymilvus.FieldSchema(name="test_field", dtype=pymilvus.DataType.INT64)
+
+
+def _mk_long_string(source_chars: str) -> str:
+    """
+    Yields a string longer than MAX_STRING_LENGTH_BYTES from source chars
+    """
+    source_chars_byte_len = len(source_chars.encode("utf-8"))
+    source_data = list(source_chars)
+
+    byte_len = 0
+    long_str_data = []
+    while byte_len <= MAX_STRING_LENGTH_BYTES:
+        long_str_data.extend(source_data)
+        byte_len += source_chars_byte_len
+
+    return "".join(long_str_data)
+
+
+@pytest.fixture(scope="module", name="long_ascii_string")
+def long_ascii_string_fixture():
+    """
+    Yields a string longer than MAX_STRING_LENGTH_BYTES containing only ascii (single-byte) characters
+    """
+    return _mk_long_string(string.ascii_letters)
+
+
+@pytest.fixture(scope="module", name="long_multibyte_string")
+def long_multibyte_string_fixture():
+    """
+    Yields a string longer than MAX_STRING_LENGTH_BYTES containing a mix of single and multi-byte characters
+    """
+    return _mk_long_string("Moρφέας")
 
 
 @pytest.mark.milvus
@@ -467,3 +503,83 @@ def test_fse_from_dict():
     result = FieldSchemaEncoder.from_dict(data)
     assert result.name == "test_field"
     assert result.dtype == pymilvus.DataType.INT64
+
+
+@pytest.mark.milvus
+@pytest.mark.parametrize("num_rows", [10, 100, 1000])
+@pytest.mark.parametrize("use_multi_byte_strings", [True, False], ids=["multi_byte", "ascii"])
+@pytest.mark.parametrize("truncate_long_strings", [True, False], ids=["truncate", "no_truncate"])
+@pytest.mark.parametrize("exceed_max_str_len", [True, False], ids=["exceed_max_len", "within_max_len"])
+def test_insert_dataframe(milvus_server_uri: str,
+                          string_collection_config: dict,
+                          num_rows: int,
+                          dataset: DatasetManager,
+                          use_multi_byte_strings: bool,
+                          truncate_long_strings: bool,
+                          exceed_max_str_len: bool,
+                          long_ascii_string: str,
+                          long_multibyte_string: str):
+    collection_name = "test_insert_dataframe"
+
+    milvus_service = MilvusVectorDBService(uri=milvus_server_uri, truncate_long_strings=truncate_long_strings)
+
+    # Make sure to drop any existing collection from previous runs.
+    milvus_service.drop(collection_name)
+
+    # Create a collection.
+    milvus_service.create(collection_name, **string_collection_config)
+
+    ids = []
+    embedding_data = []
+    long_str_col = []
+    short_str_col = []
+    for i in range(num_rows):
+        ids.append(i)
+        embedding_data.append([i / 10.0] * 3)
+        if use_multi_byte_strings:
+            long_str = long_multibyte_string
+        else:
+            long_str = long_ascii_string
+
+        if exceed_max_str_len:
+            slice_end = len(long_str)
+        else:
+            slice_end = MAX_STRING_LENGTH_BYTES
+
+        long_str_col.append(long_str[:slice_end])
+        short_str_col.append(long_str[:7])
+
+    df = dataset.df_class({
+        "id": ids, "embedding": embedding_data, "long_str_col": long_str_col, "short_str_col": short_str_col
+    })
+
+    expected_long_str = []
+    for long_str in long_str_col:
+        if truncate_long_strings:
+            expected_long_str.append(
+                long_str.encode("utf-8")[:MAX_STRING_LENGTH_BYTES].decode("utf-8", errors="ignore"))
+        else:
+            expected_long_str.append(long_str)
+
+    expected_df = dataset.df_class({
+        "id": ids, "embedding": embedding_data, "long_str_col": expected_long_str, "short_str_col": short_str_col
+    })
+
+    if (exceed_max_str_len and (not truncate_long_strings)):
+        with pytest.raises(MilvusException, match="string exceeds max length"):
+            milvus_service.insert_dataframe(collection_name, df)
+
+        return  # Skip the rest of the test if the string column exceeds the maximum length.
+    else:
+        milvus_service.insert_dataframe(collection_name, df)
+
+    # Retrieve inserted data by primary keys.
+    retrieved_data = milvus_service.retrieve_by_keys(collection_name, ids)
+    assert len(retrieved_data) == num_rows
+
+    # Clean up the collection.
+    milvus_service.drop(collection_name)
+
+    result_df = dataset.df_class(retrieved_data)
+
+    dataset.compare_df(result_df, expected_df)

--- a/tests/test_milvus_vector_db_service.py
+++ b/tests/test_milvus_vector_db_service.py
@@ -519,7 +519,6 @@ def test_fse_from_dict():
 @pytest.mark.parametrize("exceed_max_str_len", [True, False], ids=["exceed_max_len", "within_max_len"])
 def test_insert_dataframe(milvus_server_uri: str,
                           string_collection_config: dict,
-                          num_rows: int,
                           dataset: DatasetManager,
                           use_multi_byte_strings: bool,
                           truncate_long_strings: bool,

--- a/tests/test_milvus_vector_db_service.py
+++ b/tests/test_milvus_vector_db_service.py
@@ -514,7 +514,6 @@ def test_fse_from_dict():
 
 @pytest.mark.milvus
 @pytest.mark.slow
-@pytest.mark.parametrize("num_rows", [10, 100])
 @pytest.mark.parametrize("use_multi_byte_strings", [True, False], ids=["multi_byte", "ascii"])
 @pytest.mark.parametrize("truncate_long_strings", [True, False], ids=["truncate", "no_truncate"])
 @pytest.mark.parametrize("exceed_max_str_len", [True, False], ids=["exceed_max_len", "within_max_len"])
@@ -527,6 +526,7 @@ def test_insert_dataframe(milvus_server_uri: str,
                           exceed_max_str_len: bool,
                           long_ascii_string: str,
                           long_multibyte_string: str):
+    num_rows = 10
     collection_name = "test_insert_dataframe"
 
     milvus_service = MilvusVectorDBService(uri=milvus_server_uri, truncate_long_strings=truncate_long_strings)

--- a/tests/tests_data/service/milvus_string_collection_conf.json
+++ b/tests/tests_data/service/milvus_string_collection_conf.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3eb10ccec64cd704795c8c2b620eae3cc59d6ee05e1a8fc0a8cf0e6b28529e63
+size 1044

--- a/tests/tests_data/service/milvus_string_collection_conf.json
+++ b/tests/tests_data/service/milvus_string_collection_conf.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3eb10ccec64cd704795c8c2b620eae3cc59d6ee05e1a8fc0a8cf0e6b28529e63
-size 1044
+oid sha256:adbc34ae22c1037c8308b5521a01597a81d0ea117cc691e72566b463c0be6e9a
+size 1083


### PR DESCRIPTION
## Description
* Adds new helper methods to `morpheus.io.utils`, `cudf_string_cols_exceed_max_bytes` and `truncate_string_cols_by_bytes`
* When `truncate_long_strings=True` `MilvusVectorDBResourceService` will truncate all `VARCHAR` fields according to the schema's `max_length`
* Add `truncate_long_strings=True` in config for `vdb_upload` pipeline
* Set C++ mode to default for example LLM pipelines
* Remove issues 1650 & 1651 from `known_issues.md`

Closes #1650 
Closes #1651

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
