### PR TITLE
Fix get-pr-info gha reference

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -61,7 +61,7 @@ jobs:
     steps:
       - name: Get PR Info
         id: get-pr-info
-        uses: rapidsai/shared-action-workflows/get-pr-info@branch-23.08
+        uses: nv-gha-runners/get-pr-info@main
         if: ${{ startsWith(github.ref_name, 'pull-request/') }}
     outputs:
       is_pr: ${{ startsWith(github.ref_name, 'pull-request/') }}


### PR DESCRIPTION
rapidsai/shared-action-workflows/get-pr-info was deleted in favor of nv-gha-runners/get-pr-info

https://github.com/rapidsai/shared-actions/pull/11

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
