### PR TITLE
Fix DFP integrated training Azure pipeline

### DIFF
--- a/examples/digital_fingerprinting/production/morpheus/dfp/modules/dfp_training.py
+++ b/examples/digital_fingerprinting/production/morpheus/dfp/modules/dfp_training.py
@@ -102,6 +102,7 @@ def dfp_training(builder: mrc.Builder):
 
             output_message = ControlMessage()
             output_message.payload(dfp_mm)
+            output_message.set_metadata("user_id", user_id)
             output_message.set_metadata("model", model)
             output_message.set_metadata("train_scores_mean", 0.0)
             output_message.set_metadata("train_scores_std", 1.0)


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Fix DFP integrated training Azure pipeline, which indicates that `user_id` field is not attached to the `ControlMessage`.

Previously `user_id` is attached to `UserMessageMeta`, which is a subclass of `MessageMeta` that has an additional attribute. Now `UserMessageMeta` should be deprecated as all metadata can be attached directly to `ControlMessage`.

Closes #1893 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
