### PR TITLE
Always run the PR builder step even if others are cancelled

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -43,14 +43,6 @@ permissions:
 
 jobs:
 
-  pr-builder:
-    needs:
-      - prepare
-      - checks
-      - ci_pipe
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-24.02
-
   prepare:
     # Executes the get-pr-info action to determine if the PR has the skip-ci label, if the action fails we assume the
     # PR does not have the label
@@ -99,3 +91,13 @@ jobs:
       test_container: nvcr.io/ea-nvidia-morpheus/morpheus:morpheus-ci-test-240524
     secrets:
       NGC_API_KEY: ${{ secrets.NGC_API_KEY }}
+
+  pr-builder:
+    # Always run this step even if others are skipped or cancelled
+    if: '!cancelled()'
+    needs:
+      - prepare
+      - checks
+      - ci_pipe
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-24.02


### PR DESCRIPTION
## Description
- This forces the `pr-builder` step to always be run. Since this is a required step in order to merge a PR, we want to make sure it is always run.
- This is needed since we skip some steps in CI by default which causes the pr-builder step to be skipped as well.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
