### PR TITLE
Replace pdf parsing libs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -43,6 +43,14 @@ permissions:
 
 jobs:
 
+  pr-builder:
+    needs:
+      - prepare
+      - checks
+      - ci_pipe
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-24.02
+
   prepare:
     # Executes the get-pr-info action to determine if the PR has the skip-ci label, if the action fails we assume the
     # PR does not have the label
@@ -91,13 +99,3 @@ jobs:
       test_container: nvcr.io/ea-nvidia-morpheus/morpheus:morpheus-ci-test-240614
     secrets:
       NGC_API_KEY: ${{ secrets.NGC_API_KEY }}
-
-  pr-builder:
-    # Always run this step even if others are skipped or cancelled
-    if: '!cancelled()'
-    needs:
-      - prepare
-      - checks
-      - ci_pipe
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-24.02

--- a/conda/environments/all_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-121_arch-x86_64.yaml
@@ -120,7 +120,6 @@ dependencies:
 - pip:
   - --find-links https://data.dgl.ai/wheels-test/repo.html
   - --find-links https://data.dgl.ai/wheels/cu121/repo.html
-  - PyMuPDF==1.23.*
   - databricks-cli < 0.100
   - databricks-connect
   - dgl==2.0.0

--- a/conda/environments/all_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-121_arch-x86_64.yaml
@@ -83,6 +83,7 @@ dependencies:
 - pydantic
 - pylint=3.0.3
 - pypdf=3.17.4
+- pypdfium2=4.30
 - pytest-asyncio
 - pytest-benchmark=4.0
 - pytest-cov

--- a/conda/environments/dev_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/dev_cuda-121_arch-x86_64.yaml
@@ -67,6 +67,7 @@ dependencies:
 - pybind11-stubgen=0.10.5
 - pydantic
 - pylint=3.0.3
+- pypdfium2=4.30
 - pytest-asyncio
 - pytest-benchmark=4.0
 - pytest-cov

--- a/conda/environments/dev_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/dev_cuda-121_arch-x86_64.yaml
@@ -98,7 +98,6 @@ dependencies:
 - yapf=0.40.1
 - zlib=1.2.13
 - pip:
-  - PyMuPDF==1.23.*
   - databricks-cli < 0.100
   - databricks-connect
   - milvus==2.3.5

--- a/conda/environments/examples_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/examples_cuda-121_arch-x86_64.yaml
@@ -67,7 +67,6 @@ dependencies:
 - pip:
   - --find-links https://data.dgl.ai/wheels-test/repo.html
   - --find-links https://data.dgl.ai/wheels/cu121/repo.html
-  - PyMuPDF==1.23.*
   - databricks-cli < 0.100
   - databricks-connect
   - dgl==2.0.0

--- a/conda/environments/examples_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/examples_cuda-121_arch-x86_64.yaml
@@ -44,6 +44,7 @@ dependencies:
 - pluggy=1.3
 - pydantic
 - pypdf=3.17.4
+- pypdfium2=4.30
 - python-confluent-kafka>=1.9.2,<1.10.0a0
 - python-docx==1.1.0
 - python-graphviz

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -371,7 +371,6 @@ dependencies:
           - &python-docx python-docx==1.1.0
           - pip
           - pip:
-              - &PyMuPDF PyMuPDF==1.23.*
               - pytest-kafka==0.6.0
 
   example-dfp-prod:
@@ -420,7 +419,6 @@ dependencies:
             - faiss-gpu==1.7.*
             - google-search-results==2.4
             - nemollm==0.3.5
-            - *PyMuPDF
 
   model-training-tuning:
     common:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -364,6 +364,7 @@ dependencies:
       - output_types: [conda]
         packages:
           - &nodejs nodejs=18.*
+          - &pypdfium2 pypdfium2=4.30
           - pytest-asyncio
           - pytest-benchmark=4.0
           - pytest-cov
@@ -409,6 +410,7 @@ dependencies:
           - onnx=1.15
           - openai=1.13
           - pypdf=3.17.4
+          - *pypdfium2
           - *python-docx
           - requests-toolbelt=1.0 # Transitive dep needed by nemollm, specified here to ensure we get a compatible version
           - sentence-transformers=2.7

--- a/examples/llm/vdb_upload/module/content_extractor_module.py
+++ b/examples/llm/vdb_upload/module/content_extractor_module.py
@@ -20,6 +20,7 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from functools import wraps
 from typing import Dict
+import pypdfium2 as libpdfium
 from typing import List
 
 import fsspec

--- a/examples/llm/vdb_upload/module/content_extractor_module.py
+++ b/examples/llm/vdb_upload/module/content_extractor_module.py
@@ -171,7 +171,15 @@ def _converter_error_handler(func: typing.Callable) -> typing.Callable:
 
 @_converter_error_handler
 def _pdf_to_text_converter(input_info: ConverterInputInfo) -> str:
-    raise NotImplementedError("PDF to text conversion is not implemented.")
+    text = ""
+    pdf_document = libpdfium.PdfDocument(pdf_stream)
+    for page_idx in range(len(pdf_document)):
+        page = doc.get_page(page_idx)
+        textpage = page.get_textpage()
+        page_text = textpage.get_text_bounded()
+        text += page_text
+        
+    return text
 
 
 @_converter_error_handler

--- a/examples/llm/vdb_upload/module/content_extractor_module.py
+++ b/examples/llm/vdb_upload/module/content_extractor_module.py
@@ -22,7 +22,6 @@ from functools import wraps
 from typing import Dict
 from typing import List
 
-import fitz
 import fsspec
 import mrc
 import mrc.core.operators as ops
@@ -171,12 +170,7 @@ def _converter_error_handler(func: typing.Callable) -> typing.Callable:
 
 @_converter_error_handler
 def _pdf_to_text_converter(input_info: ConverterInputInfo) -> str:
-    text = ""
-    pdf_document = fitz.open(stream=input_info.io_bytes, filetype="pdf")
-    for page_num in range(pdf_document.page_count):
-        page = pdf_document[page_num]
-        text += page.get_text()
-    return text
+    raise NotImplementedError("PDF to text conversion is not implemented.")
 
 
 @_converter_error_handler

--- a/examples/llm/vdb_upload/module/content_extractor_module.py
+++ b/examples/llm/vdb_upload/module/content_extractor_module.py
@@ -20,13 +20,13 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from functools import wraps
 from typing import Dict
-import pypdfium2 as libpdfium
 from typing import List
 
 import fsspec
 import mrc
 import mrc.core.operators as ops
 import pandas as pd
+import pypdfium2 as libpdfium
 from docx import Document
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from pydantic import BaseModel  # pylint: disable=no-name-in-module
@@ -172,13 +172,13 @@ def _converter_error_handler(func: typing.Callable) -> typing.Callable:
 @_converter_error_handler
 def _pdf_to_text_converter(input_info: ConverterInputInfo) -> str:
     text = ""
-    pdf_document = libpdfium.PdfDocument(pdf_stream)
+    pdf_document = libpdfium.PdfDocument(input_info.io_bytes)
     for page_idx in range(len(pdf_document)):
-        page = doc.get_page(page_idx)
+        page = pdf_document.get_page(page_idx)
         textpage = page.get_textpage()
         page_text = textpage.get_text_bounded()
         text += page_text
-        
+
     return text
 
 


### PR DESCRIPTION
## Description
* Use pypdfium2 for PDF parsing
* Includes CI fix from PR #1860 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
