### PR TITLE
Fix file paths in `log_parsing` CLI example

### DIFF
--- a/examples/log_parsing/README.md
+++ b/examples/log_parsing/README.md
@@ -111,14 +111,14 @@ morpheus --log_level INFO \
 	--plugin "postprocessing" \
 	run --pipeline_batch_size 1024 --model_max_batch_size 32  \
 	pipeline-nlp \
-	from-file --filename ./models/datasets/validation-data/log-parsing-validation-data-input.csv  \
+	from-file --filename ./examples/data/log-parsing-validation-data-input.csv \
 	deserialize \
-	preprocess --vocab_hash_file data/bert-base-cased-hash.txt --stride 64 --column=raw \
+	preprocess --vocab_hash_file=data/bert-base-cased-hash.txt --stride 64 --column=raw \
 	monitor --description "Preprocessing rate" \
 	inf-logparsing --model_name log-parsing-onnx --server_url localhost:8001 --force_convert_inputs=True \
 	monitor --description "Inference rate" --unit inf \
-	log-postprocess --vocab_path ./models/training-tuning-scripts/sid-models/resources/bert-base-cased-vocab.txt \
-		--model_config_path=./models/log-parsing-models/log-parsing-config-20220418.json \
+	log-postprocess --vocab_path=data/bert-base-cased-vocab.txt \
+		--model_config_path=./examples/data/log-parsing-config-20220418.json \
 	to-file --filename .tmp/output/log-parsing-cli-output.jsonlines --overwrite  \
 	monitor --description "Postprocessing rate"
 ```

--- a/examples/log_parsing/postprocessing.py
+++ b/examples/log_parsing/postprocessing.py
@@ -25,6 +25,7 @@ from mrc.core import operators as ops
 import cudf
 
 from morpheus.cli.register_stage import register_stage
+from morpheus.cli.utils import MorpheusRelativePath
 from morpheus.config import Config
 from morpheus.config import PipelineModes
 from morpheus.messages import ControlMessage
@@ -35,7 +36,16 @@ from morpheus.pipeline.stage_schema import StageSchema
 logger = logging.getLogger(f"morpheus.{__name__}")
 
 
-@register_stage("log-postprocess", modes=[PipelineModes.NLP])
+@register_stage("log-postprocess",
+                modes=[PipelineModes.NLP],
+                option_args={
+                    "vocab_path": {
+                        "type": MorpheusRelativePath(exists=True, dir_okay=False, resolve_path=True)
+                    },
+                    "model_config_path": {
+                        "type": MorpheusRelativePath(exists=True, dir_okay=False, resolve_path=True)
+                    }
+                })
 class LogParsingPostProcessingStage(SinglePortStage):
 
     def __init__(self, c: Config, vocab_path: pathlib.Path, model_config_path: pathlib.Path):


### PR DESCRIPTION
## Description
* Fix file paths for CLI example to not use the models dir, as this directory doesn't exist in the release container
* Use the MorpheusRelativePath to resolve the vocab_path and model_config_path CLI arguments

Closes #2144

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
