### PR TITLE
Fix offset calculation when taking a slice of a `SlicedMessageMeta`

### DIFF
--- a/python/morpheus/morpheus/_lib/src/messages/meta.cpp
+++ b/python/morpheus/morpheus/_lib/src/messages/meta.cpp
@@ -524,7 +524,14 @@ SlicedMessageMeta::SlicedMessageMeta(std::shared_ptr<MessageMeta> other,
   m_start(start),
   m_stop(stop),
   m_column_names(std::move(columns))
-{}
+{
+    auto sliced_other = std::dynamic_pointer_cast<SlicedMessageMeta>(other);
+    if (sliced_other)
+    {
+        m_start += sliced_other->m_start;
+        m_stop += sliced_other->m_start;
+    }
+}
 
 TensorIndex SlicedMessageMeta::count() const
 {

--- a/tests/morpheus/apps/test_sid.py
+++ b/tests/morpheus/apps/test_sid.py
@@ -26,7 +26,6 @@ from _utils import calc_error_val
 from _utils import compare_class_to_scores
 from _utils import mk_async_infer
 from morpheus.config import Config
-from morpheus.config import CppConfig
 from morpheus.config import PipelineModes
 from morpheus.pipeline import LinearPipeline
 from morpheus.stages.general.monitor_stage import MonitorStage

--- a/tests/morpheus/apps/test_sid.py
+++ b/tests/morpheus/apps/test_sid.py
@@ -179,11 +179,7 @@ def test_minibert_no_trunc(config: Config, tmp_path: str, morpheus_log_level: in
                             truncated=False,
                             morpheus_log_level=morpheus_log_level)
 
-    # Not sure why these are different
-    if (CppConfig.get_should_use_cpp()):
-        assert results.diff_rows == 18
-    else:
-        assert results.diff_rows == 1333
+    assert results.diff_rows == 18
 
 
 @pytest.mark.slow
@@ -198,8 +194,4 @@ def test_minibert_truncated(config: Config, tmp_path: str, morpheus_log_level: i
                             data_col_name=data_col_name,
                             morpheus_log_level=morpheus_log_level)
 
-    # Not sure why these are different
-    if (CppConfig.get_should_use_cpp()):
-        assert results.diff_rows == 1204
-    else:
-        assert results.diff_rows == 1333
+    assert results.diff_rows == 1204

--- a/tests/morpheus/apps/test_sid_kafka.py
+++ b/tests/morpheus/apps/test_sid_kafka.py
@@ -115,4 +115,4 @@ def test_minibert_cpp(dataset_pandas: DatasetManager,
 
     results = compare_df(val_df, output_df, exclude_columns=[r'^ID$', r'^_ts_'], rel_tol=0.05)
 
-    assert results['diff_rows'] == 1585
+    assert results['diff_rows'] == 1204


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes https://github.com/nv-morpheus/Morpheus/issues/2002

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
