### PR TITLE
Add missing indicators lib to conda package

### DIFF
--- a/ci/conda/recipes/morpheus-libs/meta.yaml
+++ b/ci/conda/recipes/morpheus-libs/meta.yaml
@@ -64,6 +64,7 @@ outputs:
         - cudf {{ rapids_version }}
         - cython 3.0.*
         - glog >=0.7.1,<0.8
+        - indicators=2.3
         - libcudf {{ rapids_version }}
         - librdkafka >=1.9.2,<1.10.0a0
         - mrc {{ minor_version }}

--- a/ci/conda/recipes/morpheus/meta.yaml
+++ b/ci/conda/recipes/morpheus/meta.yaml
@@ -69,6 +69,7 @@ outputs:
         - cudf {{ rapids_version }}
         - cython 3.0.*
         - glog >=0.7.1,<0.8
+        - indicators=2.3
         - libcudf {{ rapids_version }}
         - librdkafka >=1.9.2,<1.10.0a0
         - mrc {{ minor_version }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -185,6 +185,7 @@ COPY . ./
 
 RUN --mount=type=cache,id=workspace_cache,target=/workspace/.cache,sharing=locked \
     --mount=type=cache,id=conda_pkgs,target=/opt/conda/pkgs,sharing=locked \
+    --mount=type=cache,id=pip_cache,target=/root/.cache/pip,sharing=locked \
     # Install git-lfs before running the build to avoid errors during conda build
     /opt/conda/bin/mamba install -y -n base -c conda-forge "git-lfs" &&\
     source activate base &&\
@@ -227,6 +228,7 @@ COPY ${MORPHEUS_ROOT_HOST}/conda/environments/dev_cuda-${CUDA_MAJOR_VER}${CUDA_M
 
 # Update the morpheus environment
 RUN --mount=type=cache,id=conda_pkgs,target=/opt/conda/pkgs,sharing=locked \
+    --mount=type=cache,id=pip_cache,target=/root/.cache/pip,sharing=locked \
     # Temp add channel_alias to get around conda 404 errors
     conda config --env --set channel_alias ${CONDA_CHANNEL_ALIAS} &&\
     /opt/conda/bin/conda env update --solver=libmamba -n morpheus --file conda/environments/dev.yaml &&\
@@ -263,6 +265,7 @@ COPY . ./
 
 RUN --mount=type=cache,id=workspace_cache,target=/workspace/.cache,sharing=locked \
     --mount=type=cache,id=conda_pkgs,target=/opt/conda/pkgs,sharing=locked \
+    --mount=type=cache,id=pip_cache,target=/root/.cache/pip,sharing=locked \
     # Install git-lfs before running the build to avoid errors during conda build
     /opt/conda/bin/mamba install -y -n base -c conda-forge "git-lfs" &&\
     source activate base &&\
@@ -285,6 +288,7 @@ COPY . ./
 RUN --mount=type=cache,id=workspace_cache,target=/workspace/.cache,sharing=locked \
     --mount=type=bind,from=conda_bld_morpheus,source=/opt/conda/conda-bld,target=/opt/conda/conda-bld \
     --mount=type=cache,id=conda_pkgs,target=/opt/conda/pkgs,sharing=locked \
+    --mount=type=cache,id=pip_cache,target=/root/.cache/pip,sharing=locked \
     source activate morpheus &&\
     CONDA_ALWAYS_YES=true /opt/conda/bin/mamba install -n morpheus \
         -c local \
@@ -314,6 +318,7 @@ COPY "${MORPHEUS_ROOT_HOST}/conda/environments/runtime_cuda-${CUDA_MAJOR_VER}${C
 # Mount Morpheus conda package build in `conda_bld_morpheus`
 RUN --mount=type=bind,from=conda_bld_morpheus,source=/opt/conda/conda-bld,target=/opt/conda/conda-bld \
     --mount=type=cache,id=conda_pkgs,target=/opt/conda/pkgs,sharing=locked \
+    --mount=type=cache,id=pip_cache,target=/root/.cache/pip,sharing=locked \
     # CVE-2018-20225 for the base pip, not the env one
     # conda will ignore the request to remove pip
     python -m pip uninstall -y pip && \


### PR DESCRIPTION
## Description
* `indicators` was added as a dependency but hasn't been added to the Conda meta.yaml files.
* Mount the pip cache dir as a shared cache, this prevents the pip cache from being published in the container, reducing the image size by 3GB!

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
