### PR TITLE
Update `WriteToVectorDBStage` to re-raise errors from the underlying database

### DIFF
--- a/tests/test_milvus_write_to_vector_db_stage_pipe.py
+++ b/tests/test_milvus_write_to_vector_db_stage_pipe.py
@@ -27,6 +27,7 @@ from morpheus.pipeline import LinearPipeline
 from morpheus.stages.general.linear_modules_stage import LinearModulesStage
 from morpheus.stages.input.in_memory_source_stage import InMemorySourceStage
 from morpheus.stages.output.in_memory_sink_stage import InMemorySinkStage
+from morpheus.stages.preprocess.deserialize_stage import DeserializeStage
 from morpheus.utils.module_ids import MORPHEUS_MODULE_NAMESPACE
 from morpheus.utils.module_ids import TO_CONTROL_MESSAGE
 from morpheus_llm.service.vdb.milvus_vector_db_service import MilvusVectorDBService
@@ -127,3 +128,29 @@ def test_write_to_vector_db_stage_from_cm_pipe(milvus_server_uri: str,
         assert response["accum_count"] == expected_num_output_rows
 
     assert response["err_count"] == 0
+
+
+@pytest.mark.milvus
+@pytest.mark.use_cpp
+def test_no_resource_error(milvus_server_uri: str, config: Config):
+    """
+    Test to verify that the stage re-raises errors from the underlying service.
+    """
+    collection_name = "does_not_exist_collection"
+
+    df = get_test_df(5)
+
+    milvus_service = MilvusVectorDBService(uri=milvus_server_uri)
+
+    # Make sure to drop any existing collection from previous runs.
+    milvus_service.drop(collection_name)
+
+    pipe = LinearPipeline(config)
+    pipe.set_source(InMemorySourceStage(config, [df]))
+    pipe.add_stage(DeserializeStage(config))
+
+    # Instantiate stage with service instance and insert options.
+    pipe.add_stage(WriteToVectorDBStage(config, resource_name=collection_name, service=milvus_service))
+
+    with pytest.raises(ValueError):
+        pipe.run()


### PR DESCRIPTION
## Description
* Fixes issue where the `WriteToVectorDBStage` catches/logs exceptions from the underlying database allowing failures to go unnoticed. 
* This is a behavior change, where previously errors were stored in the control message's metadata (although there was a bug in this part too so not all errors were stored in the metadata). 

Closes #1882

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
