### PR TITLE
Avoid compiler warnings

### DIFF
--- a/examples/developer_guide/3_simple_cpp_stage/CMakeLists.txt
+++ b/examples/developer_guide/3_simple_cpp_stage/CMakeLists.txt
@@ -38,6 +38,10 @@ set(CMAKE_INSTALL_RPATH "$ORIGIN")
 
 # Set the option prefix to match the outer project before including. Must be before find_package(morpheus)
 set(OPTION_PREFIX "MORPHEUS")
+
+# Set the policy to allow for CMP0144, avoids warning about MORPHEUS_ROOT being set
+cmake_policy(SET CMP0144 NEW)
+
 find_package(morpheus REQUIRED)
 
 morpheus_utils_initialize_cpm(MORPHEUS_CACHE_DIR)

--- a/examples/developer_guide/4_rabbitmq_cpp_stage/CMakeLists.txt
+++ b/examples/developer_guide/4_rabbitmq_cpp_stage/CMakeLists.txt
@@ -38,6 +38,10 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Set the option prefix to match the outer project before including. Must be before find_package(morpheus)
 set(OPTION_PREFIX "MORPHEUS")
+
+# Set the policy to allow for CMP0144, avoids warning about MORPHEUS_ROOT being set
+cmake_policy(SET CMP0144 NEW)
+
 find_package(morpheus REQUIRED)
 
 morpheus_utils_initialize_cpm(MORPHEUS_CACHE_DIR)

--- a/python/morpheus/morpheus/_lib/cmake/libmorpheus.cmake
+++ b/python/morpheus/morpheus/_lib/cmake/libmorpheus.cmake
@@ -112,6 +112,9 @@ add_dependencies(morpheus ${cudf_helpers_target})
 # In debug mode, dont allow missing symbols
 target_link_options(morpheus PUBLIC "$<$<CONFIG:Debug>:-Wl,--no-allow-shlib-undefined>")
 
+# Avoid warning from the lto-wrapper about serial compilation
+target_link_options(morpheus PUBLIC "-flto=auto")
+
 # Generates an include file for specifying external linkage since everything is hidden by default
 generate_export_header(morpheus
   NO_EXPORT_MACRO_NAME

--- a/python/morpheus_llm/morpheus_llm/_lib/cmake/libmorpheus_llm.cmake
+++ b/python/morpheus_llm/morpheus_llm/_lib/cmake/libmorpheus_llm.cmake
@@ -60,6 +60,9 @@ target_include_directories(morpheus_llm
 # In debug mode, dont allow missing symbols
 target_link_options(morpheus_llm PUBLIC "$<$<CONFIG:Debug>:-Wl,--no-allow-shlib-undefined>")
 
+# Avoid warning from the lto-wrapper about serial compilation
+target_link_options(morpheus_llm PUBLIC "-flto=auto")
+
 # Ideally, we dont use glob here. But there is no good way to guarantee you dont miss anything like *.cpp
 file(GLOB_RECURSE morpheus_llm_public_headers
   LIST_DIRECTORIES FALSE


### PR DESCRIPTION
## Description
* Set CMake policy #`CMP0144` to `NEW` in C++ examples, avoids a deprecation warning
* Set `-lto=auto` to avoid a warning about falling back to serialized compilation.

Related to https://github.com/nv-morpheus/MRC/pull/518 .

Closes #1988

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
