### PR TITLE
Standardize `NVIDIA_API_BASE` environment variable to `NVAI_BASE_URL`

### DIFF
--- a/morpheus/llm/services/nvfoundation_llm_service.py
+++ b/morpheus/llm/services/nvfoundation_llm_service.py
@@ -143,7 +143,7 @@ class NVFoundationLLMService(LLMService):
         `NGC_ORG_ID` environment variable. This value is only required if the account associated with the `api_key` is
         a member of multiple NGC organizations.
     base_url : str, optional
-            The api host url, by default None. If `None` the url will be read from the `NVIDIA_API_BASE` environment
+            The api host url, by default None. If `None` the url will be read from the `NVAI_BASE_URL` environment
             variable. If neither are present `https://api.nvcf.nvidia.com/v2` will be used., by default None
     """
 
@@ -155,7 +155,7 @@ class NVFoundationLLMService(LLMService):
 
         self._api_key = api_key
         if base_url is None:
-            self._base_url = os.getenv('NVIDIA_API_BASE', None)
+            self._base_url = os.getenv('NVAI_BASE_URL', None)
         else:
             self._base_url = base_url
 

--- a/morpheus/llm/services/nvfoundation_llm_service.py
+++ b/morpheus/llm/services/nvfoundation_llm_service.py
@@ -144,7 +144,7 @@ class NVFoundationLLMService(LLMService):
         a member of multiple NGC organizations.
     base_url : str, optional
             The api host url, by default None. If `None` the url will be read from the `NVAI_BASE_URL` environment
-            variable. If neither are present `https://api.nvcf.nvidia.com/v2` will be used., by default None
+            variable. If neither are present `https://api.nvcf.nvidia.com/v2/nvcf` will be used by langchain.
     """
 
     def __init__(self, *, api_key: str = None, base_url: str = None) -> None:


### PR DESCRIPTION
## Description
This PR standardizes the `NVIDIA_API_BASE` environment variable to `NVAI_BASE_URL` per discussion with maintainers. The new name better reflects the usage of this API for LLM-related tasks, and disambiguates it from other NVIDIA APIs we may need to use in the future.

I also updated the `NVFoundationLLMService` docstring with the new default base url used in the `langchain-nvidia-ai-endpoints` library.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
