### PR TITLE
Handling agent parsing error and adding a default value for NVAI_BASE_URL

### DIFF
--- a/morpheus/llm/nodes/langchain_agent_node.py
+++ b/morpheus/llm/nodes/langchain_agent_node.py
@@ -37,7 +37,10 @@ class LangChainAgentNode(LLMNodeBase):
         The agent executor to use to execute.
     """
 
-    def __init__(self, agent_executor: "AgentExecutor", replace_exceptions: bool=False, replace_exceptions_value: typing.Optional[str]=None):
+    def __init__(self,
+                 agent_executor: "AgentExecutor",
+                 replace_exceptions: bool = False,
+                 replace_exceptions_value: typing.Optional[str] = None):
         super().__init__()
 
         self._agent_executor = agent_executor
@@ -94,10 +97,8 @@ class LangChainAgentNode(LLMNodeBase):
                         # If the agent encounters a parsing error or a server error after retries, replace the error
                         # with a default value to prevent the pipeline from crashing
                         results[i][j] = self._replace_exceptions_value
-                        logger.warning(
-                            f"Exception encountered in result[{i}][{j}]: {answer}. "
-                            f"Replacing with default message: \"{self._replace_exceptions_value}\"."
-                        )
+                        logger.warning(f"Exception encountered in result[{i}][{j}]: {answer}. "
+                                       f"Replacing with default message: \"{self._replace_exceptions_value}\".")
 
         context.set_output(results)
 

--- a/morpheus/llm/nodes/langchain_agent_node.py
+++ b/morpheus/llm/nodes/langchain_agent_node.py
@@ -50,9 +50,6 @@ class LangChainAgentNode(LLMNodeBase):
         self._replace_exceptions = replace_exceptions
         self._replace_exceptions_value = replace_exceptions_value
 
-        if self._replace_exceptions:
-            assert self._replace_exceptions_value is not None, "When replace_exceptions is enabled, replace_exceptions_value must be provided."
-
     def get_input_names(self):
         return self._input_names
 

--- a/morpheus/llm/nodes/langchain_agent_node.py
+++ b/morpheus/llm/nodes/langchain_agent_node.py
@@ -78,6 +78,17 @@ class LangChainAgentNode(LLMNodeBase):
 
         results = await self._run_single(**input_dict)
 
+        # Processes the results to replace exceptions with a default message
+        default_message = "I do not have a definitive answer for this checklist item."
+        for i, answer_list in enumerate(results):
+            for j, answer in enumerate(answer_list):
+                if isinstance(answer, (OutputParserException, Exception)):
+                    # If the agent encounters a parsing error or a server error after retries, replace the error
+                    # with a default value to prevent the pipeline from crashing
+                    results[i][j] = default_message
+                    logger.warning(
+                        f"Exception encountered in result[{i}][{j}]: {answer}. Replacing with default message.")
+
         context.set_output(results)
 
         return context

--- a/morpheus/llm/nodes/langchain_agent_node.py
+++ b/morpheus/llm/nodes/langchain_agent_node.py
@@ -16,6 +16,8 @@ import asyncio
 import logging
 import typing
 
+from langchain_core.exceptions import OutputParserException
+
 from morpheus.llm import LLMContext
 from morpheus.llm import LLMNodeBase
 

--- a/morpheus/llm/services/nvfoundation_llm_service.py
+++ b/morpheus/llm/services/nvfoundation_llm_service.py
@@ -169,8 +169,10 @@ class NVFoundationLLMService(LLMService):
         super().__init__()
 
         self._api_key = api_key
+
+        # Set the base url from the environment if not provided. Default to None to allow the client to set the url.
         if base_url is None:
-            self._base_url = os.getenv('NVAI_BASE_URL', 'https://api.nvcf.nvidia.com/v2/nvcf')
+            self._base_url = os.getenv('NVAI_BASE_URL', None)
         else:
             self._base_url = base_url
 

--- a/morpheus/llm/services/nvfoundation_llm_service.py
+++ b/morpheus/llm/services/nvfoundation_llm_service.py
@@ -155,7 +155,7 @@ class NVFoundationLLMService(LLMService):
 
         self._api_key = api_key
         if base_url is None:
-            self._base_url = os.getenv('NVAI_BASE_URL', None)
+            self._base_url = os.getenv('NVAI_BASE_URL', 'https://api.nvcf.nvidia.com/v2/nvcf')
         else:
             self._base_url = base_url
 

--- a/tests/llm/nodes/test_langchain_agent_node.py
+++ b/tests/llm/nodes/test_langchain_agent_node.py
@@ -145,6 +145,7 @@ def test_execute_error(mock_chat_completion: tuple[mock.MagicMock, mock.MagicMoc
     node = LangChainAgentNode(agent_executor=agent)
     assert isinstance(execute_node(node, input="input1"), RuntimeError)
 
+
 @pytest.mark.parametrize(
     "arun_return,expected_output",
     [
@@ -164,9 +165,7 @@ def test_execute_replaces_exceptions(
     arun_return: list,
     expected_output: list,
 ):
-    placeholder_input_values = {
-        "foo": "bar"
-    }  # a non-empty placeholder input for the context
+    placeholder_input_values = {"foo": "bar"}  # a non-empty placeholder input for the context
     mock_agent_executor.arun.return_value = arun_return
 
     node = LangChainAgentNode(


### PR DESCRIPTION
The agent model in the CVE pipeline sometimes runs into a parsing error that crashes the entire run. This PR adds the handling of such error by replacing it with a default failure sentence and logging the failure.
This PR also includes an addition of a default value for `NVAI_BASE_URL`.