### PR TITLE
Move isort settings into pyproject.toml 

### DIFF
--- a/ci/scripts/common.sh
+++ b/ci/scripts/common.sh
@@ -20,6 +20,7 @@ export MORPHEUS_ROOT=${MORPHEUS_ROOT:-"$(realpath ${SCRIPT_DIR}/../..)"}
 
 export PY_ROOT="${MORPHEUS_ROOT}"
 export PY_CFG="${PY_ROOT}/python/morpheus/setup.cfg"
+export PROJ_TOML="${MORPHEUS_ROOT}/pyproject.toml"
 export PY_DIRS="${PY_ROOT} ci/scripts"
 
 # Determine the commits to compare against. If running in CI, these will be set. Otherwise, diff with main

--- a/ci/scripts/python_checks.sh
+++ b/ci/scripts/python_checks.sh
@@ -42,7 +42,7 @@ if [[ -n "${MORPHEUS_MODIFIED_FILES}" ]]; then
    done
 
    if [[ "${SKIP_ISORT}" == "" ]]; then
-      ISORT_OUTPUT=`python3 -m isort --settings-file ${PY_CFG} --filter-files --check-only  ${MORPHEUS_MODIFIED_FILES[@]} 2>&1`
+      ISORT_OUTPUT=`python3 -m isort --settings-file ${PROJ_TOML} --filter-files --check-only  ${MORPHEUS_MODIFIED_FILES[@]} 2>&1`
       ISORT_RETVAL=$?
    fi
 

--- a/morpheus.code-workspace
+++ b/morpheus.code-workspace
@@ -46,7 +46,7 @@
                     // "from-kafka",
                     "deserialize",
                     "preprocess",
-                    "--vocab_hash_file=./morpheus/data/bert-base-uncased-hash.txt",
+                    "--vocab_hash_file=./python/morpheus/morpheus/data/bert-base-uncased-hash.txt",
                     "--truncation=True",
                     "--do_lower_case=True",
                     "--add_special_tokens=False",
@@ -79,7 +79,7 @@
                 "cwd": "${workspaceFolder}",
                 "justMyCode": false,
                 "name": "Python: Run Pipeline (NLP)",
-                "program": "${workspaceFolder}/morpheus/cli/run.py",
+                "program": "${workspaceFolder}/python/morpheus/morpheus/cli/run.py",
                 "request": "launch",
                 "subProcess": true,
                 "type": "debugpy"
@@ -135,7 +135,7 @@
                 "cwd": "${workspaceFolder}",
                 "justMyCode": false,
                 "name": "Python: Run Pipeline (FIL)",
-                "program": "${workspaceFolder}/morpheus/cli/run.py",
+                "program": "${workspaceFolder}/python/morpheus/morpheus/cli/run.py",
                 "request": "launch",
                 "subProcess": true,
                 "type": "debugpy"
@@ -149,7 +149,7 @@
                     "--model_max_batch_size=1024",
                     "--use_cpp=False",
                     "pipeline-ae",
-                    "--columns_file=morpheus/data/columns_ae_cloudtrail.txt",
+                    "--columns_file=python/morpheus/morpheus/data/columns_ae_cloudtrail.txt",
                     "--userid_column_name=userIdentitysessionContextsessionIssueruserName",
                     "--userid_filter=user123",
                     "--timestamp_column_name=event_dt",
@@ -197,7 +197,7 @@
                 "cwd": "${workspaceFolder}",
                 "justMyCode": false,
                 "name": "Python: Run Pipeline (AE)",
-                "program": "${workspaceFolder}/morpheus/cli/run.py",
+                "program": "${workspaceFolder}/python/morpheus/morpheus/cli/run.py",
                 "request": "launch",
                 "subProcess": true,
                 "type": "debugpy"
@@ -212,7 +212,7 @@
                     "--model_max_batch_size=32",
                     // "--use_cpp=False",
                     "pipeline-nlp",
-                    "--labels_file=morpheus/data/labels_phishing.txt",
+                    "--labels_file=python/morpheus/morpheus/data/labels_phishing.txt",
                     "--model_seq_length=128",
                     "from-file",
                     "--filename=models/datasets/validation-data/phishing-email-validation-data.jsonlines",
@@ -221,7 +221,7 @@
                     // "from-kafka",
                     "deserialize",
                     "preprocess",
-                    "--vocab_hash_file=./morpheus/data/bert-base-uncased-hash.txt",
+                    "--vocab_hash_file=./python/morpheus/morpheus/data/bert-base-uncased-hash.txt",
                     "--truncation=True",
                     // "--stride=",
                     "--do_lower_case=True",
@@ -262,7 +262,7 @@
                 "cwd": "${workspaceFolder}",
                 "justMyCode": false,
                 "name": "Python: Run Pipeline (NLP-Phishing)",
-                "program": "${workspaceFolder}/morpheus/cli/run.py",
+                "program": "${workspaceFolder}/python/morpheus/morpheus/cli/run.py",
                 "request": "launch",
                 "subProcess": true,
                 "type": "debugpy"
@@ -307,7 +307,7 @@
             {
                 "MIMode": "gdb",
                 "args": [
-                    "./morpheus/cli.py",
+                    "./python/morpheus/morpheus/cli.py",
                     "--log_level=DEBUG",
                     "run",
                     "--num_threads=2",
@@ -325,7 +325,7 @@
                     // "from-kafka",
                     "deserialize",
                     "preprocess",
-                    "--vocab_hash_file=./morpheus/data/bert-base-uncased-hash.txt",
+                    "--vocab_hash_file=./python/morpheus/morpheus/data/bert-base-uncased-hash.txt",
                     "--truncation=True",
                     "--do_lower_case=True",
                     "--add_special_tokens=False",
@@ -403,7 +403,7 @@
             {
                 "MIMode": "gdb",
                 "args": [
-                    "./morpheus/cli.py",
+                    "./python/morpheus/morpheus/cli.py",
                     "--log_level=DEBUG",
                     // "--debug",
                     "run",
@@ -496,7 +496,7 @@
             {
                 "MIMode": "gdb",
                 "args": [
-                    "./morpheus/cli.py",
+                    "./python/morpheus/morpheus/cli.py",
                     "--log_level=DEBUG",
                     "run",
                     "--num_threads=1",
@@ -600,7 +600,7 @@
                 "externalConsole": false,
                 "miDebuggerPath": "gdb",
                 "name": "Debug LLM C++ Tests",
-                "program": "${workspaceFolder}/build/morpheus/_lib/tests/test_llm.x",
+                "program": "${workspaceFolder}/build/python/morpheus/morpheus/_lib/tests/test_llm.x",
                 "request": "launch",
                 "setupCommands": [
                     {
@@ -679,7 +679,7 @@
         "files.trimFinalNewlines": true,
         "files.trimTrailingWhitespace": true,
         "flake8.args": [
-            "--style=${workspaceFolder}/setup.cfg"
+            "--style=${workspaceFolder}/python/morpheus/setup.cfg"
         ],
         "pylint.args": [
             "--rcfile=${workspaceFolder}/pyproject.toml",
@@ -730,7 +730,7 @@
             }
         ],
         "yapf.args": [
-            "--style=${workspaceFolder}/setup.cfg"
+            "--style=${workspaceFolder}/python/morpheus/setup.cfg"
         ]
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -719,3 +719,37 @@ ignored-argument-names = "_.*|^ignored_|^unused_"
 # List of qualified module names which can have objects that can redefine
 # builtins.
 redefining-builtins-modules = ["six.moves", "past.builtins", "future.builtins", "builtins", "io"]
+
+
+# ===== isort Config =====
+[tool.isort]
+line_length=120
+multi_line_output=3
+include_trailing_comma=true
+force_grid_wrap=0
+combine_as_imports=true
+order_by_type=true
+force_single_line=true
+src_paths = ["python", "tests"]
+known_dask = ["dask", "distributed", "dask_cuda"]
+known_rapids = ["nvstrings", "nvcategory", "nvtext", "cudf", "cuml", "cugraph", "dask_cudf"]
+known_first_party = ["morpheus", "_utils"]
+default_section = "THIRDPARTY"
+sections= ["FUTURE", "STDLIB", "THIRDPARTY", "DASK", "RAPIDS", "FIRSTPARTY", "LOCALFOLDER"]
+skip= [
+    "__init__.py",
+    # Skip _version.py as it is auto-generated
+    "_version.py",
+    ".eggs",
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".tmp",
+    ".tox",
+    ".venv",
+    "buck-out",
+    "build",
+    "dist",
+    "models",
+    "thirdparty"
+]

--- a/python/morpheus/setup.cfg
+++ b/python/morpheus/setup.cfg
@@ -24,50 +24,6 @@ versionfile_build = morpheus/_version.py
 tag_prefix = v
 parentdir_prefix = morpheus-
 
-# ===== isort Config =====
-[isort]
-line_length=120
-multi_line_output=3
-include_trailing_comma=True
-force_grid_wrap=0
-combine_as_imports=True
-order_by_type=True
-force_single_line=True
-src_paths=morpheus,tests
-known_dask=
-    dask
-    distributed
-    dask_cuda
-known_rapids=
-    nvstrings
-    nvcategory
-    nvtext
-    cudf
-    cuml
-    cugraph
-    dask_cudf
-known_first_party=
-    morpheus
-    _utils
-default_section=THIRDPARTY
-sections=FUTURE,STDLIB,THIRDPARTY,DASK,RAPIDS,FIRSTPARTY,LOCALFOLDER
-skip=
-    __init__.py
-    # Skip _version.py as it is auto-generated
-    _version.py
-    .eggs
-    .git
-    .hg
-    .mypy_cache
-    .tmp
-    .tox
-    .venv
-    buck-out
-    build
-    dist
-    models
-    thirdparty
-
 # ===== flake8 Config =====
 [flake8]
 filename = *.py, *.pyx, *.pxd


### PR DESCRIPTION
## Description
* Fixes isort vscode integration
* Fixes an issue where `tests` was listed in `src_paths` but this was expected to be relative to `python/morpheus`

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
