### PR TITLE
Fix version incompatibility causing `Kafka` service fails to launch

### DIFF
--- a/ci/conda/recipes/morpheus-libs/meta.yaml
+++ b/ci/conda/recipes/morpheus-libs/meta.yaml
@@ -102,13 +102,14 @@ outputs:
         - python-confluent-kafka >=1.9.2,<1.10.0a0
         - python-graphviz
         - rapids-dask-dependency {{ rapids_version }} # provides dask and distributed
-        - requests
+        - requests<2.29.0
         - requests-cache =1.1.*
         - scikit-learn =1.3.2.*
         - sqlalchemy <2.0 # 2.0 is incompatible with pandas=1.3
         - tqdm =4.*
         - tritonclient =2.34.*
         - typing_utils =0.1.*
+        - urllib3<2.0
         - watchdog =3.0.*
         - websockets
     test:

--- a/ci/conda/recipes/morpheus/meta.yaml
+++ b/ci/conda/recipes/morpheus/meta.yaml
@@ -108,13 +108,14 @@ outputs:
         - python-confluent-kafka >=1.9.2,<1.10.0a0
         - python-graphviz
         - rapids-dask-dependency {{ rapids_version }} # provides dask and distributed
-        - requests
+        - requests<2.29.0
         - requests-cache =1.1.*
         - scikit-learn =1.3.2.*
         - sqlalchemy <2.0 # 2.0 is incompatible with pandas=1.3
         - tqdm =4.*
         - tritonclient =2.34.*
         - typing_utils =0.1.*
+        - urllib3<2.0
         - watchdog =3.0.*
         - websockets
     test:

--- a/conda/environments/all_cuda-125_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-125_arch-aarch64.yaml
@@ -101,9 +101,9 @@ dependencies:
 - rapidjson=1.1.0
 - rapids-dask-dependency=24.10
 - rdma-core>=48
-- requests
 - requests-cache=1.1
 - requests-toolbelt=1.0
+- requests<2.29.0
 - s3fs=2024.10
 - scikit-build=0.17.6
 - scikit-learn=1.3.2
@@ -115,6 +115,7 @@ dependencies:
 - transformers=4.36.2
 - tritonclient=2.34
 - typing_utils=0.1
+- urllib3<2.0
 - versioneer
 - versioneer-518
 - watchdog=3.0

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -104,9 +104,9 @@ dependencies:
 - rapidjson=1.1.0
 - rapids-dask-dependency=24.10
 - rdma-core>=48
-- requests
 - requests-cache=1.1
 - requests-toolbelt=1.0
+- requests<2.29.0
 - s3fs=2024.10
 - scikit-build=0.17.6
 - scikit-learn=1.3.2
@@ -118,6 +118,7 @@ dependencies:
 - transformers=4.36.2
 - tritonclient=2.34
 - typing_utils=0.1
+- urllib3<2.0
 - vale-styles-microsoft
 - vale-styles-write-good
 - vale=3.7

--- a/conda/environments/dev_cuda-125_arch-aarch64.yaml
+++ b/conda/environments/dev_cuda-125_arch-aarch64.yaml
@@ -85,8 +85,8 @@ dependencies:
 - rapidjson=1.1.0
 - rapids-dask-dependency=24.10
 - rdma-core>=48
-- requests
 - requests-cache=1.1
+- requests<2.29.0
 - scikit-build=0.17.6
 - scikit-learn=1.3.2
 - sphinx
@@ -96,6 +96,7 @@ dependencies:
 - tqdm=4
 - tritonclient=2.34
 - typing_utils=0.1
+- urllib3<2.0
 - versioneer
 - versioneer-518
 - watchdog=3.0

--- a/conda/environments/dev_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/dev_cuda-125_arch-x86_64.yaml
@@ -87,8 +87,8 @@ dependencies:
 - rapidjson=1.1.0
 - rapids-dask-dependency=24.10
 - rdma-core>=48
-- requests
 - requests-cache=1.1
+- requests<2.29.0
 - scikit-build=0.17.6
 - scikit-learn=1.3.2
 - sphinx
@@ -98,6 +98,7 @@ dependencies:
 - tqdm=4
 - tritonclient=2.34
 - typing_utils=0.1
+- urllib3<2.0
 - vale-styles-microsoft
 - vale-styles-write-good
 - vale=3.7

--- a/conda/environments/examples_cuda-125_arch-aarch64.yaml
+++ b/conda/environments/examples_cuda-125_arch-aarch64.yaml
@@ -49,9 +49,9 @@ dependencies:
 - python-graphviz
 - python=3.10
 - rapids-dask-dependency=24.10
-- requests
 - requests-cache=1.1
 - requests-toolbelt=1.0
+- requests<2.29.0
 - s3fs=2024.10
 - scikit-learn=1.3.2
 - sqlalchemy<2.0
@@ -59,6 +59,7 @@ dependencies:
 - transformers=4.36.2
 - tritonclient=2.34
 - typing_utils=0.1
+- urllib3<2.0
 - watchdog=3.0
 - websockets
 - pip:

--- a/conda/environments/examples_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/examples_cuda-125_arch-x86_64.yaml
@@ -51,9 +51,9 @@ dependencies:
 - python-graphviz
 - python=3.10
 - rapids-dask-dependency=24.10
-- requests
 - requests-cache=1.1
 - requests-toolbelt=1.0
+- requests<2.29.0
 - s3fs=2024.10
 - scikit-learn=1.3.2
 - sqlalchemy<2.0
@@ -61,6 +61,7 @@ dependencies:
 - transformers=4.36.2
 - tritonclient=2.34
 - typing_utils=0.1
+- urllib3<2.0
 - watchdog=3.0
 - websockets
 - pip:

--- a/conda/environments/runtime_cuda-125_arch-aarch64.yaml
+++ b/conda/environments/runtime_cuda-125_arch-aarch64.yaml
@@ -37,13 +37,14 @@ dependencies:
 - python-graphviz
 - python=3.10
 - rapids-dask-dependency=24.10
-- requests
 - requests-cache=1.1
+- requests<2.29.0
 - scikit-learn=1.3.2
 - sqlalchemy<2.0
 - tqdm=4
 - tritonclient=2.34
 - typing_utils=0.1
+- urllib3<2.0
 - watchdog=3.0
 - websockets
 - pip:

--- a/conda/environments/runtime_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/runtime_cuda-125_arch-x86_64.yaml
@@ -37,13 +37,14 @@ dependencies:
 - python-graphviz
 - python=3.10
 - rapids-dask-dependency=24.10
-- requests
 - requests-cache=1.1
+- requests<2.29.0
 - scikit-learn=1.3.2
 - sqlalchemy<2.0
 - tqdm=4
 - tritonclient=2.34
 - typing_utils=0.1
+- urllib3<2.0
 - watchdog=3.0
 - websockets
 - pip:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -402,13 +402,14 @@ dependencies:
           - python-graphviz
           - pluggy=1.3
           - rapids-dask-dependency=24.10 # provides dask and distributed
-          - requests
+          - requests<2.29.0
           - requests-cache=1.1
           - scikit-learn=1.3.2
           - sqlalchemy<2.0 # 2.0 is incompatible with pandas=1.3
           - tqdm=4
           - tritonclient=2.34
           - typing_utils=0.1
+          - urllib3<2.0
           - watchdog=3.0
           - websockets
           - pip

--- a/docs/source/developer_guide/contributing.md
+++ b/docs/source/developer_guide/contributing.md
@@ -314,6 +314,12 @@ Launching a full production Kafka cluster is outside the scope of this project; 
       $ echo $KAFKA_ADVERTISED_HOST_NAME
       "172.17.0.1"
       ```
+   1. Change the value of `DOCKER_API_VERSION` to an updated version. The default version `1.22` is no longer supported by Kafka. The supported version can be obtained by running `docker version` command and looking into `API version` field. For example, if the `API version` of the machine is `1.47`, the config should be updated to:
+
+      ```yaml
+      environment:
+         DOCKER_API_VERSION: 1.47
+      ```
 6. Launch Kafka with 3 instances:
 
    ```bash
@@ -356,7 +362,7 @@ Launching a full production Kafka cluster is outside the scope of this project; 
    ```
    **Note:** If you are using `to-kafka`, ensure your output topic is also created.
 
-9. Generate input messages
+9.  Generate input messages
    1. In order for Morpheus to read from Kafka, messages need to be published to the cluster. You can use the `kafka-console-producer.sh` script to load data:
 
       ```bash


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
This issue is caused by multiple version incompatibilities.

- The `DOCKER_API_VERSION` IN `docker-compose.yml` of `kafka-docker` is out of date. This prevents the kafka server from launching. Below is the error message from docker:
`Error response from daemon: {"message":"client version 1.22 is too old. Minimum supported API version is 1.24, please upgrade your client to a newer version"}`
 Thus the `DOCKER_API_VERSION` needs to be updated manually.

- After launching the `kafka` service, there are two exceptions being thrown when the LLM agent pipeline connecting to `kafka` service. According to https://stackoverflow.com/questions/78518146/docker-compose-fails-with-error-urllib3-exceptions-urlschemeunknown-not-suppor and https://github.com/google-deepmind/alphafold/issues/867#issuecomment-1984260145, those are caused by conda package version incompatibility of `requests` and `urllib3`. Those need to be pinned to a lower version to avoid the issue.

Closes #2152 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
