### PR TITLE
Remove automock for merlin as we no longer have/use merlin

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -173,7 +173,6 @@ autodoc_mock_imports = [
     "datacompy",
     "langchain",
     "langchain_core",
-    "merlin",
     "morpheus.cli.commands",  # Dont document the CLI in Sphinx
     "pandas",
     "pydantic",


### PR DESCRIPTION
## Description
* This was needed to prevent documentation builds from loading merlin, which would require a GPU. 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
