### PR TITLE
Fix output directory for `gnn_fraud_detection_pipeline` example

### DIFF
--- a/examples/gnn_fraud_detection_pipeline/README.md
+++ b/examples/gnn_fraud_detection_pipeline/README.md
@@ -134,5 +134,5 @@ morpheus --log_level INFO \
 	gnn-fraud-classification --model_xgb_file examples/gnn_fraud_detection_pipeline/model/xgb.pt \
 	monitor --description "Add classification rate" \
 	serialize \
-	to-file --filename "gnn_fraud_detection_cli_output.csv" --overwrite
+	to-file --filename ".tmp/output/gnn_fraud_detection_cli_output.csv" --overwrite
 ```


### PR DESCRIPTION
## Description
* Set the output directory to `.tmp/output` to match other examples.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
