### PR TITLE
Set lower CPU usage for `test_shared_process_pool.py` to avoid slowing down the test

### DIFF
--- a/tests/utils/test_shared_process_pool.py
+++ b/tests/utils/test_shared_process_pool.py
@@ -15,6 +15,7 @@
 
 import logging
 import multiprocessing as mp
+import os
 import threading
 from decimal import Decimal
 from fractions import Fraction
@@ -31,6 +32,8 @@ logger = logging.getLogger(__name__)
 
 @pytest.fixture(scope="session", autouse=True)
 def setup_and_teardown():
+    # Set lower CPU usage for unit test to avoid slowing down the test
+    os.environ["MORPHEUS_SHARED_PROCESS_POOL_CPU_USAGE"] = "0.1"
 
     pool = SharedProcessPool()
 
@@ -43,6 +46,7 @@ def setup_and_teardown():
     # Stop the pool after all tests are done
     pool.stop()
     pool.join()
+    os.environ.pop("MORPHEUS_SHARED_PROCESS_POOL_CPU_USAGE", None)
 
 
 @pytest.fixture(name="shared_process_pool")


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
`test_shared_process_pool.py` is taking longer than expected when running on remote-ci, causing multiple ci pipelines failed due to (1h) timeout. 
This is probably because:
- The number of workers of `SharedProcessPool` is set to `0.5 * os.sched_getaffinity(0)` by default. If the test is running on a machine that has 64 cores, it will maintain 32 sub-processes.
- For each unit test, the process pool need to create all the sub-processes and then `join()` all of them when tear down, which might be slow when the number of processes is large.
- Running the test in remote-ci is slower than running locally, probably because there are multiple ci jobs running on the same machine

The test should run faster by setting the number of workers to `0.1 * os.sched_getaffinity(0)` and it should avoid ci from being blocked by timeout.

Closes  #1936 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
