### PR TITLE
Fix DOCA builds on ARM64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,13 @@ add_custom_target(${PROJECT_NAME}_style_checks
   COMMENT "Building dependencies for style checks"
 )
 
+# CMAKE_LIBRARY_ARCHITECTURE is needed to find DOCA dependencies
+if(NOT DEFINED CMAKE_LIBRARY_ARCHITECTURE)
+  set(CMAKE_LIBRARY_ARCHITECTURE "${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_SYSTEM_NAME}-${CMAKE_CXX_COMPILER_ID}")
+  string(TOLOWER "${CMAKE_LIBRARY_ARCHITECTURE}" CMAKE_LIBRARY_ARCHITECTURE)
+  message(STATUS "Setting CMAKE_LIBRARY_ARCHITECTURE to ${CMAKE_LIBRARY_ARCHITECTURE}")
+endif()
+
 # Configure all dependencies
 include(dependencies)
 

--- a/ci/scripts/github/cmake_all.sh
+++ b/ci/scripts/github/cmake_all.sh
@@ -34,12 +34,6 @@ fi
 export CMAKE_BUILD_ALL_FEATURES="${_FLAGS[@]}"
 unset _FLAGS
 
-if [[ ${REAL_ARCH} == "aarch64" ]]; then
-    # Currently DOCA is failing to build on ARM
-    # https://github.com/nv-morpheus/Morpheus/issues/2092
-    export MORPHEUS_SUPPORT_DOCA=OFF
-fi
-
-if [[ ${MORPHEUS_SUPPORT_DOCA} == @(TRUE|ON) && ${REAL_ARCH} == "x86_64" ]]; then
+if [[ ${MORPHEUS_SUPPORT_DOCA} == @(TRUE|ON) ]]; then
     export CMAKE_BUILD_ALL_FEATURES="${CMAKE_BUILD_ALL_FEATURES} -DMORPHEUS_SUPPORT_DOCA=ON"
 fi

--- a/cmake/package_search/Finddoca.cmake
+++ b/cmake/package_search/Finddoca.cmake
@@ -42,11 +42,6 @@ block(SCOPE_FOR VARIABLES
   set("CMAKE_FIND_ROOT_PATH_MODE_INCLUDE" BOTH)
   set("CMAKE_FIND_ROOT_PATH_MODE_LIBRARY" BOTH)
 
-  # CMAKE_LIBRARY_ARCHITECTURE needs to be set for this to work correctly. Will be restored at the end of the block
-  if(NOT DEFINED CMAKE_LIBRARY_ARCHITECTURE)
-    set(CMAKE_LIBRARY_ARCHITECTURE x86_64-linux-gnu)
-  endif()
-
   # Find the include path
   find_path(
     doca_INCLUDE_DIR doca_gpunetio.h

--- a/cmake/package_search/Findlibdpdk.cmake
+++ b/cmake/package_search/Findlibdpdk.cmake
@@ -28,11 +28,6 @@ block(SCOPE_FOR VARIABLES
   # List of required args. Start with INCLUDE_DIR since the first one is displayed
   list(APPEND libdpdk_REQUIRED_VARS bsd_FOUND libdpdk_INCLUDE_DIR)
 
-  # CMAKE_LIBRARY_ARCHITECTURE needs to be set for this to work correctly. Will be restored at the end of the block
-  if(NOT DEFINED CMAKE_LIBRARY_ARCHITECTURE)
-    set(CMAKE_LIBRARY_ARCHITECTURE x86_64-linux-gnu)
-  endif()
-
   # This library will always be installed on the host. Allow that to be searched here (Should fix this up in the future)
   set("CMAKE_FIND_ROOT_PATH_MODE_INCLUDE" BOTH)
   set("CMAKE_FIND_ROOT_PATH_MODE_LIBRARY" BOTH)
@@ -76,7 +71,7 @@ block(SCOPE_FOR VARIABLES
         set_target_properties(${library_name} PROPERTIES
           IMPORTED_LINK_INTERFACE_LANGUAGES "C"
           IMPORTED_LOCATION "${${library_name}_LIBRARY}"
-          INTERFACE_INCLUDE_DIRECTORIES "${libdpdk_INCLUDE_DIR};${libdpdk_INCLUDE_DIR}/../x86_64-linux-gnu/dpdk"
+          INTERFACE_INCLUDE_DIRECTORIES "${libdpdk_INCLUDE_DIR};${libdpdk_INCLUDE_DIR}/../${CMAKE_LIBRARY_ARCHITECTURE}/dpdk"
           INTERFACE_LINK_LIBRARIES "bsd::bsd"
         )
 


### PR DESCRIPTION
## Description
* Remove hard-coded `x86_64` values in CMake scripts for DOCA 
* Define `CMAKE_LIBRARY_ARCHITECTURE` in top-level `CMakeLists.txt` as this controls which directories are searched by `find_library` (https://cmake.org/cmake/help/v2.8.8/cmake.html#command:find_library).

Closes #2092

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
