### PR TITLE
Remove `SharedProcessPool.terminate()` related tests to avoid stack traces and blocking remote-ci

### DIFF
--- a/tests/utils/test_shared_process_pool.py
+++ b/tests/utils/test_shared_process_pool.py
@@ -111,7 +111,7 @@ def test_pool_status(shared_process_pool):
     assert pool._total_usage == 0.5
     _check_pool_stage_settings(pool, "test_stage", 0.5)
 
-    pool.terminate()
+    pool.stop()
     pool.join()
     assert pool.status == PoolStatus.SHUTDOWN
 


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
This PR removes `SharedProcessPool.terminate()` related tests, which is generating stack traces that might cause remote-ci failure
Closes #1926 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
