### PR TITLE
Remove out of date instructions from  `contributing.md`

### DIFF
--- a/docs/source/developer_guide/contributing.md
+++ b/docs/source/developer_guide/contributing.md
@@ -150,17 +150,13 @@ This workflow utilizes a Docker container to set up most dependencies ensuring a
    ```bash
    ./scripts/compile.sh
    ```
-   This script will run both CMake Configure with default options and CMake build.
-4. Install Morpheus
-   ```bash
-   pip install -e /workspace
-   ```
-   Once Morpheus has been built, it can be installed into the current virtual environment.
-5. [Run Morpheus](../getting_started.md#running-morpheus)
+   This script will run CMake Configure with default options, the CMake build and install Morpheus into the environment.
+
+4. [Run Morpheus](../getting_started.md#running-morpheus)
    ```bash
    morpheus run pipeline-nlp ...
    ```
-   At this point, Morpheus can be fully used. Any changes to Python code will not require a rebuild. Changes to C++ code will require calling `./scripts/compile.sh`. Installing Morpheus is only required once per virtual environment.
+   At this point, Morpheus can be fully used. Any changes to Python code will not require a rebuild. Changes to C++ code will require calling `./scripts/compile.sh`.
 
 ### Build in a Conda Environment
 

--- a/docs/source/developer_guide/contributing.md
+++ b/docs/source/developer_guide/contributing.md
@@ -144,9 +144,6 @@ This workflow utilizes a Docker container to set up most dependencies ensuring a
       Then once the container is started you will need to install some extra packages to enable launching Docker containers:
       ```bash
       ./external/utilities/docker/install_docker.sh
-
-      # Install utils for checking output
-      apt install -y jq bc
       ```
 
 3. Compile Morpheus


### PR DESCRIPTION
## Description
* `jq` and `bc` are installed in the container by default
* `pip intall` is no longer needed as this is now executed by cmake

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
