### PR TITLE
Fix LLM Agents Kafka pipeline 

### DIFF
--- a/docs/source/extra_info/known_issues.md
+++ b/docs/source/extra_info/known_issues.md
@@ -19,6 +19,5 @@ limitations under the License.
 
 - TrainAEStage fails with a Segmentation fault ([#1641](https://github.com/nv-morpheus/Morpheus/issues/1641))
 - vdb_upload example pipeline triggers an internal error in Triton ([#1649](https://github.com/nv-morpheus/Morpheus/issues/1649))
-- LLM Agents Kafka pipeline is broken ([#1791](https://github.com/nv-morpheus/Morpheus/issues/1791))
 
 Refer to [open issues in the Morpheus project](https://github.com/nv-morpheus/Morpheus/issues)

--- a/examples/llm/agents/README.md
+++ b/examples/llm/agents/README.md
@@ -157,8 +157,6 @@ python examples/llm/main.py agents simple [OPTIONS]
 
 ### Run example (Kafka Pipeline):
 
-> **Warning**: The Kafka Agents pipeline is currently broken [#1791](https://github.com/nv-morpheus/Morpheus/issues/1791)
-
 The Kafka Example in the Morpheus LLM Agents demonstrates an streaming implementation, utilizing Kafka messages to
 facilitate the near real-time processing of LLM queries. This example is similar to the Simple example but makes use of
 a KafkaSourceStage to stream and retrieve messages from the Kafka topic
@@ -201,6 +199,14 @@ python examples/llm/main.py agents kafka [OPTIONS]
 - `--model_name TEXT`
     - **Description**: The name of the model to use in OpenAI.
     - **Default**: `gpt-3.5-turbo-instruct`
+
+- `--bootstrap_servers TEXT`
+    - **Description**: The Kafka bootstrap servers to connect to, if undefined the client will attempt to infer the bootrap servers from the environment.
+    - **Default**: `auto`
+
+- `--topic TEXT`
+    - **Description**: The Kafka topic to listen to for input messages.
+    - **Default**: `input`
 
 - `--help`
     - **Description**: Show the help message with options and commands details.

--- a/examples/llm/agents/common.py
+++ b/examples/llm/agents/common.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import time
+
+from langchain.agents import AgentType
+from langchain.agents import initialize_agent
+from langchain.agents import load_tools
+from langchain.agents.agent import AgentExecutor
+from langchain.llms.openai import OpenAI
+
+import cudf
+
+from morpheus.config import Config
+from morpheus.config import PipelineModes
+from morpheus.llm import LLMEngine
+from morpheus.llm.nodes.extracter_node import ExtracterNode
+from morpheus.llm.nodes.langchain_agent_node import LangChainAgentNode
+from morpheus.llm.task_handlers.simple_task_handler import SimpleTaskHandler
+from morpheus.messages import ControlMessage
+from morpheus.pipeline.linear_pipeline import LinearPipeline
+from morpheus.stages.general.monitor_stage import MonitorStage
+from morpheus.stages.input.in_memory_source_stage import InMemorySourceStage
+from morpheus.stages.llm.llm_engine_stage import LLMEngineStage
+from morpheus.stages.output.in_memory_sink_stage import InMemorySinkStage
+from morpheus.stages.preprocess.deserialize_stage import DeserializeStage
+from morpheus.utils.concat_df import concat_dataframes
+
+logger = logging.getLogger(__name__)
+
+
+def _build_agent_executor(model_name: str) -> AgentExecutor:
+
+    llm = OpenAI(model=model_name, temperature=0.0, client=None)
+
+    tools = load_tools(["serpapi", "llm-math"], llm=llm)
+
+    agent_executor = initialize_agent(tools, llm, agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION, verbose=True)
+
+    return agent_executor
+
+
+def _build_engine(model_name: str) -> LLMEngine:
+
+    engine = LLMEngine()
+
+    engine.add_node("extracter", node=ExtracterNode())
+
+    engine.add_node("agent",
+                    inputs=[("/extracter")],
+                    node=LangChainAgentNode(agent_executor=_build_agent_executor(model_name=model_name)))
+
+    engine.add_task_handler(inputs=["/agent"], handler=SimpleTaskHandler())
+
+    return engine

--- a/examples/llm/agents/common.py
+++ b/examples/llm/agents/common.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import logging
-import time
 
 from langchain.agents import AgentType
 from langchain.agents import initialize_agent
@@ -21,10 +20,7 @@ from langchain.agents import load_tools
 from langchain.agents.agent import AgentExecutor
 from langchain.llms.openai import OpenAI
 
-import cudf
-
 from morpheus.config import Config
-from morpheus.config import PipelineModes
 from morpheus.llm import LLMEngine
 from morpheus.llm.nodes.extracter_node import ExtracterNode
 from morpheus.llm.nodes.langchain_agent_node import LangChainAgentNode
@@ -32,11 +28,9 @@ from morpheus.llm.task_handlers.simple_task_handler import SimpleTaskHandler
 from morpheus.messages import ControlMessage
 from morpheus.pipeline.linear_pipeline import LinearPipeline
 from morpheus.stages.general.monitor_stage import MonitorStage
-from morpheus.stages.input.in_memory_source_stage import InMemorySourceStage
 from morpheus.stages.llm.llm_engine_stage import LLMEngineStage
 from morpheus.stages.output.in_memory_sink_stage import InMemorySinkStage
 from morpheus.stages.preprocess.deserialize_stage import DeserializeStage
-from morpheus.utils.concat_df import concat_dataframes
 
 logger = logging.getLogger(__name__)
 

--- a/examples/llm/agents/run.py
+++ b/examples/llm/agents/run.py
@@ -91,6 +91,20 @@ def simple(**kwargs):
     default='gpt-3.5-turbo-instruct',
     help="The name of the model to use in OpenAI",
 )
+@click.option(
+    "--bootstrap_servers",
+    required=True,
+    type=str,
+    default='auto',
+    help="The Kafka bootstrap servers to connect to",
+)
+@click.option(
+    "--topic",
+    required=True,
+    type=str,
+    default='input',
+    help="The Kafka topic to listen to for input messages",
+)
 def kafka(**kwargs):
 
     from .kafka_pipeline import pipeline as _pipeline

--- a/examples/llm/agents/simple_pipeline.py
+++ b/examples/llm/agents/simple_pipeline.py
@@ -104,7 +104,7 @@ def pipeline(
 
     sink = pipe.add_stage(InMemorySinkStage(config))
 
-    pipe.add_stage(MonitorStage(config, description="Upload rate", unit="events", delayed_start=True))
+    pipe.add_stage(MonitorStage(config, description="Agent rate", unit="events", delayed_start=True))
 
     start_time = time.time()
 

--- a/examples/llm/agents/simple_pipeline.py
+++ b/examples/llm/agents/simple_pipeline.py
@@ -15,56 +15,17 @@
 import logging
 import time
 
-from langchain.agents import AgentType
-from langchain.agents import initialize_agent
-from langchain.agents import load_tools
-from langchain.agents.agent import AgentExecutor
-from langchain.llms.openai import OpenAI
-
 import cudf
 
 from morpheus.config import Config
 from morpheus.config import PipelineModes
-from morpheus.llm import LLMEngine
-from morpheus.llm.nodes.extracter_node import ExtracterNode
-from morpheus.llm.nodes.langchain_agent_node import LangChainAgentNode
-from morpheus.llm.task_handlers.simple_task_handler import SimpleTaskHandler
-from morpheus.messages import ControlMessage
 from morpheus.pipeline.linear_pipeline import LinearPipeline
-from morpheus.stages.general.monitor_stage import MonitorStage
 from morpheus.stages.input.in_memory_source_stage import InMemorySourceStage
-from morpheus.stages.llm.llm_engine_stage import LLMEngineStage
-from morpheus.stages.output.in_memory_sink_stage import InMemorySinkStage
-from morpheus.stages.preprocess.deserialize_stage import DeserializeStage
 from morpheus.utils.concat_df import concat_dataframes
 
+from .common import build_common_pipeline
+
 logger = logging.getLogger(__name__)
-
-
-def _build_agent_executor(model_name: str) -> AgentExecutor:
-
-    llm = OpenAI(model=model_name, temperature=0.0, client=None)
-
-    tools = load_tools(["serpapi", "llm-math"], llm=llm)
-
-    agent_executor = initialize_agent(tools, llm, agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION, verbose=True)
-
-    return agent_executor
-
-
-def _build_engine(model_name: str) -> LLMEngine:
-
-    engine = LLMEngine()
-
-    engine.add_node("extracter", node=ExtracterNode())
-
-    engine.add_node("agent",
-                    inputs=[("/extracter")],
-                    node=LangChainAgentNode(agent_executor=_build_agent_executor(model_name=model_name)))
-
-    engine.add_task_handler(inputs=["/agent"], handler=SimpleTaskHandler())
-
-    return engine
 
 
 def pipeline(
@@ -95,16 +56,7 @@ def pipeline(
 
     pipe.set_source(InMemorySourceStage(config, dataframes=source_dfs, repeat=repeat_count))
 
-    pipe.add_stage(
-        DeserializeStage(config, message_type=ControlMessage, task_type="llm_engine", task_payload=completion_task))
-
-    pipe.add_stage(MonitorStage(config, description="Source rate", unit='questions'))
-
-    pipe.add_stage(LLMEngineStage(config, engine=_build_engine(model_name=model_name)))
-
-    sink = pipe.add_stage(InMemorySinkStage(config))
-
-    pipe.add_stage(MonitorStage(config, description="Agent rate", unit="events", delayed_start=True))
+    sink = build_common_pipeline(config=config, pipe=pipe, task_payload=completion_task, model_name=model_name)
 
     start_time = time.time()
 


### PR DESCRIPTION
## Description
* Simple agents pipeline moved to `common.py` to be shared with the kafka pipeline
* Add `--bootstrap_servers` and `--topic` flags.
* Fix mis-named "Upload rate" monitor description with "Agent rate"

Closes #1791

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
