### PR TITLE
Disable shared memory by default, and fix `--stop_after` flag for `vdb_upload` example

### DIFF
--- a/examples/llm/vdb_upload/run.py
+++ b/examples/llm/vdb_upload/run.py
@@ -104,7 +104,7 @@ def run():
 @click.option("--source_type",
               multiple=True,
               type=click.Choice(['rss', 'filesystem', 'doca'], case_sensitive=False),
-              default=[],
+              default=['rss'],
               show_default=True,
               help="The type of source to use. Can specify multiple times for different source types.")
 @click.option(

--- a/examples/llm/vdb_upload/vdb_config.yaml
+++ b/examples/llm/vdb_upload/vdb_config.yaml
@@ -20,7 +20,7 @@ vdb_pipeline:
       force_convert_inputs: true
       model_name: "all-MiniLM-L6-v2"
       server_url: "http://localhost:8001"
-      use_shared_memory: true
+      use_shared_memory: false
 
   pipeline:
     edge_buffer_size: 128

--- a/examples/llm/vdb_upload/vdb_utils.py
+++ b/examples/llm/vdb_upload/vdb_utils.py
@@ -284,7 +284,7 @@ def build_cli_configs(source_type,
             "force_convert_inputs": True,
             "model_name": embedding_model_name,
             "server_url": triton_server_url,
-            "use_shared_memory": True,
+            "use_shared_memory": False,
         },
         "num_threads": num_threads,
     }


### PR DESCRIPTION
## Description
* Disable shared memory by default since the C++ impl of the Triton stage doesn't support it
* Set the default source type to `rss` since it is the default, but defaulting to `None` causes any RSS related CLI flags to be ignored

Closes #1753

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
