### PR TITLE
Fix `RabbitMQ` output path

### DIFF
--- a/examples/developer_guide/2_2_rabbitmq/README.md
+++ b/examples/developer_guide/2_2_rabbitmq/README.md
@@ -38,7 +38,7 @@ In a second terminal from the root of the Morpheus repo execute:
 python examples/developer_guide/2_2_rabbitmq/read_simple.py
 ```
 
-This will read from a RabbitMQ exchange named 'logs', and write the results to `/tmp/results.json`.
+This will read from a RabbitMQ exchange named 'logs', and write the results to `results.json`.
 
 If no exchange named 'logs' exists in RabbitMQ it will be created. By default the `read_simple.py` script will utilize the class-based `RabbitMQSourceStage`, alternately using the `--use_source_function` flag will utilize the function-based `rabbitmq_source` stage.
 
@@ -64,7 +64,7 @@ morpheus --log_level=INFO --plugin examples/developer_guide/2_2_rabbitmq/rabbitm
   run pipeline-other \
   from-rabbitmq --host=localhost --exchange=logs \
   monitor \
-  to-file --filename=/tmp/results.json --overwrite
+  to-file --filename=results.json --overwrite
 ```
 
 ### Write Pipeline

--- a/examples/developer_guide/2_2_rabbitmq/read_simple.py
+++ b/examples/developer_guide/2_2_rabbitmq/read_simple.py
@@ -53,7 +53,7 @@ def run_pipeline(use_source_function: bool):
     pipeline.add_stage(MonitorStage(config))
 
     # Write the to the output file
-    pipeline.add_stage(WriteToFileStage(config, filename='/tmp/results.json', file_type=FileTypes.JSON, overwrite=True))
+    pipeline.add_stage(WriteToFileStage(config, filename='results.json', file_type=FileTypes.JSON, overwrite=True))
 
     # Run the pipeline
     pipeline.run()

--- a/examples/developer_guide/4_rabbitmq_cpp_stage/README.md
+++ b/examples/developer_guide/4_rabbitmq_cpp_stage/README.md
@@ -55,7 +55,7 @@ In a second terminal from the root of the Morpheus repo execute:
 python examples/developer_guide/4_rabbitmq_cpp_stage/src/read_simple.py
 ```
 
-This will read from a RabbitMQ exchange named 'logs', and write the results to `./.tmp/results.json`.
+This will read from a RabbitMQ exchange named 'logs', and write the results to `results.json`.
 
 If no exchange named 'logs' exists in RabbitMQ it will be created.
 

--- a/examples/developer_guide/4_rabbitmq_cpp_stage/README.md
+++ b/examples/developer_guide/4_rabbitmq_cpp_stage/README.md
@@ -55,7 +55,7 @@ In a second terminal from the root of the Morpheus repo execute:
 python examples/developer_guide/4_rabbitmq_cpp_stage/src/read_simple.py
 ```
 
-This will read from a RabbitMQ exchange named 'logs', and write the results to `/tmp/results.json`.
+This will read from a RabbitMQ exchange named 'logs', and write the results to `./.tmp/results.json`.
 
 If no exchange named 'logs' exists in RabbitMQ it will be created.
 

--- a/examples/developer_guide/4_rabbitmq_cpp_stage/src/read_simple.py
+++ b/examples/developer_guide/4_rabbitmq_cpp_stage/src/read_simple.py
@@ -55,7 +55,7 @@ def run_pipeline(use_cpp, num_threads):
     pipeline.add_stage(MonitorStage(config))
 
     # Write the to the output file
-    pipeline.add_stage(WriteToFileStage(config, filename='/tmp/results.json', file_type=FileTypes.JSON, overwrite=True))
+    pipeline.add_stage(WriteToFileStage(config, filename='results.json', file_type=FileTypes.JSON, overwrite=True))
 
     # Run the pipeline
     pipeline.run()


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
The examples in `examples/developer_guide/2_2_rabbitmq` and `4_rabbitmq_cpp_stage` do not generate output files to `$MORPHEUS_ROOT` when following the README guidance. Change the output path to the root of repo to be consistent with other examples.

Closes #1754

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
