### PR TITLE
Avoid memory leak warnings from `pypdfium2`

### DIFF
--- a/examples/llm/cli.py
+++ b/examples/llm/cli.py
@@ -16,6 +16,10 @@ import logging
 import time
 
 import click
+# pypdfium2 utilizes an atexit handler to perform cleanup, importing here to ensure that handler is registered before
+# after_pipeline is, and thus is executed after after_pipeline is invoked. This avoids memory leak warnings at shutdown.
+# https://github.com/nv-morpheus/Morpheus/issues/1864
+import pypdfium2  # pylint: disable=unused-import # noqa: F401
 
 from llm.agents import run as run_agents
 from llm.completion import run as run_completion


### PR DESCRIPTION
## Description
* Import `pypdfium2` early to ensure the `atexit` registered by `pypdfium2` is invoked after our `after_pipeline` method is.

Closes #1864

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
