### PR TITLE
Remove setting of `prog_name`, this implies that an executable named `morpheus_llm` exists

### DIFF
--- a/examples/llm/main.py
+++ b/examples/llm/main.py
@@ -26,7 +26,7 @@ def run_cli():
 
     from llm.cli import cli
 
-    cli(obj={}, auto_envvar_prefix='MORPHEUS_LLM', show_default=True, prog_name="morpheus_llm")
+    cli(obj={}, auto_envvar_prefix='MORPHEUS_LLM', show_default=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description
The prog_name was appearing in help strings, ex:
```
python examples/llm/main.py vdb_upload --help
```

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
