### PR TITLE
Revert the relative path change used in examples

### DIFF
--- a/examples/gnn_fraud_detection_pipeline/run.py
+++ b/examples/gnn_fraud_detection_pipeline/run.py
@@ -16,6 +16,10 @@ import logging
 import os
 
 import click
+# pylint: disable=no-name-in-module
+from stages.classification_stage import ClassificationStage
+from stages.graph_construction_stage import FraudGraphConstructionStage
+from stages.graph_sage_stage import GraphSAGEStage
 
 from morpheus.config import Config
 from morpheus.config import PipelineModes
@@ -26,11 +30,6 @@ from morpheus.stages.output.write_to_file_stage import WriteToFileStage
 from morpheus.stages.postprocess.serialize_stage import SerializeStage
 from morpheus.stages.preprocess.deserialize_stage import DeserializeStage
 from morpheus.utils.logger import configure_logging
-
-# pylint: disable=no-name-in-module
-from .stages.classification_stage import ClassificationStage
-from .stages.graph_construction_stage import FraudGraphConstructionStage
-from .stages.graph_sage_stage import GraphSAGEStage
 
 CUR_DIR = os.path.dirname(__file__)
 

--- a/examples/ransomware_detection/run.py
+++ b/examples/ransomware_detection/run.py
@@ -18,6 +18,8 @@ import typing
 
 import click
 import yaml
+from stages.create_features import CreateFeaturesRWStage
+from stages.preprocessing import PreprocessingRWStage
 
 from morpheus.config import Config
 from morpheus.config import PipelineModes
@@ -29,9 +31,6 @@ from morpheus.stages.output.write_to_file_stage import WriteToFileStage
 from morpheus.stages.postprocess.add_scores_stage import AddScoresStage
 from morpheus.stages.postprocess.serialize_stage import SerializeStage
 from morpheus.utils.logger import configure_logging
-
-from .stages.create_features import CreateFeaturesRWStage
-from .stages.preprocessing import PreprocessingRWStage
 
 CUR_DIR = os.path.dirname(__file__)
 


### PR DESCRIPTION
This change was made because of check-style failures when tests were refactored but is causing import failures.

Note: This commit also reverts the style fix and the local imports are mis-sorted. We may need to update the style checker to fix it post release.