### PR TITLE
Specify `count: all` for GPU resources in docker compose yamls

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,9 +16,9 @@
 ARG BASE
 ARG PYTHON_PACKAGE_MANAGER
 
-FROM node:22 as node
+FROM node:22 AS node
 
-FROM ${BASE} as base
+FROM ${BASE} AS base
 
 # ===== install common packages ==================================================================
 
@@ -71,11 +71,11 @@ npm install -g camouflage-server@0.15
 EOF
 
 
-FROM base as pip-base
+FROM base AS pip-base
 
 ENV DEFAULT_VIRTUAL_ENV=morpheus
 
-FROM base as conda-base
+FROM base AS conda-base
 
 ENV DEFAULT_CONDA_ENV=morpheus
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -123,7 +123,7 @@ RUN --mount=type=cache,id=conda_pkgs,target=/opt/conda/pkgs,sharing=locked \
 
 # ============ Stage: conda_env ============
 # Create the conda environment and install all dependencies
-FROM base as conda_env
+FROM base AS conda_env
 
 ARG MORPHEUS_ROOT_HOST
 
@@ -151,7 +151,7 @@ SHELL ["/bin/bash", "-c"]
 
 # ============ Stage: conda_bld_morpheus_core ============
 # Now build the morpheus conda package
-FROM conda_env as conda_bld_morpheus_core
+FROM conda_env AS conda_bld_morpheus_core
 
 ARG MORPHEUS_ROOT_HOST
 ARG CUDA_MAJOR_VER
@@ -198,7 +198,7 @@ RUN --mount=type=cache,id=workspace_cache,target=/workspace/.cache,sharing=locke
 
 # ============ Stage: base_extended ============
 # Base environment with any optional extensions. ex. DOCA libs
-FROM conda_env as base_extended
+FROM conda_env AS base_extended
 
 # Add one or more optional dependencies to the base environment
 ARG MORPHEUS_ROOT_HOST
@@ -216,7 +216,7 @@ RUN --mount=type=cache,id=doca,target=/tmp/doca,sharing=locked \
 
 # ============ Stage: conda_env_dev ============
 # Create the development conda environment
-FROM base_extended as conda_env_dev
+FROM base_extended AS conda_env_dev
 
 ARG MORPHEUS_ROOT_HOST
 ARG CUDA_MAJOR_VER
@@ -237,7 +237,7 @@ RUN --mount=type=cache,id=conda_pkgs,target=/opt/conda/pkgs,sharing=locked \
 
 # ============ Stage: conda_bld_morpheus ============
 # Now build the morpheus conda package
-FROM base_extended as conda_bld_morpheus
+FROM base_extended AS conda_bld_morpheus
 
 ARG MORPHEUS_ROOT_HOST
 ARG CUDA_MAJOR_VER
@@ -278,7 +278,7 @@ RUN --mount=type=cache,id=workspace_cache,target=/workspace/.cache,sharing=locke
 
 # ============ Stage: build_docs ============
 # Now build the morpheus docs
-FROM conda_env_dev as build_docs
+FROM conda_env_dev AS build_docs
 
 ARG MORPHEUS_ROOT_HOST
 
@@ -308,7 +308,7 @@ RUN --mount=type=cache,id=workspace_cache,target=/workspace/.cache,sharing=locke
 
 # ============ Stage: runtime_conda_create ============
 # Setup conda for the runtime environment
-FROM base_extended as runtime_conda_create
+FROM base_extended AS runtime_conda_create
 ARG MORPHEUS_ROOT_HOST
 ARG CUDA_MAJOR_VER
 ARG CUDA_MINOR_VER
@@ -341,7 +341,7 @@ RUN --mount=type=bind,from=conda_bld_morpheus,source=/opt/conda/conda-bld,target
 # ============ Stage: git_clone ============
 # Perform a clone of the git repository this ensures that when we copy files from the source repository, we aren't
 # unintentionally including build artifacts or other files that shouldn't be in the final image
-FROM conda_env_dev as git_clone
+FROM conda_env_dev AS git_clone
 
 ARG MORPHEUS_ROOT_HOST
 
@@ -356,7 +356,7 @@ RUN --mount=type=bind,source=.,target=/opt/host_repo \
 
 # ============ Stage: runtime ============
 # Setup container for runtime environment
-FROM runtime_conda_create as runtime
+FROM runtime_conda_create AS runtime
 
 ARG MORPHEUS_ROOT_HOST
 
@@ -380,7 +380,7 @@ CMD [ "morpheus" ]
 
 # ============ Stage: development ============
 # Install and configure development only packages
-FROM conda_env_dev as development
+FROM conda_env_dev AS development
 
 ARG CUDA_MAJOR_VER
 ARG CUDA_MINOR_VER
@@ -412,7 +412,7 @@ RUN git config --global --add safe.directory "*"
 
 # ============ Stage: python_debug_bld ===========
 # Configure and build cpython with debugging symbols
-FROM development as development_pydbg
+FROM development AS development_pydbg
 
 COPY ${MORPHEUS_ROOT_HOST}/ci/conda/recipes/python-dbg/ ./ci/conda/recipes/python-dbg
 COPY ${MORPHEUS_ROOT_HOST}/ci/conda/recipes/run_conda_build.sh ./ci/conda/recipes/run_conda_build.sh

--- a/examples/digital_fingerprinting/production/Dockerfile
+++ b/examples/digital_fingerprinting/production/Dockerfile
@@ -16,7 +16,7 @@
 ARG BASE_IMG=nvcr.io/nvidia/cuda
 ARG BASE_IMG_TAG=12.5.1-base-ubuntu22.04
 
-FROM ${BASE_IMG}:${BASE_IMG_TAG} as base
+FROM ${BASE_IMG}:${BASE_IMG_TAG} AS base
 
 # Install necessary dependencies using apt-get
 RUN apt-get update && apt-get install -y \
@@ -55,13 +55,13 @@ ENTRYPOINT [ "/opt/conda/envs/morpheus-dfp/bin/tini", "--", "/workspace/examples
 SHELL ["/bin/bash", "-c"]
 
 # ===== Setup for running unattended =====
-FROM base as runtime
+FROM base AS runtime
 
 # Launch morpheus
 CMD ["./launch.sh"]
 
 # ===== Setup for running Jupyter =====
-FROM base as jupyter
+FROM base AS jupyter
 
 # Install the jupyter specific requirements
 RUN source activate morpheus-dfp &&\

--- a/examples/digital_fingerprinting/production/docker-compose.yml
+++ b/examples/digital_fingerprinting/production/docker-compose.yml
@@ -78,6 +78,7 @@ services:
           devices:
             - driver: nvidia
               capabilities: [ gpu ]
+              count: all
     image: dfp_morpheus_jupyter
     container_name: jupyter
     ports:
@@ -109,6 +110,7 @@ services:
           devices:
             - driver: nvidia
               capabilities: [ gpu ]
+              count: all
     networks:
       - frontend
       - backend

--- a/examples/sid_visualization/docker-compose.yml
+++ b/examples/sid_visualization/docker-compose.yml
@@ -20,6 +20,7 @@ x-with-gpus: &with_gpus
         devices:
           - capabilities:
               - gpu
+            count: all
 
 services:
   triton:


### PR DESCRIPTION
## Description
* According to https://docs.docker.com/compose/how-tos/gpu-support/ "If count is set to all or not specified, all GPUs available on the host are used by default." However we have observed the opposite, that by not specifying count the container doesn't have access to any GPUs.
* Update `Dockerfile`s to ensure the `FROM x AS y` lines have consistent casing, avoids a build warning in newer versions of Docker.

Closes #2099
Closes #2102

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
