### PR TITLE
Fix minor issues with LLM example documentation

### DIFF
--- a/examples/llm/agents/README.md
+++ b/examples/llm/agents/README.md
@@ -126,9 +126,12 @@ This example demonstrates the basic implementation of Morpheus pipeline, showcas
 - Stores and manages the results within the pipeline using an InMemorySinkStage.
 
 
+To run the example with default options, use the following command:
 ```bash
-python examples/llm/main.py agents simple [OPTIONS]
+python examples/llm/main.py --log_level=info agents simple
 ```
+
+Available options for the Simple pipeline are as follows:
 
 ### Options:
 - `--use_cpu_only`
@@ -158,10 +161,6 @@ python examples/llm/main.py agents simple [OPTIONS]
 - `--help`
     - **Description**: Show the help message with options and commands details.
 
-
-```bash
-python examples/llm/main.py --log_level=info agents simple
-```
 
 ### Run example (Kafka Pipeline):
 

--- a/examples/llm/agents/README.md
+++ b/examples/llm/agents/README.md
@@ -159,6 +159,10 @@ python examples/llm/main.py agents simple [OPTIONS]
     - **Description**: Show the help message with options and commands details.
 
 
+```bash
+python examples/llm/main.py --log_level=info agents simple
+```
+
 ### Run example (Kafka Pipeline):
 
 The Kafka Example in the Morpheus LLM Agents demonstrates an streaming implementation, utilizing Kafka messages to

--- a/examples/llm/agents/README.md
+++ b/examples/llm/agents/README.md
@@ -131,7 +131,7 @@ To run the example with default options, use the following command:
 python examples/llm/main.py --log_level=info agents simple
 ```
 
-Available options for the Simple pipeline are as follows:
+Available options for the simple pipeline are as follows:
 
 ### Options:
 - `--use_cpu_only`

--- a/examples/llm/completion/README.md
+++ b/examples/llm/completion/README.md
@@ -145,6 +145,5 @@ python examples/llm/main.py completion [OPTIONS] COMMAND [ARGS]...
 ### Running Morpheus Pipeline with OpenAI LLM service
 
 ```bash
-
 python examples/llm/main.py completion pipeline --llm_service OpenAI
 ```

--- a/examples/llm/rag/README.md
+++ b/examples/llm/rag/README.md
@@ -96,14 +96,6 @@ The standalone Morpheus pipeline is built using the following components:
 
 Before running the pipeline, we need obtain service API keys for the following services:
 
-### Ensure that LFS files are downloaded
-
-To retrieve datasets from LFS run the following:
-
-```bash
-./scripts/fetch_data.py fetch datasets
-```
-
 ### Obtain an OpenAI API or NGC API Key
 
 #### NGC

--- a/examples/llm/vdb_upload/README.md
+++ b/examples/llm/vdb_upload/README.md
@@ -123,10 +123,10 @@ Before running the pipeline, we need to ensure that the following services are r
 
 #### Ensure LFS files are downloaded
 
-To retrieve datasets from LFS run the following:
+To retrieve the datasets from LFS run the following:
 
 ```bash
-./scripts/fetch_data.py fetch datasets
+./scripts/fetch_data.py fetch examples
 ```
 
 #### Milvus Service

--- a/examples/llm/vdb_upload/README.md
+++ b/examples/llm/vdb_upload/README.md
@@ -131,8 +131,13 @@ To retrieve the datasets from LFS run the following:
 
 #### Milvus Service
 
-- Follow the instructions [here](https://milvus.io/docs/install_standalone-docker.md) to install and run a Milvus
-  service.
+- Refer to the [Milvus documentation](https://milvus.io/docs/install-overview.md) for more details on running Milvus. For the purposes of testing the pipeline, we will launch an instance of Milvus Lite.
+
+From the root of the Morpheus repository, run the following to launch Milvus in a separate terminal:
+```bash
+mkdir -p .tmp/milvusdb
+milvus-server --data .tmp/milvusdb
+```
 
 #### Triton Service
 


### PR DESCRIPTION
## Description
* Agents: Show an actual runnable command that can be copy/pasted, not just the command usage.
* Completion: Remove blank line in command block
* RAG: Remove section about fetching data, RAG doesn't need any LFS files.
* VDB Upload: Pipeline requires the `examples` dataset not the `datasets` dataset.
* VDB Upload: Document how to run Milvus

Closes #1991

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
