### PR TITLE
Work-around glog dependency issues for C++ examples

### DIFF
--- a/examples/developer_guide/3_simple_cpp_stage/CMakeLists.txt
+++ b/examples/developer_guide/3_simple_cpp_stage/CMakeLists.txt
@@ -43,6 +43,7 @@ set(OPTION_PREFIX "MORPHEUS")
 cmake_policy(SET CMP0144 NEW)
 
 find_package(morpheus REQUIRED)
+find_package(glog REQUIRED) # work-around for #2149
 
 morpheus_utils_initialize_cpm(MORPHEUS_CACHE_DIR)
 

--- a/examples/developer_guide/3_simple_cpp_stage/src/simple_cpp_stage/_lib/CMakeLists.txt
+++ b/examples/developer_guide/3_simple_cpp_stage/src/simple_cpp_stage/_lib/CMakeLists.txt
@@ -24,6 +24,7 @@ morpheus_add_pybind11_module(pass_thru_cpp
     morpheus
     CUDA::nvtx3
     cudf::cudf
+    glog::glog
 )
 
 list(POP_BACK CMAKE_MESSAGE_CONTEXT)

--- a/examples/developer_guide/4_rabbitmq_cpp_stage/CMakeLists.txt
+++ b/examples/developer_guide/4_rabbitmq_cpp_stage/CMakeLists.txt
@@ -43,6 +43,7 @@ set(OPTION_PREFIX "MORPHEUS")
 cmake_policy(SET CMP0144 NEW)
 
 find_package(morpheus REQUIRED)
+find_package(glog REQUIRED)
 
 morpheus_utils_initialize_cpm(MORPHEUS_CACHE_DIR)
 

--- a/examples/developer_guide/4_rabbitmq_cpp_stage/src/rabbitmq_cpp_stage/_lib/CMakeLists.txt
+++ b/examples/developer_guide/4_rabbitmq_cpp_stage/src/rabbitmq_cpp_stage/_lib/CMakeLists.txt
@@ -25,6 +25,7 @@ morpheus_add_pybind11_module(rabbitmq_cpp_stage
     morpheus
     CUDA::nvtx3
     cudf::cudf
+    glog::glog
     rabbitmq
     SimpleAmqpClient
 )


### PR DESCRIPTION
## Description
* Explicitly call `find_package(glog REQUIRED)` and link to `glog::glog` in C++ examples
* This is a work-around for issue #2149

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
