### PR TITLE
Ensure that `pytest` is able to run without optional dependencies

### DIFF
--- a/python/morpheus_llm/morpheus_llm/error.py
+++ b/python/morpheus_llm/morpheus_llm/error.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+IMPORT_ERROR_MESSAGE = (
+    "{package} not found. Install it and other additional dependencies by running the following command:\n"
+    "`conda env update --solver=libmamba -n morpheus "
+    "--file conda/environments/examples_cuda-121_arch-x86_64.yaml`")

--- a/python/morpheus_llm/morpheus_llm/llm/nodes/langchain_agent_node.py
+++ b/python/morpheus_llm/morpheus_llm/llm/nodes/langchain_agent_node.py
@@ -26,8 +26,8 @@ IMPORT_EXCEPTION = None
 
 try:
     from langchain_core.exceptions import OutputParserException
-except ImportError as e:
-    IMPORT_EXCEPTION = e
+except ImportError as import_exc:
+    IMPORT_EXCEPTION = import_exc
 
 if typing.TYPE_CHECKING:
     from langchain.agents import AgentExecutor

--- a/python/morpheus_llm/morpheus_llm/llm/nodes/langchain_agent_node.py
+++ b/python/morpheus_llm/morpheus_llm/llm/nodes/langchain_agent_node.py
@@ -16,12 +16,18 @@ import asyncio
 import logging
 import typing
 
-from langchain_core.exceptions import OutputParserException
-
+from morpheus_llm.error import IMPORT_ERROR_MESSAGE
 from morpheus_llm.llm import LLMContext
 from morpheus_llm.llm import LLMNodeBase
 
 logger = logging.getLogger(__name__)
+
+IMPORT_EXCEPTION = None
+
+try:
+    from langchain_core.exceptions import OutputParserException
+except ImportError as e:
+    IMPORT_EXCEPTION = e
 
 if typing.TYPE_CHECKING:
     from langchain.agents import AgentExecutor
@@ -47,6 +53,9 @@ class LangChainAgentNode(LLMNodeBase):
                  agent_executor: "AgentExecutor",
                  replace_exceptions: bool = False,
                  replace_exceptions_value: typing.Optional[str] = None):
+        if IMPORT_EXCEPTION is not None:
+            raise ImportError(IMPORT_ERROR_MESSAGE.format('langchain_core')) from IMPORT_EXCEPTION
+
         super().__init__()
 
         self._agent_executor = agent_executor

--- a/python/morpheus_llm/morpheus_llm/llm/services/nemo_llm_service.py
+++ b/python/morpheus_llm/morpheus_llm/llm/services/nemo_llm_service.py
@@ -228,7 +228,7 @@ class NeMoLLMService(LLMService):
         """
 
         if IMPORT_EXCEPTION is not None:
-            raise ImportError(IMPORT_ERROR_MESSAGE) from IMPORT_EXCEPTION
+            raise ImportError(IMPORT_ERROR_MESSAGE.format(package='nemollm')) from IMPORT_EXCEPTION
 
         super().__init__()
 

--- a/python/morpheus_llm/morpheus_llm/llm/services/nemo_llm_service.py
+++ b/python/morpheus_llm/morpheus_llm/llm/services/nemo_llm_service.py
@@ -18,16 +18,13 @@ import typing
 import warnings
 
 from morpheus.utils.env_config_value import EnvConfigValue
+from morpheus_llm.error import IMPORT_ERROR_MESSAGE
 from morpheus_llm.llm.services.llm_service import LLMClient
 from morpheus_llm.llm.services.llm_service import LLMService
 
 logger = logging.getLogger(__name__)
 
 IMPORT_EXCEPTION = None
-IMPORT_ERROR_MESSAGE = (
-    "NemoLLM not found. Install it and other additional dependencies by running the following command:\n"
-    "`conda env update --solver=libmamba -n morpheus "
-    "--file conda/environments/examples_cuda-121_arch-x86_64.yaml --prune`")
 
 try:
     import nemollm
@@ -53,7 +50,7 @@ class NeMoLLMClient(LLMClient):
 
     def __init__(self, parent: "NeMoLLMService", *, model_name: str, **model_kwargs) -> None:
         if IMPORT_EXCEPTION is not None:
-            raise ImportError(IMPORT_ERROR_MESSAGE) from IMPORT_EXCEPTION
+            raise ImportError(IMPORT_ERROR_MESSAGE.format(package='nemollm')) from IMPORT_EXCEPTION
 
         super().__init__()
 

--- a/python/morpheus_llm/morpheus_llm/llm/services/nvfoundation_llm_service.py
+++ b/python/morpheus_llm/morpheus_llm/llm/services/nvfoundation_llm_service.py
@@ -16,17 +16,13 @@ import logging
 import typing
 
 from morpheus.utils.env_config_value import EnvConfigValue
+from morpheus_llm.error import IMPORT_ERROR_MESSAGE
 from morpheus_llm.llm.services.llm_service import LLMClient
 from morpheus_llm.llm.services.llm_service import LLMService
 
 logger = logging.getLogger(__name__)
 
 IMPORT_EXCEPTION = None
-IMPORT_ERROR_MESSAGE = (
-    "The `langchain-nvidia-ai-endpoints` package was not found. Install it and other additional dependencies by "
-    "running the following command:"
-    "`conda env update --solver=libmamba -n morpheus "
-    "--file conda/environments/examples_cuda-121_arch-x86_64.yaml`")
 
 try:
     from langchain_core.prompt_values import StringPromptValue
@@ -52,7 +48,8 @@ class NVFoundationLLMClient(LLMClient):
 
     def __init__(self, parent: "NVFoundationLLMService", *, model_name: str, **model_kwargs) -> None:
         if IMPORT_EXCEPTION is not None:
-            raise ImportError(IMPORT_ERROR_MESSAGE) from IMPORT_EXCEPTION
+            raise ImportError(
+                IMPORT_ERROR_MESSAGE.format(package='langchain-nvidia-ai-endpoints')) from IMPORT_EXCEPTION
 
         super().__init__()
 
@@ -218,7 +215,8 @@ class NVFoundationLLMService(LLMService):
 
     def __init__(self, *, api_key: APIKey | str = None, base_url: BaseURL | str = None, **model_kwargs) -> None:
         if IMPORT_EXCEPTION is not None:
-            raise ImportError(IMPORT_ERROR_MESSAGE) from IMPORT_EXCEPTION
+            raise ImportError(
+                IMPORT_ERROR_MESSAGE.format(package='langchain-nvidia-ai-endpoints')) from IMPORT_EXCEPTION
 
         super().__init__()
 

--- a/python/morpheus_llm/morpheus_llm/llm/services/openai_chat_service.py
+++ b/python/morpheus_llm/morpheus_llm/llm/services/openai_chat_service.py
@@ -23,16 +23,13 @@ from textwrap import dedent
 import appdirs
 
 from morpheus.utils.env_config_value import EnvConfigValue
+from morpheus_llm.error import IMPORT_ERROR_MESSAGE
 from morpheus_llm.llm.services.llm_service import LLMClient
 from morpheus_llm.llm.services.llm_service import LLMService
 
 logger = logging.getLogger(__name__)
 
 IMPORT_EXCEPTION = None
-IMPORT_ERROR_MESSAGE = ("OpenAIChatService & OpenAIChatClient require the openai package to be installed. "
-                        "Install it by running the following command:\n"
-                        "`conda env update --solver=libmamba -n morpheus "
-                        "--file conda/environments/examples_cuda-121_arch-x86_64.yaml --prune`")
 
 try:
     import openai
@@ -107,7 +104,7 @@ class OpenAIChatClient(LLMClient):
                  json=False,
                  **model_kwargs) -> None:
         if IMPORT_EXCEPTION is not None:
-            raise ImportError(IMPORT_ERROR_MESSAGE) from IMPORT_EXCEPTION
+            raise ImportError(IMPORT_ERROR_MESSAGE.format(package='openai')) from IMPORT_EXCEPTION
 
         super().__init__()
 
@@ -400,7 +397,7 @@ class OpenAIChatService(LLMService):
                  default_model_kwargs: dict = None) -> None:
 
         if IMPORT_EXCEPTION is not None:
-            raise ImportError(IMPORT_ERROR_MESSAGE) from IMPORT_EXCEPTION
+            raise ImportError(IMPORT_ERROR_MESSAGE.format(package='openai')) from IMPORT_EXCEPTION
 
         super().__init__()
 

--- a/python/morpheus_llm/morpheus_llm/service/vdb/faiss_vdb_service.py
+++ b/python/morpheus_llm/morpheus_llm/service/vdb/faiss_vdb_service.py
@@ -21,6 +21,7 @@ import pandas as pd
 
 import cudf
 
+from morpheus_llm.error import IMPORT_ERROR_MESSAGE
 from morpheus_llm.service.vdb.vector_db_service import VectorDBResourceService
 from morpheus_llm.service.vdb.vector_db_service import VectorDBService
 

--- a/python/morpheus_llm/morpheus_llm/service/vdb/faiss_vdb_service.py
+++ b/python/morpheus_llm/morpheus_llm/service/vdb/faiss_vdb_service.py
@@ -27,7 +27,6 @@ from morpheus_llm.service.vdb.vector_db_service import VectorDBService
 logger = logging.getLogger(__name__)
 
 IMPORT_EXCEPTION = None
-IMPORT_ERROR_MESSAGE = "FaissDBResourceService requires the FAISS library to be installed."
 
 try:
     from langchain.embeddings.base import Embeddings
@@ -50,7 +49,7 @@ class FaissVectorDBResourceService(VectorDBResourceService):
 
     def __init__(self, parent: "FaissVectorDBService", *, name: str) -> None:
         if IMPORT_EXCEPTION is not None:
-            raise ImportError(IMPORT_ERROR_MESSAGE) from IMPORT_EXCEPTION
+            raise ImportError(IMPORT_ERROR_MESSAGE.format(package='langchain and faiss-gpu')) from IMPORT_EXCEPTION
 
         super().__init__()
 
@@ -285,7 +284,7 @@ class FaissVectorDBService(VectorDBService):
     def __init__(self, local_dir: str, embeddings: "Embeddings"):
 
         if IMPORT_EXCEPTION is not None:
-            raise ImportError(IMPORT_ERROR_MESSAGE) from IMPORT_EXCEPTION
+            raise ImportError(IMPORT_ERROR_MESSAGE.format(package='langchain and faiss-gpu')) from IMPORT_EXCEPTION
 
         self._local_dir = local_dir
         self._embeddings = embeddings

--- a/python/morpheus_llm/morpheus_llm/service/vdb/milvus_vector_db_service.py
+++ b/python/morpheus_llm/morpheus_llm/service/vdb/milvus_vector_db_service.py
@@ -25,13 +25,13 @@ import cudf
 from morpheus.io.utils import cudf_string_cols_exceed_max_bytes
 from morpheus.io.utils import truncate_string_cols_by_bytes
 from morpheus.utils.type_aliases import DataFrameType
+from morpheus_llm.error import IMPORT_ERROR_MESSAGE
 from morpheus_llm.service.vdb.vector_db_service import VectorDBResourceService
 from morpheus_llm.service.vdb.vector_db_service import VectorDBService
 
 logger = logging.getLogger(__name__)
 
 IMPORT_EXCEPTION = None
-IMPORT_ERROR_MESSAGE = "MilvusVectorDBResourceService requires the milvus and pymilvus packages to be installed."
 
 # Milvus has a max string length in bytes of 65,535. Multi-byte characters like "ñ" will have a string length of 1, the
 # byte length encoded as UTF-8 will be 2
@@ -234,7 +234,7 @@ class MilvusVectorDBResourceService(VectorDBResourceService):
 
     def __init__(self, name: str, client: "MilvusClient", truncate_long_strings: bool = False) -> None:
         if IMPORT_EXCEPTION is not None:
-            raise ImportError(IMPORT_ERROR_MESSAGE) from IMPORT_EXCEPTION
+            raise ImportError(IMPORT_ERROR_MESSAGE.format(package='pymilvus')) from IMPORT_EXCEPTION
 
         super().__init__()
 

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -20,8 +20,13 @@ import typing
 from unittest import mock
 
 import pytest
-from pynvml.smi import NVSMI_QUERY_GPU
-from pynvml.smi import nvidia_smi
+
+try:
+    from pynvml.smi import NVSMI_QUERY_GPU
+    from pynvml.smi import nvidia_smi
+except ImportError:
+    print("pynvml is not installed")
+
 from test_bench_e2e_pipelines import E2E_TEST_CONFIGS
 
 

--- a/tests/benchmarks/test_bench_agents_simple_pipeline.py
+++ b/tests/benchmarks/test_bench_agents_simple_pipeline.py
@@ -19,13 +19,17 @@ import os
 import typing
 from unittest import mock
 
-import langchain
 import pytest
-from langchain.agents import AgentType
-from langchain.agents import initialize_agent
-from langchain.agents import load_tools
-from langchain.agents.tools import Tool
-from langchain.utilities import serpapi
+
+try:
+    import langchain
+    from langchain.agents import AgentType
+    from langchain.agents import initialize_agent
+    from langchain.agents import load_tools
+    from langchain.agents.tools import Tool
+    from langchain.utilities import serpapi
+except ImportError:
+    print("langchain is not installed")
 
 import cudf
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,10 @@ if PYTEST_KAFKA_AVAIL:
     from _utils.kafka import kafka_server  # noqa: F401  pylint:disable=unused-import
     from _utils.kafka import zookeeper_proc  # noqa: F401  pylint:disable=unused-import
 
+OPT_DEP_SKIP_REASON = (
+    "This test requires the {package} package to be installed, to install this run:\n"
+    "`conda env update --solver=libmamba -n morpheus --file conda/environments/examples_cuda-121_arch-x86_64.yaml`")
+
 
 def pytest_addoption(parser: pytest.Parser):
     """
@@ -1064,22 +1068,7 @@ def nemollm_fixture(fail_missing: bool):
     """
     Fixture to ensure nemollm is installed
     """
-    skip_reason = ("Tests for the NeMoLLMService require the nemollm package to be installed, to install this run:\n"
-                   "`conda env update --solver=libmamba -n morpheus "
-                   "--file conda/environments/all_cuda-121_arch-x86_64.yaml --prune`")
-    yield import_or_skip("nemollm", reason=skip_reason, fail_missing=fail_missing)
-
-
-@pytest.fixture(name="nvfoundationllm", scope='session')
-def nvfoundationllm_fixture(fail_missing: bool):
-    """
-    Fixture to ensure nvfoundationllm is installed
-    """
-    skip_reason = (
-        "Tests for NVFoundation require the langchain-nvidia-ai-endpoints package to be installed, to install this "
-        "run:\n `conda env update --solver=libmamba -n morpheus "
-        "--file conda/environments/all_cuda-121_arch-x86_64.yaml --prune`")
-    yield import_or_skip("langchain_nvidia_ai_endpoints", reason=skip_reason, fail_missing=fail_missing)
+    yield import_or_skip("nemollm", reason=OPT_DEP_SKIP_REASON.format(package="nemollm"), fail_missing=fail_missing)
 
 
 @pytest.fixture(name="openai", scope='session')
@@ -1087,10 +1076,45 @@ def openai_fixture(fail_missing: bool):
     """
     Fixture to ensure openai is installed
     """
-    skip_reason = ("Tests for the OpenAIChatService require the openai package to be installed, to install this run:\n"
-                   "`conda env update --solver=libmamba -n morpheus "
-                   "--file conda/environments/all_cuda-121_arch-x86_64.yaml --prune`")
-    yield import_or_skip("openai", reason=skip_reason, fail_missing=fail_missing)
+    yield import_or_skip("openai", reason=OPT_DEP_SKIP_REASON.format(package="openai"), fail_missing=fail_missing)
+
+
+@pytest.fixture(name="langchain", scope='session')
+def langchain_fixture(fail_missing: bool):
+    """
+    Fixture to ensure langchain is installed
+    """
+    yield import_or_skip("langchain", reason=OPT_DEP_SKIP_REASON.format(package="langchain"), fail_missing=fail_missing)
+
+
+@pytest.fixture(name="langchain_core", scope='session')
+def langchain_core_fixture(fail_missing: bool):
+    """
+    Fixture to ensure langchain_core is installed
+    """
+    yield import_or_skip("langchain_core",
+                         reason=OPT_DEP_SKIP_REASON.format(package="langchain_core"),
+                         fail_missing=fail_missing)
+
+
+@pytest.fixture(name="langchain_community", scope='session')
+def langchain_community_fixture(fail_missing: bool):
+    """
+    Fixture to ensure langchain_community is installed
+    """
+    yield import_or_skip("langchain_community",
+                         reason=OPT_DEP_SKIP_REASON.format(package="langchain_community"),
+                         fail_missing=fail_missing)
+
+
+@pytest.fixture(name="langchain_nvidia_ai_endpoints", scope='session')
+def langchain_nvidia_ai_endpoints_fixture(fail_missing: bool):
+    """
+    Fixture to ensure langchain_nvidia_ai_endpoints is installed
+    """
+    yield import_or_skip("langchain_nvidia_ai_endpoints",
+                         reason=OPT_DEP_SKIP_REASON.format(package="langchain_nvidia_ai_endpoints"),
+                         fail_missing=fail_missing)
 
 
 @pytest.mark.usefixtures("openai")

--- a/tests/llm/conftest.py
+++ b/tests/llm/conftest.py
@@ -13,11 +13,60 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import types
 from unittest import mock
 
 import pytest
 
 from _utils import require_env_variable
+
+
+@pytest.fixture(name="nemollm", scope='session', autouse=True)
+def nemollm_fixture(nemollm: types.ModuleType, fail_missing: bool):
+    """
+    Fixture to ensure nemollm is installed
+    """
+    yield nemollm
+
+
+@pytest.fixture(name="openai", scope='session', autouse=True)
+def openai_fixture(openai: types.ModuleType, fail_missing: bool):
+    """
+    Fixture to ensure openai is installed
+    """
+    yield openai
+
+
+@pytest.fixture(name="langchain", scope='session', autouse=True)
+def langchain_fixture(langchain: types.ModuleType, fail_missing: bool):
+    """
+    Fixture to ensure langchain is installed
+    """
+    yield langchain
+
+
+@pytest.fixture(name="langchain_core", scope='session', autouse=True)
+def langchain_core_fixture(langchain_core: types.ModuleType, fail_missing: bool):
+    """
+    Fixture to ensure langchain_core is installed
+    """
+    yield langchain_core
+
+
+@pytest.fixture(name="langchain_community", scope='session', autouse=True)
+def langchain_community_fixture(langchain_community: types.ModuleType, fail_missing: bool):
+    """
+    Fixture to ensure langchain_community is installed
+    """
+    yield langchain_community
+
+
+@pytest.fixture(name="langchain_nvidia_ai_endpoints", scope='session', autouse=True)
+def langchain_nvidia_ai_endpoints_fixture(langchain_nvidia_ai_endpoints: types.ModuleType, fail_missing: bool):
+    """
+    Fixture to ensure langchain_nvidia_ai_endpoints is installed
+    """
+    yield langchain_nvidia_ai_endpoints
 
 
 @pytest.fixture(name="countries")

--- a/tests/llm/conftest.py
+++ b/tests/llm/conftest.py
@@ -22,7 +22,7 @@ from _utils import require_env_variable
 
 
 @pytest.fixture(name="nemollm", scope='session', autouse=True)
-def nemollm_fixture(nemollm: types.ModuleType, fail_missing: bool):
+def nemollm_fixture(nemollm: types.ModuleType):
     """
     Fixture to ensure nemollm is installed
     """
@@ -30,7 +30,7 @@ def nemollm_fixture(nemollm: types.ModuleType, fail_missing: bool):
 
 
 @pytest.fixture(name="openai", scope='session', autouse=True)
-def openai_fixture(openai: types.ModuleType, fail_missing: bool):
+def openai_fixture(openai: types.ModuleType):
     """
     Fixture to ensure openai is installed
     """
@@ -38,7 +38,7 @@ def openai_fixture(openai: types.ModuleType, fail_missing: bool):
 
 
 @pytest.fixture(name="langchain", scope='session', autouse=True)
-def langchain_fixture(langchain: types.ModuleType, fail_missing: bool):
+def langchain_fixture(langchain: types.ModuleType):
     """
     Fixture to ensure langchain is installed
     """
@@ -46,7 +46,7 @@ def langchain_fixture(langchain: types.ModuleType, fail_missing: bool):
 
 
 @pytest.fixture(name="langchain_core", scope='session', autouse=True)
-def langchain_core_fixture(langchain_core: types.ModuleType, fail_missing: bool):
+def langchain_core_fixture(langchain_core: types.ModuleType):
     """
     Fixture to ensure langchain_core is installed
     """
@@ -54,7 +54,7 @@ def langchain_core_fixture(langchain_core: types.ModuleType, fail_missing: bool)
 
 
 @pytest.fixture(name="langchain_community", scope='session', autouse=True)
-def langchain_community_fixture(langchain_community: types.ModuleType, fail_missing: bool):
+def langchain_community_fixture(langchain_community: types.ModuleType):
     """
     Fixture to ensure langchain_community is installed
     """
@@ -62,7 +62,7 @@ def langchain_community_fixture(langchain_community: types.ModuleType, fail_miss
 
 
 @pytest.fixture(name="langchain_nvidia_ai_endpoints", scope='session', autouse=True)
-def langchain_nvidia_ai_endpoints_fixture(langchain_nvidia_ai_endpoints: types.ModuleType, fail_missing: bool):
+def langchain_nvidia_ai_endpoints_fixture(langchain_nvidia_ai_endpoints: types.ModuleType):
     """
     Fixture to ensure langchain_nvidia_ai_endpoints is installed
     """

--- a/tests/llm/nodes/test_langchain_agent_node.py
+++ b/tests/llm/nodes/test_langchain_agent_node.py
@@ -30,8 +30,6 @@ try:
     from langchain.agents import AgentType
     from langchain.agents import Tool
     from langchain.agents import initialize_agent
-    from langchain.callbacks.manager import AsyncCallbackManagerForToolRun
-    from langchain.callbacks.manager import CallbackManagerForToolRun
     from langchain_community.chat_models.openai import ChatOpenAI
     from langchain_core.tools import BaseTool
 except ImportError:

--- a/tests/llm/nodes/test_langchain_agent_node.py
+++ b/tests/llm/nodes/test_langchain_agent_node.py
@@ -33,6 +33,7 @@ try:
     from langchain.callbacks.manager import AsyncCallbackManagerForToolRun
     from langchain.callbacks.manager import CallbackManagerForToolRun
     from langchain_community.chat_models.openai import ChatOpenAI
+    from langchain_core.tools import BaseTool
 except ImportError:
     pass
 

--- a/tests/llm/nodes/test_langchain_agent_node.py
+++ b/tests/llm/nodes/test_langchain_agent_node.py
@@ -26,6 +26,16 @@ from _utils.llm import mk_mock_openai_response
 from morpheus_llm.llm import LLMNodeBase
 from morpheus_llm.llm.nodes.langchain_agent_node import LangChainAgentNode
 
+try:
+    from langchain.agents import AgentType
+    from langchain.agents import Tool
+    from langchain.agents import initialize_agent
+    from langchain.callbacks.manager import AsyncCallbackManagerForToolRun
+    from langchain.callbacks.manager import CallbackManagerForToolRun
+    from langchain_community.chat_models.openai import ChatOpenAI
+except ImportError:
+    pass
+
 if typing.TYPE_CHECKING:
     from langchain.callbacks.manager import AsyncCallbackManagerForToolRun
     from langchain.callbacks.manager import CallbackManagerForToolRun
@@ -81,11 +91,6 @@ def test_execute(
 
 
 def test_execute_tools(mock_chat_completion: tuple[mock.MagicMock, mock.MagicMock]):
-    from langchain.agents import AgentType
-    from langchain.agents import Tool
-    from langchain.agents import initialize_agent
-    from langchain_community.chat_models.openai import ChatOpenAI
-
     # Tests the execute method of the LangChainAgentNode with a a mocked tools and chat completion
     (_, mock_async_client) = mock_chat_completion
     chat_responses = [
@@ -128,11 +133,6 @@ def test_execute_tools(mock_chat_completion: tuple[mock.MagicMock, mock.MagicMoc
 
 
 def test_execute_error(mock_chat_completion: tuple[mock.MagicMock, mock.MagicMock]):
-    from langchain.agents import AgentType
-    from langchain.agents import Tool
-    from langchain.agents import initialize_agent
-    from langchain_community.chat_models.openai import ChatOpenAI
-
     # Tests the execute method of the LangChainAgentNode with a a mocked tools and chat completion
     (_, mock_async_client) = mock_chat_completion
     chat_responses = [
@@ -181,10 +181,6 @@ def test_execute_error(mock_chat_completion: tuple[mock.MagicMock, mock.MagicMoc
                          }],
                          ids=["single-metadata", "single-metadata-list", "multiple-metadata-list"])
 def test_metadata(mock_chat_completion: tuple[mock.MagicMock, mock.MagicMock], metadata: dict):
-    from langchain.agents import AgentType
-    from langchain.agents import initialize_agent
-    from langchain_community.chat_models.openai import ChatOpenAI
-    from langchain_core.tools import BaseTool
 
     class MetadataSaverTool(BaseTool):
         # The base class defines *args and **kwargs in the signature for _run and _arun requiring the arguments-differ

--- a/tests/llm/nodes/test_langchain_agent_node.py
+++ b/tests/llm/nodes/test_langchain_agent_node.py
@@ -30,14 +30,12 @@ try:
     from langchain.agents import AgentType
     from langchain.agents import Tool
     from langchain.agents import initialize_agent
+    from langchain.callbacks.manager import AsyncCallbackManagerForToolRun
+    from langchain.callbacks.manager import CallbackManagerForToolRun
     from langchain_community.chat_models.openai import ChatOpenAI
     from langchain_core.tools import BaseTool
 except ImportError:
     pass
-
-if typing.TYPE_CHECKING:
-    from langchain.callbacks.manager import AsyncCallbackManagerForToolRun
-    from langchain.callbacks.manager import CallbackManagerForToolRun
 
 
 class OutputParserExceptionStandin(Exception):
@@ -192,14 +190,14 @@ def test_metadata(mock_chat_completion: tuple[mock.MagicMock, mock.MagicMock], m
         def _run(
             self,
             query: str,
-            run_manager: typing.Optional["CallbackManagerForToolRun"] = None,
+            run_manager: typing.Optional[CallbackManagerForToolRun] = None,
         ) -> str:
             raise NotImplementedError("This tool only supports async")
 
         async def _arun(
             self,
             query: str,
-            run_manager: typing.Optional["AsyncCallbackManagerForToolRun"] = None,
+            run_manager: typing.Optional[AsyncCallbackManagerForToolRun] = None,
         ) -> str:
             assert query is not None  # avoiding unused-argument
             assert run_manager is not None

--- a/tests/llm/services/conftest.py
+++ b/tests/llm/services/conftest.py
@@ -36,12 +36,12 @@ def openai_fixture(openai):
     yield openai
 
 
-@pytest.fixture(name="nvfoundationllm", autouse=True, scope='session')
-def nvfoundationllm_fixture(nvfoundationllm):
+@pytest.fixture(name="langchain_nvidia_ai_endpoints", autouse=True, scope='session')
+def langchain_nvidia_ai_endpoints_fixture(langchain_nvidia_ai_endpoints):
     """
-    All of the tests in this subdir require nvfoundationllm
+    All of the tests in this subdir require langchain_nvidia_ai_endpoints
     """
-    yield nvfoundationllm
+    yield langchain_nvidia_ai_endpoints
 
 
 @pytest.fixture(name="mock_chat_completion", autouse=True)

--- a/tests/llm/services/test_nvfoundation_llm_service.py
+++ b/tests/llm/services/test_nvfoundation_llm_service.py
@@ -17,12 +17,16 @@ import os
 from unittest import mock
 
 import pytest
-from langchain_core.messages import ChatMessage
-from langchain_core.outputs import ChatGeneration
-from langchain_core.outputs import LLMResult
 
 from morpheus_llm.llm.services.nvfoundation_llm_service import NVFoundationLLMClient
 from morpheus_llm.llm.services.nvfoundation_llm_service import NVFoundationLLMService
+
+try:
+    from langchain_core.messages import ChatMessage
+    from langchain_core.outputs import ChatGeneration
+    from langchain_core.outputs import LLMResult
+except ImportError:
+    pass
 
 
 @pytest.fixture(name="set_default_nvidia_api_key", autouse=True, scope="function")
@@ -34,7 +38,7 @@ def set_default_nvidia_api_key_fixture():
 
 @pytest.mark.parametrize("api_key", ["nvapi-12345", None])
 @pytest.mark.parametrize("base_url", ["http://test.nvidia.com/v1", None])
-def test_constructor(api_key: str, base_url: bool):
+def test_constructor(api_key: str | None, base_url: bool | None):
 
     service = NVFoundationLLMService(api_key=api_key, base_url=base_url)
 

--- a/tests/llm/test_agents_simple_pipe.py
+++ b/tests/llm/test_agents_simple_pipe.py
@@ -18,12 +18,6 @@ import re
 from unittest import mock
 
 import pytest
-from langchain.agents import AgentType
-from langchain.agents import initialize_agent
-from langchain.agents import load_tools
-from langchain.agents.tools import Tool
-from langchain_community.llms import OpenAI  # pylint: disable=no-name-in-module
-from langchain_community.utilities import serpapi
 
 import cudf
 
@@ -48,6 +42,12 @@ def questions_fixture():
 
 
 def _build_agent_executor(model_name: str):
+    from langchain.agents import AgentType
+    from langchain.agents import initialize_agent
+    from langchain.agents import load_tools
+    from langchain.agents.tools import Tool
+    from langchain_community.llms import OpenAI  # pylint: disable=no-name-in-module
+    from langchain_community.utilities import serpapi
 
     llm = OpenAI(model=model_name, temperature=0, cache=False)
 
@@ -134,6 +134,7 @@ def test_agents_simple_pipe(mock_openai_agenerate: mock.AsyncMock,
 
     from langchain.schema import Generation
     from langchain.schema import LLMResult
+    from langchain_community.utilities import serpapi
 
     assert serpapi.SerpAPIWrapper().aresults is mock_serpapi_aresults
 

--- a/tests/llm/test_agents_simple_pipe.py
+++ b/tests/llm/test_agents_simple_pipe.py
@@ -35,6 +35,16 @@ from morpheus_llm.llm.nodes.langchain_agent_node import LangChainAgentNode
 from morpheus_llm.llm.task_handlers.simple_task_handler import SimpleTaskHandler
 from morpheus_llm.stages.llm.llm_engine_stage import LLMEngineStage
 
+try:
+    from langchain.agents import AgentType
+    from langchain.agents import initialize_agent
+    from langchain.agents import load_tools
+    from langchain.agents.tools import Tool
+    from langchain_community.llms import OpenAI  # pylint: disable=no-name-in-module
+    from langchain_community.utilities import serpapi
+except ImportError:
+    pass
+
 
 @pytest.fixture(name="questions")
 def questions_fixture():
@@ -42,13 +52,6 @@ def questions_fixture():
 
 
 def _build_agent_executor(model_name: str):
-    from langchain.agents import AgentType
-    from langchain.agents import initialize_agent
-    from langchain.agents import load_tools
-    from langchain.agents.tools import Tool
-    from langchain_community.llms import OpenAI  # pylint: disable=no-name-in-module
-    from langchain_community.utilities import serpapi
-
     llm = OpenAI(model=model_name, temperature=0, cache=False)
 
     # Explicitly construct the serpapi tool, loading it via load_tools makes it too difficult to mock
@@ -131,10 +134,6 @@ def test_agents_simple_pipe(mock_openai_agenerate: mock.AsyncMock,
                             config: Config,
                             questions: list[str]):
     os.environ.update({'OPENAI_API_KEY': 'test_api_key', 'SERPAPI_API_KEY': 'test_api_key'})
-
-    from langchain.schema import Generation
-    from langchain.schema import LLMResult
-    from langchain_community.utilities import serpapi
 
     assert serpapi.SerpAPIWrapper().aresults is mock_serpapi_aresults
 

--- a/tests/llm/test_agents_simple_pipe.py
+++ b/tests/llm/test_agents_simple_pipe.py
@@ -40,6 +40,8 @@ try:
     from langchain.agents import initialize_agent
     from langchain.agents import load_tools
     from langchain.agents.tools import Tool
+    from langchain.schema import Generation
+    from langchain.schema import LLMResult
     from langchain_community.llms import OpenAI  # pylint: disable=no-name-in-module
     from langchain_community.utilities import serpapi
 except ImportError:

--- a/tests/utils/test_shared_process_pool.py
+++ b/tests/utils/test_shared_process_pool.py
@@ -93,6 +93,7 @@ def test_singleton():
     assert pool_1 is pool_2
 
 
+@pytest.mark.slow
 def test_pool_status(shared_process_pool):
 
     pool = shared_process_pool
@@ -125,6 +126,7 @@ def test_pool_status(shared_process_pool):
     assert not pool._task_queues
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "a, b, expected",
     [
@@ -157,6 +159,7 @@ def test_submit_single_task(shared_process_pool, a, b, expected):
         pool.submit_task("test_stage", _add_task, 10, 20)
 
 
+@pytest.mark.slow
 def test_submit_task_with_invalid_stage(shared_process_pool):
 
     pool = shared_process_pool
@@ -165,6 +168,7 @@ def test_submit_task_with_invalid_stage(shared_process_pool):
         pool.submit_task("stage_does_not_exist", _add_task, 10, 20)
 
 
+@pytest.mark.slow
 def test_submit_task_raises_exception(shared_process_pool):
 
     pool = shared_process_pool
@@ -175,6 +179,7 @@ def test_submit_task_raises_exception(shared_process_pool):
         task.result()
 
 
+@pytest.mark.slow
 def test_submit_task_with_unserializable_result(shared_process_pool):
 
     pool = shared_process_pool
@@ -185,6 +190,7 @@ def test_submit_task_with_unserializable_result(shared_process_pool):
         task.result()
 
 
+@pytest.mark.slow
 def test_submit_task_with_unserializable_arg(shared_process_pool):
 
     pool = shared_process_pool
@@ -195,6 +201,7 @@ def test_submit_task_with_unserializable_arg(shared_process_pool):
         pool.submit_task("test_stage", _arbitrary_function, threading.Lock())
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "a, b, expected",
     [
@@ -220,6 +227,7 @@ def test_submit_multiple_tasks(shared_process_pool, a, b, expected):
         assert future.result() == expected
 
 
+@pytest.mark.slow
 def test_set_usage(shared_process_pool):
 
     pool = shared_process_pool
@@ -256,6 +264,7 @@ def test_set_usage(shared_process_pool):
     assert pool._total_usage == 0.9
 
 
+@pytest.mark.slow
 def test_task_completion_with_early_stop(shared_process_pool):
 
     pool = shared_process_pool
@@ -292,6 +301,7 @@ def test_task_completion_with_early_stop(shared_process_pool):
         assert task.done()
 
 
+@pytest.mark.slow
 def test_terminate_running_tasks(shared_process_pool):
 
     pool = shared_process_pool


### PR DESCRIPTION
## Description
* Ensure it is possible to run `pytest --run_slow` with only the dev yaml installed.
* Mark the tests in `tests/utils/test_shared_process_pool.py` as slow tests
* Remove redundant import error messages.

Closes [#1920](https://github.com/nv-morpheus/Morpheus/issues/1920)

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
