### PR TITLE
Avoid using cudf_helpers.pyx to copy a cuDF DataFrame

### DIFF
--- a/python/morpheus/morpheus/_lib/src/utilities/cudf_util.cpp
+++ b/python/morpheus/morpheus/_lib/src/utilities/cudf_util.cpp
@@ -71,16 +71,13 @@ pybind11::object CudfHelper::table_from_table_with_metadata(cudf::io::table_with
 
 pybind11::object CudfHelper::table_from_table_info(const TableInfoBase& table_info)
 {
-    // Get the table info data from the table_into
-    auto table_info_data = table_info.get_data();
-
     auto py_object_parent = table_info.get_parent()->get_py_object();
 
     // Need to guarantee that we have the gil here
     pybind11::gil_scoped_acquire gil;
+    using namespace pybind11::literals;
 
-    return pybind11::reinterpret_steal<pybind11::object>(
-        (PyObject*)make_table_from_table_info_data(std::move(table_info_data), py_object_parent.ptr()));
+    return py_object_parent.attr("copy")("deep"_a = true);
 }
 
 TableInfoData CudfHelper::table_info_data_from_table(pybind11::object table)


### PR DESCRIPTION
## Description
* Avoid calling `make_table_from_table_info_data` to perform a copy of a cuDF, we're already holding the gil, so just call the `DataFrame.copy` method instead.

Closes #1934

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
