### PR TITLE
Fix merging of CLI args and Yaml configs in `vdb_upload` example

### DIFF
--- a/examples/llm/vdb_upload/langchain.py
+++ b/examples/llm/vdb_upload/langchain.py
@@ -20,7 +20,7 @@ from langchain.embeddings.huggingface import HuggingFaceEmbeddings
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain.vectorstores.milvus import Milvus
 
-from examples.llm.vdb_upload.vdb_utils import build_rss_urls
+from examples.llm.vdb_upload.vdb_utils import DEFAULT_RSS_URLS
 from morpheus.utils.logging_timer import log_time
 
 logger = logging.getLogger(__name__)
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 def chain(model_name, save_cache):
     with log_time(msg="Seeding with chain took {duration} ms. {rate_per_sec} docs/sec", log_fn=logger.debug) as log:
-        loader = RSSFeedLoader(urls=build_rss_urls())
+        loader = RSSFeedLoader(urls=DEFAULT_RSS_URLS.copy())
 
         documents = loader.load()
 

--- a/examples/llm/vdb_upload/run.py
+++ b/examples/llm/vdb_upload/run.py
@@ -16,7 +16,6 @@ import logging
 import os
 
 import click
-from vdb_upload.vdb_utils import build_cli_configs
 from vdb_upload.vdb_utils import build_config
 from vdb_upload.vdb_utils import is_valid_service
 
@@ -192,7 +191,7 @@ def pipeline(ctx: click.Context, **kwargs):
     type=click.Path(file_okay=True, dir_okay=False),
     help="Location to save the cache to",
 )
-def langchain(**kwargs)
+def langchain(**kwargs):
     from .langchain import chain
 
     return chain(**kwargs)

--- a/examples/llm/vdb_upload/run.py
+++ b/examples/llm/vdb_upload/run.py
@@ -17,7 +17,7 @@ import os
 
 import click
 from vdb_upload.vdb_utils import build_cli_configs
-from vdb_upload.vdb_utils import build_final_config
+from vdb_upload.vdb_utils import build_config
 from vdb_upload.vdb_utils import is_valid_service
 
 logger = logging.getLogger(__name__)
@@ -144,7 +144,8 @@ def run():
     default="http://localhost:19530",
     help="URI for connecting to Vector Database server.",
 )
-def pipeline(**kwargs):
+@click.pass_context
+def pipeline(ctx: click.Context, **kwargs):
     """
     Configure and run the data processing pipeline based on the specified command-line options.
 
@@ -154,6 +155,8 @@ def pipeline(**kwargs):
 
     Parameters
     ----------
+    ctx: click.Context
+        Click context object.
     **kwargs : dict
         Keyword arguments containing command-line options.
 
@@ -161,18 +164,19 @@ def pipeline(**kwargs):
     -------
     The result of the internal pipeline function call.
     """
-    vdb_config_path = kwargs.pop('vdb_config_path', None)
-    cli_source_conf, cli_embed_conf, cli_pipe_conf, cli_tok_conf, cli_vdb_conf = build_cli_configs(**kwargs)
-    final_config = build_final_config(vdb_config_path,
-                                      cli_source_conf,
-                                      cli_embed_conf,
-                                      cli_pipe_conf,
-                                      cli_tok_conf,
-                                      cli_vdb_conf)
 
+    vdb_config_path = kwargs.pop('vdb_config_path', None)
+
+    # When a config file is provided, only merge the explicit flags set by the user
+    explicit_cli_args = {}
+    for (key, value) in kwargs.items():
+        if ctx.get_parameter_source(key) is not click.core.ParameterSource.DEFAULT:
+            explicit_cli_args[key] = value
+
+    config = build_config(vdb_conf_path=vdb_config_path, explicit_cli_args=explicit_cli_args, implicit_cli_args=kwargs)
     # Call the internal pipeline function with the final config dictionary
     from .pipeline import pipeline as _pipeline
-    return _pipeline(**final_config)
+    return _pipeline(**config)
 
 
 @run.command()
@@ -188,7 +192,7 @@ def pipeline(**kwargs):
     type=click.Path(file_okay=True, dir_okay=False),
     help="Location to save the cache to",
 )
-def langchain(**kwargs):
+def langchain(**kwargs)
     from .langchain import chain
 
     return chain(**kwargs)

--- a/examples/llm/vdb_upload/vdb_config.yaml
+++ b/examples/llm/vdb_upload/vdb_config.yaml
@@ -31,7 +31,7 @@ vdb_pipeline:
 
   sources:
     - type: rss
-      name: "rss_cve"
+      name: "rss"
       config:
         batch_size: 128 # Number of rss feeds per batch
         cache_dir: "./.cache/http"

--- a/examples/llm/vdb_upload/vdb_config.yaml
+++ b/examples/llm/vdb_upload/vdb_config.yaml
@@ -75,7 +75,6 @@ vdb_pipeline:
         output_batch_size: 2048 # Number of chunked documents per output batch
         request_timeout_sec: 2.0
         run_indefinitely: true
-        stop_after_rec: 64
         strip_markup: true
         web_scraper_config:
           chunk_overlap: 51

--- a/examples/llm/vdb_upload/vdb_config.yaml
+++ b/examples/llm/vdb_upload/vdb_config.yaml
@@ -75,7 +75,7 @@ vdb_pipeline:
         output_batch_size: 2048 # Number of chunked documents per output batch
         request_timeout_sec: 2.0
         run_indefinitely: true
-        stop_after_rec: 0
+        stop_after_rec: 64
         strip_markup: true
         web_scraper_config:
           chunk_overlap: 51

--- a/examples/llm/vdb_upload/vdb_utils.py
+++ b/examples/llm/vdb_upload/vdb_utils.py
@@ -138,6 +138,13 @@ DEFAULT_MILVUS_CONFIG = {
     }
 }
 
+YAML_TO_CONFIG_MAPPING = {
+    'embeddings': 'embeddings_config',
+    'pipeline': 'pipeline_config',
+    'tokenizer': 'tokenizer_config',
+    'vdb': 'vdb_config'
+}
+
 
 def build_milvus_config(resource_schema_config: dict):
     schema_fields = []
@@ -294,7 +301,7 @@ def _cli_args_to_config(cli_args: dict[str, typing.Any], include_defaults: bool 
         if len(cli_args.get('feed_inputs', [])) > 0:
             rss_config['feed_input'] = cli_args['feed_inputs']
 
-        source_config['rss'] = {'type': 'rss', 'name': 'rss-cli', 'config': rss_config}
+        source_config['rss'] = {'type': 'rss', 'name': 'rss', 'config': rss_config}
 
     if 'filesystem' in source_type:
         fs_config = {"extractor_config": {}}
@@ -418,9 +425,11 @@ def build_config(vdb_conf_path: str | None,
             yaml_config = yaml.safe_load(file).get('vdb_pipeline', {})
 
         # Yaml specific transforms
-        yaml_config['vdb_config'] = yaml_config.pop('vdb', {})
+        for (yaml_key, config_key) in YAML_TO_CONFIG_MAPPING.items():
+            yaml_config[config_key] = yaml_config.pop(yaml_key, {})
+
         sources = yaml_config.pop('sources', [])
-        yaml_config['source_config'] = {src['type']: src for src in sources}
+        yaml_config['source_config'] = {src['name']: src for src in sources}
 
     else:
         yaml_config = {}

--- a/examples/llm/vdb_upload/vdb_utils.py
+++ b/examples/llm/vdb_upload/vdb_utils.py
@@ -446,16 +446,3 @@ def build_config(vdb_conf_path: str | None,
     final_config['pipeline_config'] = build_pipeline_config(final_config['pipeline_config'])
 
     return final_config
-
-
-def build_rss_urls() -> typing.List[str]:
-    """
-    Builds a list of RSS feed URLs.
-
-    Returns
-    -------
-    typing.List[str]
-        A list of URLs as strings, each pointing to a different RSS feed.
-    """
-
-    return DEFAULT_RSS_URLS.copy()

--- a/tests/examples/llm/vdb_upload/test_vdb_utils.py
+++ b/tests/examples/llm/vdb_upload/test_vdb_utils.py
@@ -28,29 +28,29 @@ def test_is_valid_service_with_mixed_case(import_vdb_update_utils_module):
     assert import_vdb_update_utils_module.is_valid_service(None, None, "MilVuS") == "milvus"
 
 
-def test_merge_configs_non_overlapping(import_vdb_update_utils_module):
+def test_merge_dicts_non_overlapping(import_vdb_update_utils_module):
     file_config = {"key1": "value1"}
     cli_config = {"key2": "value2"}
     expected = {"key1": "value1", "key2": "value2"}
-    assert import_vdb_update_utils_module.merge_configs(file_config, cli_config) == expected
+    assert import_vdb_update_utils_module.merge_dicts(file_config, cli_config) == expected
 
 
-def test_merge_configs_overlapping(import_vdb_update_utils_module):
+def test_merge_dicts_overlapping(import_vdb_update_utils_module):
     file_config = {"key1": "value1", "key2": "old_value"}
     cli_config = {"key2": "new_value"}
     expected = {"key1": "value1", "key2": "new_value"}
-    assert import_vdb_update_utils_module.merge_configs(file_config, cli_config) == expected
+    assert import_vdb_update_utils_module.merge_dicts(file_config, cli_config) == expected
 
 
-def test_merge_configs_none_in_cli(import_vdb_update_utils_module):
+def test_merge_dicts_none_in_cli(import_vdb_update_utils_module):
     file_config = {"key1": "value1", "key2": "value2"}
     cli_config = {"key2": None}
-    expected = {"key1": "value1", "key2": "value2"}
-    assert import_vdb_update_utils_module.merge_configs(file_config, cli_config) == expected
+    expected = {"key1": "value1", "key2": None}
+    assert import_vdb_update_utils_module.merge_dicts(file_config, cli_config) == expected
 
 
-def test_merge_configs_empty(import_vdb_update_utils_module):
+def test_merge_dicts_empty(import_vdb_update_utils_module):
     file_config = {}
     cli_config = {"key1": "value1"}
     expected = {"key1": "value1"}
-    assert import_vdb_update_utils_module.merge_configs(file_config, cli_config) == expected
+    assert import_vdb_update_utils_module.merge_dicts(file_config, cli_config) == expected


### PR DESCRIPTION
## Description
Currently CLI args always take precedence over Yaml config values, however since most of the CLI args have a default value in practice the Yaml config values are always ignored.

* Differentiate the explicit CLI args the user specified on the command line from the CLI args which include default values the user didn't specify. 
* Move default values out of the code blocks into global dicts
* Fix bug type-o causing Yaml schema definitions to be ignored.
* Resulting code is 100 lines shorter

Precedence order:
1. Explicit CLI args
2. Yaml config (if there is one)
3. Default CLI args

Closes #1752

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
