### PR TITLE
Suppress spurious socket error messages from `GenerateVizFramesStage`  on shutdown

### DIFF
--- a/examples/developer_guide/2_2_rabbitmq/README.md
+++ b/examples/developer_guide/2_2_rabbitmq/README.md
@@ -44,6 +44,7 @@ pip install -r examples/developer_guide/2_2_rabbitmq/requirements.txt
 ## Launch the reader
 In a second terminal from the root of the Morpheus repo execute:
 ```bash
+export MORPHEUS_ROOT=$(pwd)
 python examples/developer_guide/2_2_rabbitmq/read_simple.py
 ```
 

--- a/examples/developer_guide/4_rabbitmq_cpp_stage/README.md
+++ b/examples/developer_guide/4_rabbitmq_cpp_stage/README.md
@@ -58,6 +58,7 @@ The image can be verified with the web management console by opening http://loca
 ## Launch the reader
 In a second terminal from the root of the Morpheus repo execute:
 ```bash
+export MORPHEUS_ROOT=$(pwd)
 python examples/developer_guide/4_rabbitmq_cpp_stage/src/read_simple.py
 ```
 
@@ -68,6 +69,7 @@ If no exchange named 'logs' exists in RabbitMQ it will be created.
 ## Launch the writer
 In a third terminal from the root of the Morpheus repo execute:
 ```bash
+export MORPHEUS_ROOT=$(pwd)
 python examples/developer_guide/4_rabbitmq_cpp_stage/src/write_simple.py
 ```
 

--- a/python/morpheus/morpheus/stages/postprocess/generate_viz_frames_stage.py
+++ b/python/morpheus/morpheus/stages/postprocess/generate_viz_frames_stage.py
@@ -25,7 +25,7 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import websockets.legacy.server
-from websockets.server import serve
+from websockets.server import serve  # pylint: disable=no-name-in-module
 
 from morpheus.cli.register_stage import register_stage
 from morpheus.config import Config
@@ -207,7 +207,9 @@ class GenerateVizFramesStage(GpuAndCpuMixin, PassThruTypeMixin, SinglePortStage)
                 except Closed:
                     break
                 except Exception as ex:
-                    logger.exception("Error occurred trying to send message over socket", exc_info=ex)
+                    if not self._server_close_event.is_set():
+                        # Don't log if we are shutting down
+                        logger.exception("Error occurred trying to send message over socket", exc_info=ex)
 
             logger.info("Disconnected from: %s:%s", *websocket.remote_address)
 


### PR DESCRIPTION
## Description
* Don't log error messages if `_server_close_event` has already been set.
* Unrelated documentation improvement for the RabbitMQ examples to ensue the `MORPHEUS_ROOT` environment variable is set.

Closes #2135

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
