### PR TITLE
Drop 'CI Pipeline / Check' dependency from the 'package-core' job

### DIFF
--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -207,7 +207,7 @@ jobs:
   package-core:
     name: Package Core
     if: ${{ inputs.conda_core_run_build }}
-    needs: [check, documentation, test]
+    needs: [documentation, test]
     runs-on: linux-amd64-cpu16
     timeout-minutes: 60
     container:


### PR DESCRIPTION
"CI Pipeline / check" job is only run on pull-requests so having that as a dependency was preventing the "packaging job" from happening on merges to the branch.
