### PR TITLE
Fix conda errors in release container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -265,7 +265,6 @@ COPY "${MORPHEUS_ROOT_HOST}/scripts" "./scripts"
 COPY "${MORPHEUS_ROOT_HOST}/*.md" "./"
 COPY "${MORPHEUS_ROOT_HOST}/LICENSE" "./"
 
-# Ensure the conda-bld directory is indexed even if empty
 RUN /opt/conda/bin/conda clean -afy && \
     # Ensure the conda-bld directory is indexed even if empty
     /opt/conda/bin/conda index /opt/conda/conda-bld

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,7 @@
 # ============== LEGEND =================================================== #
 #                         [conda_bld_morpheus]
 #                               /
-# [base] -> [conda_env] -> [base_extended] -> [runtime]
+# [base] -> [conda_env] -> [base_extended] -> [runtime_conda_create] -> [runtime]
 #                               \
 #                         [conda_env_dev] -> [development] -> [development_pydbg]
 #
@@ -218,23 +218,14 @@ RUN --mount=type=cache,id=workspace_cache,target=/workspace/.cache,sharing=locke
     cd ${MORPHEUS_ROOT_HOST} &&\
     MORPHEUS_PYTHON_BUILD_STUBS=OFF CONDA_BLD_PATH=/opt/conda/conda-bld ./ci/conda/recipes/run_conda_build.sh morpheus
 
-# ============ Stage: runtime ============
-# Setup container for runtime environment
-FROM base_extended as runtime
-
+# ============ Stage: runtime_conda_create ============
+# Setup conda for the runtime environment
+FROM base_extended as runtime_conda_create
 ARG MORPHEUS_ROOT_HOST
 ARG CUDA_MAJOR_VER
 ARG CUDA_MINOR_VER
 
-# Only copy specific files/folders over that are necessary for runtime
-COPY "${MORPHEUS_ROOT_HOST}/conda/environments/*.yaml" "./conda/environments/"
-COPY "${MORPHEUS_ROOT_HOST}/docker" "./docker"
-COPY "${MORPHEUS_ROOT_HOST}/docs" "./docs"
-COPY "${MORPHEUS_ROOT_HOST}/examples" "./examples"
-COPY "${MORPHEUS_ROOT_HOST}/models" "./models"
-COPY "${MORPHEUS_ROOT_HOST}/scripts" "./scripts"
-COPY "${MORPHEUS_ROOT_HOST}/*.md" "./"
-COPY "${MORPHEUS_ROOT_HOST}/LICENSE" "./"
+COPY "${MORPHEUS_ROOT_HOST}/conda/environments/runtime_cuda-${CUDA_MAJOR_VER}${CUDA_MINOR_VER}_arch-x86_64.yaml" "./conda/environments/"
 
 # Mount Morpheus conda package build in `conda_bld_morpheus`
 RUN --mount=type=bind,from=conda_bld_morpheus,source=/opt/conda/conda-bld,target=/opt/conda/conda-bld \
@@ -254,12 +245,30 @@ RUN --mount=type=bind,from=conda_bld_morpheus,source=/opt/conda/conda-bld,target
         -c nvidia/label/dev \
         -c pytorch \
         -c defaults \
-        morpheus &&\
+        morpheus && \
+    /opt/conda/bin/conda env update --solver=libmamba -n morpheus --file \
+        conda/environments/runtime_cuda-${CUDA_MAJOR_VER}${CUDA_MINOR_VER}_arch-x86_64.yaml
 
-    /opt/conda/bin/conda env update --solver=libmamba -n morpheus --file conda/environments/runtime_cuda-${CUDA_MAJOR_VER}${CUDA_MINOR_VER}_arch-x86_64.yaml && \
-    conda clean -afy && \
+# ============ Stage: runtime ============
+# Setup container for runtime environment
+FROM runtime_conda_create as runtime
+
+ARG MORPHEUS_ROOT_HOST
+
+# Only copy specific files/folders over that are necessary for runtime
+COPY "${MORPHEUS_ROOT_HOST}/conda/environments/*.yaml" "./conda/environments/"
+COPY "${MORPHEUS_ROOT_HOST}/docker" "./docker"
+COPY "${MORPHEUS_ROOT_HOST}/docs" "./docs"
+COPY "${MORPHEUS_ROOT_HOST}/examples" "./examples"
+COPY "${MORPHEUS_ROOT_HOST}/models" "./models"
+COPY "${MORPHEUS_ROOT_HOST}/scripts" "./scripts"
+COPY "${MORPHEUS_ROOT_HOST}/*.md" "./"
+COPY "${MORPHEUS_ROOT_HOST}/LICENSE" "./"
+
+# Ensure the conda-bld directory is indexed even if empty
+RUN /opt/conda/bin/conda clean -afy && \
     # Ensure the conda-bld directory is indexed even if empty
-    conda index  /opt/conda/conda-bld
+    /opt/conda/bin/conda index /opt/conda/conda-bld
 
 # Use morpheus by default
 CMD [ "morpheus" ]
@@ -291,7 +300,7 @@ RUN source activate morpheus && \
     npm cache clean --force && \
     conda clean -afy  && \
     # Ensure the conda-bld directory is indexed even if empty
-    conda index  /opt/conda/conda-bld
+    conda index /opt/conda/conda-bld
 
 # Setup git to allow other users to access /workspace. Requires git 2.35.3 or
 # greater. See https://marc.info/?l=git&m=164989570902912&w=2. Only enable for

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -298,9 +298,7 @@ RUN --mount=type=cache,id=apt,target=/var/cache/apt \
 RUN source activate morpheus && \
     npm install -g camouflage-server@0.15 && \
     npm cache clean --force && \
-    conda clean -afy  && \
-    # Ensure the conda-bld directory is indexed even if empty
-    conda index /opt/conda/conda-bld
+    conda clean -afy
 
 # Setup git to allow other users to access /workspace. Requires git 2.35.3 or
 # greater. See https://marc.info/?l=git&m=164989570902912&w=2. Only enable for

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -257,7 +257,9 @@ RUN --mount=type=bind,from=conda_bld_morpheus,source=/opt/conda/conda-bld,target
         morpheus &&\
 
     /opt/conda/bin/conda env update --solver=libmamba -n morpheus --file conda/environments/runtime_cuda-${CUDA_MAJOR_VER}${CUDA_MINOR_VER}_arch-x86_64.yaml && \
-    conda clean -afy
+    conda clean -afy && \
+    # Ensure the conda-bld directory is indexed even if empty
+    conda index  /opt/conda/conda-bld
 
 # Use morpheus by default
 CMD [ "morpheus" ]
@@ -287,7 +289,9 @@ RUN --mount=type=cache,id=apt,target=/var/cache/apt \
 RUN source activate morpheus && \
     npm install -g camouflage-server@0.15 && \
     npm cache clean --force && \
-    conda clean -afy
+    conda clean -afy  && \
+    # Ensure the conda-bld directory is indexed even if empty
+    conda index  /opt/conda/conda-bld
 
 # Setup git to allow other users to access /workspace. Requires git 2.35.3 or
 # greater. See https://marc.info/?l=git&m=164989570902912&w=2. Only enable for

--- a/examples/digital_fingerprinting/production/Dockerfile
+++ b/examples/digital_fingerprinting/production/Dockerfile
@@ -28,7 +28,7 @@ WORKDIR /workspace/examples/digital_fingerprinting/
 
 # Install DFP dependencies
 RUN source activate morpheus \
-    && mamba env update -n morpheus --file /workspace/conda/environments/examples_cuda-121_arch-x86_64.yaml
+    && /opt/conda/bin/conda env update --solver=libmamba -n morpheus --file /workspace/conda/environments/examples_cuda-121_arch-x86_64.yaml
 
 # Set the tracking URI for mlflow
 ENV MLFLOW_TRACKING_URI="http://mlflow:5000"
@@ -53,7 +53,7 @@ FROM base as jupyter
 
 # Install the jupyter specific requirements
 RUN source activate morpheus &&\
-    mamba install -y -c conda-forge \
+    /opt/conda/bin/conda install --solver=libmamba -y -c conda-forge \
         ipywidgets \
         jupyter_contrib_nbextensions \
         # notebook v7 is incompatible with jupyter_contrib_nbextensions


### PR DESCRIPTION
## Description
* Ensures that `/opt/conda/conda-bld` is a valid local conda channel. Without this any additional conda commands would error on an invalid conda channel (#1744). 
* Creates a new intermediate docker stage `runtime_conda_create` allowing it to make use of the read-only `/opt/conda/conda-bld` mount from `conda_bld_morpheus`. Then initializing the `/opt/conda/conda-bld` dir as a valid/empty local channel in the `runtime` stage.
* Update `examples/digital_fingerprinting/production/Dockerfile` to use conda with the libmamba solver.

Closes #1744

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
