### PR TITLE
Update DFP integrated pipeline to use MRC `Router` node

### DIFF
--- a/docs/source/developer_guide/guides/10_modular_pipeline_digital_fingerprinting.md
+++ b/docs/source/developer_guide/guides/10_modular_pipeline_digital_fingerprinting.md
@@ -71,7 +71,7 @@ The front-end loader outputs one or more control messages that are passed to the
 
 Moreover, the updated pipeline supports human-in-the-loop workflows, such as the ability to manually trigger training or inference tasks against a specific set of data, and the capacity for real-time labeling of production inference events that can be injected back into the training pipeline.
 
-The following content will track the pipeline declared in `examples/digital_fingerprinting/production/morpheus/dfp_integrated_training_streaming_pipeline.py`
+The following content will track the pipeline declared in `examples/digital_fingerprinting/production/dfp_integrated_training_streaming_pipeline.py`
 
 ```python
 # Setup and command line argument parsing
@@ -115,7 +115,7 @@ For a full introduction to Morpheus modules, refer to the [Python Modules](7_pyt
 ## DFP Deployment
 
 
-Source: `examples/digital_fingerprinting/production/morpheus/dfp/modules/dfp_deployment.py`
+Source: `python/morpheus_dfp/morpheus_dfp/modules/dfp_deployment.py`
 
 This is the top level module that encapsulates the entire Digital Fingerprinting pipeline, it is primarily responsible for wrapping the training and inference pipelines, providing the correct module interface, and doing some configuration pre-processing. Since this module is monolithic, it supports a significant number of configuration options; however, the majority of these have intelligent defaults and are not required to be specified.
 
@@ -162,7 +162,7 @@ There are a number of modules that are used in both the training and inference p
 
 ### DFP Preprocessing
 
-Source: `examples/digital_fingerprinting/production/morpheus/dfp/modules/dfp_preproc.py`
+Source: `python/morpheus_dfp/morpheus_dfp/modules/dfp_preproc.py`
 
 The `dfp_preproc` module is a functional component within the Morpheus framework that combines multiple processing pipeline modules related to inference and training. This module simplifies the pipeline by consolidating various modules into a single, cohesive unit. The `dfp_preproc` module supports configuration parameters such as the cache directory, timestamp column name, batching options, user splitting options, and supported data loaders for various file types.
 
@@ -207,7 +207,7 @@ For a complete reference, refer to: [DataLoader Module](../../modules/core/data_
 
 ### DFP Split Users
 
-Source: `examples/digital_fingerprinting/production/morpheus/dfp/modules/dfp_split_users.py`
+Source: `python/morpheus_dfp/morpheus_dfp/modules/dfp_split_users.py`
 
 The `dfp_split_users` module is responsible for splitting the input data based on user IDs. The module provides configuration options, such as fallback username, include generic user, include individual users, and specify lists of user IDs to include or exclude in the output.
 
@@ -218,7 +218,7 @@ For a complete reference, refer to: [DFP Split Users](../../modules/examples/dig
 
 ### DFP Rolling Window
 
-Source: `examples/digital_fingerprinting/production/morpheus/dfp/modules/dfp_rolling_window.py`
+Source: `python/morpheus_dfp/morpheus_dfp/modules/dfp_rolling_window.py`
 
 The `dfp_rolling_window` module is responsible for maintaining a rolling window of historical data, acting as a streaming caching and batching system. The module provides various configuration options, such as aggregation span, cache directory, caching options, timestamp column name, and trigger conditions.
 
@@ -233,7 +233,7 @@ For a complete reference, refer to: [DFP Rolling Window](../../modules/examples/
 
 ### DFP Data Prep
 
-Source: `examples/digital_fingerprinting/production/morpheus/dfp/modules/dfp_data_prep.py`
+Source: `python/morpheus_dfp/morpheus_dfp/modules/dfp_data_prep.py`
 
 The `dfp_data_prep` module is responsible for preparing data for either inference or model training. The module requires a defined schema for data preparation.
 
@@ -243,7 +243,7 @@ For a complete reference, refer to: [DFP Data Prep](../../modules/examples/digit
 
 ## DFP Training Pipeline
 
-Source: `examples/digital_fingerprinting/production/morpheus/dfp/modules/dfp_training_pipe.py`
+Source: `python/morpheus_dfp/morpheus_dfp/modules/dfp_training_pipe.py`
 
 The DFP Training Pipe module is a consolidated module that integrates several DFP pipeline modules that are essential to the training process. This module function provides a single entry point to the training pipeline, simplifying the process of training a model. The module offers configurable parameters for various stages in the pipeline, including data batching, data preprocessing, and data encoding for model training. Additionally, the MLflow model writer options allow for the trained model to be saved for future use.
 
@@ -281,7 +281,7 @@ def dfp_training_pipe(builder: mrc.Builder):
 
 ### DFP Training
 
-Source: `examples/digital_fingerprinting/production/morpheus/dfp/modules/dfp_training.py`
+Source: `python/morpheus_dfp/morpheus_dfp/modules/dfp_training.py`
 
 The `dfp_training` module function is responsible for training the model. The `on_data` function is defined to handle incoming `ControlMessage` instances. It retrieves the user ID and the input data from the `ControlMessage`, creates an instance of the `AutoEncoder` class with the specified `model_kwargs`, and trains the model on the input data. The output message includes the trained model and metadata.
 
@@ -301,7 +301,7 @@ For a complete reference, refer to: [MLflow Model Writer](../../modules/core/mlf
 
 ## DFP Inference Pipeline
 
-Source: `examples/digital_fingerprinting/production/morpheus/dfp/modules/dfp_inference_pipe.py`
+Source: `python/morpheus_dfp/morpheus_dfp/modules/dfp_inference_pipe.py`
 
 The `dfp_inference_pipe` module function consolidates multiple digital fingerprinting pipeline (DFP) modules relevant to the inference process into a single module. Its purpose is to simplify the creation and configuration of an inference pipeline by combining all necessary components.
 
@@ -350,7 +350,7 @@ def dfp_inference_pipe(builder: mrc.Builder):
 
 ### DFP Inference
 
-Source: `examples/digital_fingerprinting/production/morpheus/dfp/modules/dfp_inference.py`
+Source: `python/morpheus_dfp/morpheus_dfp/modules/dfp_inference.py`
 
 The `dfp_inference` module function creates an inference module that retrieves trained models and performs inference on the input data. The module requires a `model_name_formatter` and a `fallback_username` to be configured in its parameters.
 
@@ -373,7 +373,7 @@ For a complete reference, refer to: [Filter Detections](../../modules/core/filte
 
 ### DFP Post Processing
 
-Source: `examples/digital_fingerprinting/production/morpheus/dfp/modules/dfp_postprocessing.py`
+Source: `python/morpheus_dfp/morpheus_dfp/modules/dfp_postprocessing.py`
 
 The `dfp_postprocessing` module function performs post-processing tasks on the input data.
 

--- a/docs/source/extra_info/troubleshooting.md
+++ b/docs/source/extra_info/troubleshooting.md
@@ -48,7 +48,7 @@ Error trying to get model
 
 Traceback (most recent call last):
 
-File "/workspace/examples/digital_fingerprinting/production/morpheus/dfp/stages/dfp_inference_stage.py", line 101, in on_data
+File "/workspace/python/morpheus_dfp/morpheus_dfp/stages/dfp_inference_stage.py", line 101, in on_data
 
 loaded_model = model_cache.load_model(self._client)
 ```

--- a/examples/digital_fingerprinting/production/dfp_integrated_training_batch_pipeline.py
+++ b/examples/digital_fingerprinting/production/dfp_integrated_training_batch_pipeline.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import logging
-import typing
 from datetime import datetime
 
 import click

--- a/examples/digital_fingerprinting/production/dfp_integrated_training_batch_pipeline.py
+++ b/examples/digital_fingerprinting/production/dfp_integrated_training_batch_pipeline.py
@@ -120,17 +120,17 @@ from morpheus_dfp.utils.schema_utils import SchemaBuilder
 @click.option('--silence_monitors', flag_value=True, help='Controls whether monitors will be verbose.')
 def run_pipeline(source: str,
                  train_users: str,
-                 skip_user: typing.Tuple[str],
-                 only_user: typing.Tuple[str],
-                 start_time: datetime,
+                 skip_user: tuple[str],
+                 only_user: tuple[str],
+                 start_time: datetime | None,
                  duration: str,
                  cache_dir: str,
                  log_level: int,
                  sample_rate_s: int,
-                 tracking_uri,
-                 silence_monitors,
-                 mlflow_experiment_name_template,
-                 mlflow_model_name_template,
+                 tracking_uri: str,
+                 silence_monitors: bool,
+                 mlflow_experiment_name_template: str | None,
+                 mlflow_model_name_template: str | None,
                  **kwargs):
     if (skip_user and only_user):
         logging.error("Option --skip_user and --only_user are mutually exclusive. Exiting")

--- a/python/morpheus_dfp/morpheus_dfp/modules/dfp_deployment.py
+++ b/python/morpheus_dfp/morpheus_dfp/modules/dfp_deployment.py
@@ -15,8 +15,9 @@
 import logging
 
 import mrc
-from mrc.core.node import Broadcast
+from mrc.core.node import Router
 
+from morpheus.messages import ControlMessage
 from morpheus.utils.loader_ids import FSSPEC_LOADER
 from morpheus.utils.module_ids import DATA_LOADER
 from morpheus.utils.module_ids import MORPHEUS_MODULE_NAMESPACE
@@ -165,7 +166,7 @@ def dfp_deployment(builder: mrc.Builder):
     #                                        |
     #                                        v
     #                     +-------------------------------------+
-    #                     |              broadcast              |
+    #                     |                router               |
     #                     +-------------------------------------+
     #                               /                   \
     #                              /                     \
@@ -205,13 +206,21 @@ def dfp_deployment(builder: mrc.Builder):
                                                     "dfp_inference_pipe",
                                                     dfp_inference_pipe_conf)
 
-    # Create broadcast node to fork the pipeline.
-    broadcast = Broadcast(builder, "broadcast")
+    def router_key_fn(cm: ControlMessage) -> str:
+        if cm.has_task("training"):
+            return "training"
+        if cm.has_task("inference"):
+            return "inference"
+
+        raise ValueError("Control message does not have a valid task.")
+
+    # Create router node to fork the pipeline.
+    router = Router(builder, "router", router_keys=["training", "inference"], key_fn=router_key_fn)
 
     # Make an edge between modules
-    builder.make_edge(fsspec_dataloader_module.output_port("output"), broadcast)
-    builder.make_edge(broadcast, dfp_training_pipe_module.input_port("input"))
-    builder.make_edge(broadcast, dfp_inference_pipe_module.input_port("input"))
+    builder.make_edge(fsspec_dataloader_module.output_port("output"), router)
+    builder.make_edge(router.get_source("training"), dfp_training_pipe_module.input_port("input"))
+    builder.make_edge(router.get_source("inference"), dfp_inference_pipe_module.input_port("input"))
 
     out_nodes = [dfp_training_pipe_module.output_port("output"), dfp_inference_pipe_module.output_port("output")]
 

--- a/python/morpheus_dfp/morpheus_dfp/modules/dfp_inference_pipe.py
+++ b/python/morpheus_dfp/morpheus_dfp/modules/dfp_inference_pipe.py
@@ -215,9 +215,6 @@ def dfp_inference_pipe(builder: mrc.Builder):
         "batching_options": config.get("batching_options", {}),
         "cache_dir": cache_dir,
         "monitor_options": monitor_options,
-        "pre_filter_options": {
-            "enable_task_filtering": True, "filter_task_type": "inference"
-        },
         "timestamp_column_name": ts_column_name,
         "user_splitting_options": config.get("user_splitting_options", {}),
     }

--- a/python/morpheus_dfp/morpheus_dfp/modules/dfp_inference_pipe.py
+++ b/python/morpheus_dfp/morpheus_dfp/modules/dfp_inference_pipe.py
@@ -211,10 +211,14 @@ def dfp_inference_pipe(builder: mrc.Builder):
     ts_column_name = config.get("timestamp_column_name")
     monitor_options = config.get("monitor_options", {})
 
+    preproc_monitor_options = monitor_options.copy()
+    if "name_postfix" not in preproc_monitor_options:
+        preproc_monitor_options["name_postfix"] = "[inference_pipe]"
+
     preproc_options = {
         "batching_options": config.get("batching_options", {}),
         "cache_dir": cache_dir,
-        "monitor_options": monitor_options,
+        "monitor_options": preproc_monitor_options,
         "timestamp_column_name": ts_column_name,
         "user_splitting_options": config.get("user_splitting_options", {}),
     }

--- a/python/morpheus_dfp/morpheus_dfp/modules/dfp_preproc.py
+++ b/python/morpheus_dfp/morpheus_dfp/modules/dfp_preproc.py
@@ -87,8 +87,7 @@ def dfp_preproc(builder: mrc.Builder):
     ts_column_name = config.get("timestamp_column_name", None)
 
     monitor_options = config.get("monitor_options", {})
-    pre_filter_options = config.get("pre_filter_options", {})
-    task_type = pre_filter_options.get("filter_task_type")
+    monitor_name_postfix = monitor_options.get("name_postfix", "")
 
     batching_opts = config.get("batching_options", {})
     batching_opts["cache_dir"] = cache_dir
@@ -100,7 +99,7 @@ def dfp_preproc(builder: mrc.Builder):
 
     supported_loaders = config.get("supported_loaders", {})
 
-    file_to_df_monitor_default = {"description": f"FileToDF [{task_type}_pipe]"}
+    file_to_df_monitor_default = {"description": f"FileToDF {monitor_name_postfix}"}
     file_to_df_monitor_conf = merge_dictionaries(monitor_options, file_to_df_monitor_default)
 
     # Double check on how 'batcher_config' is used in the file_batcher module.
@@ -123,7 +122,7 @@ def dfp_preproc(builder: mrc.Builder):
     dfp_split_users_default = {"fallback_username": config.get("fallback_username", "generic_user")}
     dfp_split_users_conf = merge_dictionaries(splitting_opts, dfp_split_users_default)
 
-    dfp_split_users_monitor_default = {"description": f"SplitUsers [{task_type}_pipe]"}
+    dfp_split_users_monitor_default = {"description": f"SplitUsers {monitor_name_postfix}"}
     dfp_split_users_monitor_conf = merge_dictionaries(monitor_options, dfp_split_users_monitor_default)
 
     file_batcher_module = builder.load_module(FILE_BATCHER, "morpheus", "file_batcher", file_batcher_conf)

--- a/python/morpheus_dfp/morpheus_dfp/modules/dfp_preproc.py
+++ b/python/morpheus_dfp/morpheus_dfp/modules/dfp_preproc.py
@@ -20,7 +20,6 @@ from morpheus.modules.general.monitor import MonitorLoaderFactory
 from morpheus.utils.loader_ids import FILE_TO_DF_LOADER
 from morpheus.utils.module_ids import DATA_LOADER
 from morpheus.utils.module_ids import FILE_BATCHER
-from morpheus.utils.module_ids import FILTER_CONTROL_MESSAGE
 from morpheus.utils.module_ids import MORPHEUS_MODULE_NAMESPACE
 from morpheus.utils.module_utils import merge_dictionaries
 from morpheus.utils.module_utils import register_module
@@ -103,9 +102,6 @@ def dfp_preproc(builder: mrc.Builder):
 
     file_to_df_monitor_default = {"description": f"FileToDF [{task_type}_pipe]"}
     file_to_df_monitor_conf = merge_dictionaries(monitor_options, file_to_df_monitor_default)
-
-    pre_filter_default = {}
-    pre_filter_conf = merge_dictionaries(pre_filter_options, pre_filter_default)
 
     # Double check on how 'batcher_config' is used in the file_batcher module.
     batching_opts_default = {

--- a/python/morpheus_dfp/morpheus_dfp/modules/dfp_training_pipe.py
+++ b/python/morpheus_dfp/morpheus_dfp/modules/dfp_training_pipe.py
@@ -186,9 +186,6 @@ def dfp_training_pipe(builder: mrc.Builder):
         "batching_options": config.get("batching_options", {}),
         "cache_dir": cache_dir,
         "monitor_options": monitor_options,
-        "pre_filter_options": {
-            "enable_task_filtering": True, "filter_task_type": "training"
-        },
         "timestamp_column_name": ts_column_name,
         "user_splitting_options": config.get("user_splitting_options", {}),
     }

--- a/python/morpheus_dfp/morpheus_dfp/modules/dfp_training_pipe.py
+++ b/python/morpheus_dfp/morpheus_dfp/modules/dfp_training_pipe.py
@@ -182,10 +182,14 @@ def dfp_training_pipe(builder: mrc.Builder):
     ts_column_name = config.get("timestamp_column_name")
     monitor_options = config.get("monitor_options", {})
 
+    preproc_monitor_options = monitor_options.copy()
+    if "name_postfix" not in preproc_monitor_options:
+        preproc_monitor_options["name_postfix"] = "[training_pipe]"
+
     preproc_options = {
         "batching_options": config.get("batching_options", {}),
         "cache_dir": cache_dir,
-        "monitor_options": monitor_options,
+        "monitor_options": preproc_monitor_options,
         "timestamp_column_name": ts_column_name,
         "user_splitting_options": config.get("user_splitting_options", {}),
     }

--- a/python/morpheus_dfp/morpheus_dfp/utils/dfp_arg_parser.py
+++ b/python/morpheus_dfp/morpheus_dfp/utils/dfp_arg_parser.py
@@ -36,12 +36,12 @@ class TimeFields:
 class DFPArgParser:
 
     def __init__(self,
-                 skip_user: str,
-                 only_user: str,
-                 start_time: str,
+                 skip_user: tuple[str],
+                 only_user: tuple[str],
+                 start_time: datetime | None,
                  log_level: int,
                  cache_dir: str,
-                 sample_rate_s: str,
+                 sample_rate_s: int,
                  duration: str,
                  source: str,
                  tracking_uri: str,


### PR DESCRIPTION
## Description
* Replace `Broadcast` with `Router`
* Remove unneeded filter node from `dfp_preproc` module
* Fix DFP file & class paths in documentation
* Remove python blocks from documentation which didn't offer much to readers

Closes #2034 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
