### PR TITLE
Allow running something other than bash when using docker scripts

### DIFF
--- a/docker/run_container_dev.sh
+++ b/docker/run_container_dev.sh
@@ -22,4 +22,4 @@ export DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG:-"dev-$(date +'%y%m%d')"}
 export DOCKER_ARGS="-v $PWD:/workspace -v /dev/hugepages:/dev/hugepages --privileged"
 
 # Call the general run script
-${SCRIPT_DIR}/run_container.sh
+${SCRIPT_DIR}/run_container.sh "${@:-bash}"

--- a/docker/run_container_release.sh
+++ b/docker/run_container_release.sh
@@ -35,4 +35,4 @@ if [[ ${MORPHEUS_SUPPORT_DOCA} == @(TRUE|ON) ]]; then
 fi
 
 # Call the general run script
-${SCRIPT_DIR}/run_container.sh
+${SCRIPT_DIR}/run_container.sh "${@:-bash}"


### PR DESCRIPTION
## Description
* Allow the user to optionally run something other than `bash` when using `docker/run_container_release.sh` and `docker/run_container_dev.sh`

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
