### PR TITLE
Optionally clone Morpheus from a URL during Docker builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -57,6 +57,9 @@ ARG PYTHON_VER=3.10
 # Allows running the docker build from a different directory than MORPHEUS_ROOT. Needed for using Morpheus in a
 # submodule
 ARG MORPHEUS_ROOT_HOST=.
+ARG MORPHEUS_GIT_URL=""
+ARG MORPHEUS_GIT_BRANCH=main
+
 # Supply a channel alias to use for conda. This is needed if the conda channels go down
 ARG CONDA_CHANNEL_ALIAS="https://conda.anaconda.org"
 
@@ -339,11 +342,13 @@ RUN --mount=type=bind,from=conda_bld_morpheus,source=/opt/conda/conda-bld,target
 FROM conda_env_dev as git_clone
 
 ARG MORPHEUS_ROOT_HOST
+ARG MORPHEUS_GIT_URL
+ARG MORPHEUS_GIT_TAG
 
 # Source the morpheus env to pick up the git-lfs package
 RUN --mount=type=bind,source=${MORPHEUS_ROOT_HOST},target=/opt/host_repo \
     source activate morpheus &&\
-    git clone file:///opt/host_repo /tmp/morpheus_repo &&\
+    MORPHEUS_ROOT_HOST="/opt/host_repo" /opt/host_repo/docker/clone_source.sh /tmp/morpheus_repo &&\
     cd /tmp/morpheus_repo &&\
     git lfs install &&\
     /tmp/morpheus_repo/scripts/fetch_data.py fetch datasets examples

--- a/docker/build_container.sh
+++ b/docker/build_container.sh
@@ -41,6 +41,10 @@ PYTHON_VER=${PYTHON_VER:-3.10}
 # Determine the relative path from $PWD to $MORPHEUS_ROOT
 MORPHEUS_ROOT_HOST=${MORPHEUS_ROOT_HOST:-"$(realpath --relative-to=${PWD} ${MORPHEUS_ROOT})"}
 
+# When defined use the git url and tag to clone the source
+MORPHEUS_GIT_URL=${MORPHEUS_GIT_URL:-""}
+MORPHEUS_GIT_TAG=${MORPHEUS_GIT_TAG:-"$(git -C ${MORPHEUS_ROOT} describe --tags --abbrev=0)"}
+
 # Build the docker arguments
 DOCKER_ARGS="-t ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}"
 DOCKER_ARGS="${DOCKER_ARGS} --target ${DOCKER_TARGET}"
@@ -54,6 +58,8 @@ DOCKER_ARGS="${DOCKER_ARGS} --build-arg MORPHEUS_ROOT_HOST=${MORPHEUS_ROOT_HOST}
 DOCKER_ARGS="${DOCKER_ARGS} --build-arg MORPHEUS_SUPPORT_DOCA=${MORPHEUS_SUPPORT_DOCA}"
 DOCKER_ARGS="${DOCKER_ARGS} --build-arg MORPHEUS_BUILD_MORPHEUS_LLM=${MORPHEUS_BUILD_MORPHEUS_LLM}"
 DOCKER_ARGS="${DOCKER_ARGS} --build-arg PYTHON_VER=${PYTHON_VER}"
+DOCKER_ARGS="${DOCKER_ARGS} --build-arg MORPHEUS_GIT_URL=${MORPHEUS_GIT_URL}"
+DOCKER_ARGS="${DOCKER_ARGS} --build-arg MORPHEUS_GIT_TAG=${MORPHEUS_GIT_TAG}"
 DOCKER_ARGS="${DOCKER_ARGS} --network=host"
 
 # Last add any extra args (duplicates override earlier ones)
@@ -70,6 +76,8 @@ echo "   FROM_IMAGE                 : ${FROM_IMAGE}"
 echo "   LINUX_DISTRO               : ${LINUX_DISTRO}"
 echo "   LINUX_VER                  : ${LINUX_VER}"
 echo "   MORPHEUS_ROOT_HOST         : ${MORPHEUS_ROOT_HOST}"
+echo "   MORPHEUS_GIT_URL           : ${MORPHEUS_GIT_URL}"
+echo "   MORPHEUS_GIT_TAG           : ${MORPHEUS_GIT_TAG}"
 echo "   MORPHEUS_SUPPORT_DOCA      : ${MORPHEUS_SUPPORT_DOCA}"
 echo "   MORPHEUS_BUILD_MORPHEUS_LLM: ${MORPHEUS_BUILD_MORPHEUS_LLM}"
 echo "   PYTHON_VER                 : ${PYTHON_VER}"

--- a/docker/clone_source.sh
+++ b/docker/clone_source.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# set -x
+
+GIT_ARGS=()
+
+if [[ -n "${MORPHEUS_GIT_URL}" ]]; then
+    GIT_ARGS+=("--branch" "${MORPHEUS_GIT_TAG}")
+    GIT_ARGS+=("${MORPHEUS_GIT_URL}")
+else
+    GIT_ARGS+=("file://${MORPHEUS_ROOT_HOST}")
+fi
+
+echo "Cloning source from ${GIT_ARGS[@]}"
+git clone --verbose "${GIT_ARGS[@]}" $*


### PR DESCRIPTION
## Description
* Optionally clone from a git url if `MORPHEUS_GIT_URL` & `MORPHEUS_GIT_TAG` are defined, otherwise the host repo is used.
* Fixes issue when morpheus is in a submodule and the parent repo is not accessible to the Docker workspace
* Clone is now performed in a new shell script `docker/clone_source.sh`

Closes [#1870](https://github.com/nv-morpheus/Morpheus/issues/1870)

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
