### PR TITLE
Performance improvements for `AbpPcapPreprocessingStage`

### DIFF
--- a/examples/abp_pcap_detection/abp_pcap_preprocessing.py
+++ b/examples/abp_pcap_detection/abp_pcap_preprocessing.py
@@ -85,7 +85,6 @@ class AbpPcapPreprocessingStage(PreprocessBaseStage):
         orig_df = meta.get_data()
 
         # Converts the int flags field into a binary string
-        #flags_bin_series = orig_df["flags"].to_pandas().apply(lambda x: format(int(x), "05b"))
         flags = orig_df["flags"].astype("int8")
         flags_bin_series = (flags // 16 % 2).astype('O') + (flags // 8 % 2).astype('O') + (
             flags // 4 % 2).astype('O') + (flags // 2 % 2).astype('O') + (flags % 2).astype('O')


### PR DESCRIPTION
## Description
* Avoid redundant calls to `get_data`
* Avoid pandas conversion when converting the `flags` field to a binary number.


## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
