### PR TITLE
Document known Arm64 issues and work-around PyTorch installation issues for DFP

### DIFF
--- a/docs/source/extra_info/known_issues.md
+++ b/docs/source/extra_info/known_issues.md
@@ -19,6 +19,7 @@ limitations under the License.
 
 - `vdb_upload` example pipeline triggers an internal error in Triton ([#1649](https://github.com/nv-morpheus/Morpheus/issues/1649))
 - `ransomware_detection` example pipeline occasionally logs a `distributed.comm.core.CommClosedError` error during shutdown ([#2026](https://github.com/nv-morpheus/Morpheus/issues/2026)).
+- Arm64 users need to install CUDA enabled PyTorch by hand ([#2095](https://github.com/nv-morpheus/Morpheus/issues/2095))
 - `abp_pcap_detection` pipeline running slowly on AArch64 ([#2120](https://github.com/nv-morpheus/Morpheus/issues/2120))
 - LLM `vdb_upload` and `rag` pipelines not supported on AArch64 ([#2122](https://github.com/nv-morpheus/Morpheus/issues/2122))
 - `gnn_fraud_detection_pipeline` not working on AArch64 ([#2123](https://github.com/nv-morpheus/Morpheus/issues/2123))

--- a/docs/source/extra_info/known_issues.md
+++ b/docs/source/extra_info/known_issues.md
@@ -20,7 +20,7 @@ limitations under the License.
 - `vdb_upload` example pipeline triggers an internal error in Triton ([#1649](https://github.com/nv-morpheus/Morpheus/issues/1649))
 - `ransomware_detection` example pipeline occasionally logs a `distributed.comm.core.CommClosedError` error during shutdown ([#2026](https://github.com/nv-morpheus/Morpheus/issues/2026)).
 - Arm64 users need to install CUDA enabled PyTorch by hand ([#2095](https://github.com/nv-morpheus/Morpheus/issues/2095))
-- Performance issues were observed running the `abp_pcap_detection` and `ransomware_detection` pipelines on AArch64 ([#2120](https://github.com/nv-morpheus/Morpheus/issues/2120)) & ([#2124](https://github.com/nv-morpheus/Morpheus/issues/2124)) on Ubuntu 22.04, Arm64 users should consider upgrading to Ubuntu 24.04.
+- Performance issues were observed running the `abp_pcap_detection` and `ransomware_detection` pipelines on AArch64 ([#2120](https://github.com/nv-morpheus/Morpheus/issues/2120)) & ([#2124](https://github.com/nv-morpheus/Morpheus/issues/2124)) on Ubuntu 22.04. Arm64 users should consider upgrading to Ubuntu 24.04.
 - LLM `vdb_upload` and `rag` pipelines not supported on AArch64 ([#2122](https://github.com/nv-morpheus/Morpheus/issues/2122))
 - `gnn_fraud_detection_pipeline` not working on AArch64 ([#2123](https://github.com/nv-morpheus/Morpheus/issues/2123))
 - DFP visualization fails to install on AArch64 ([#2125](https://github.com/nv-morpheus/Morpheus/issues/2125))

--- a/docs/source/extra_info/known_issues.md
+++ b/docs/source/extra_info/known_issues.md
@@ -20,10 +20,9 @@ limitations under the License.
 - `vdb_upload` example pipeline triggers an internal error in Triton ([#1649](https://github.com/nv-morpheus/Morpheus/issues/1649))
 - `ransomware_detection` example pipeline occasionally logs a `distributed.comm.core.CommClosedError` error during shutdown ([#2026](https://github.com/nv-morpheus/Morpheus/issues/2026)).
 - Arm64 users need to install CUDA enabled PyTorch by hand ([#2095](https://github.com/nv-morpheus/Morpheus/issues/2095))
-- `abp_pcap_detection` pipeline running slowly on AArch64 ([#2120](https://github.com/nv-morpheus/Morpheus/issues/2120))
+- Performance issues were observed running the `abp_pcap_detection` and `ransomware_detection` pipelines on AArch64 ([#2120](https://github.com/nv-morpheus/Morpheus/issues/2120)) & ([#2124](https://github.com/nv-morpheus/Morpheus/issues/2124)) on Ubuntu 22.04, Arm64 users should consider upgrading to Ubuntu 24.04.
 - LLM `vdb_upload` and `rag` pipelines not supported on AArch64 ([#2122](https://github.com/nv-morpheus/Morpheus/issues/2122))
 - `gnn_fraud_detection_pipeline` not working on AArch64 ([#2123](https://github.com/nv-morpheus/Morpheus/issues/2123))
-- `ransomware_detection` pipeline running slowly on AArch64 ([#2124](https://github.com/nv-morpheus/Morpheus/issues/2124))
 - DFP visualization fails to install on AArch64 ([#2125](https://github.com/nv-morpheus/Morpheus/issues/2125))
 
 Refer to [open issues in the Morpheus project](https://github.com/nv-morpheus/Morpheus/issues)

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -34,6 +34,11 @@ More advanced users, or those who are interested in using the latest pre-release
 - [The NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#installation)
 - [NVIDIA Triton Inference Server](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tritonserver) `24.09` or higher
 
+> **Note for Arm64/AArch64 users:**
+>
+> In testing performance issues were observed running on Ubuntu 22.04, upgrating to Ubuntu 24.04 resolved the issues, Arm64 users should consider upgrading to the latest release of their Linux distribution.
+> In addition to this, Arm64 users should be aware that most but not all Morpheus pipelines are supported on Arm64. Refer to the [Known Issues](./extra_info/known_issues.md) document for more information.
+
 > **Note about Docker:**
 >
 > The Morpheus documentation and examples assume that the [Manage Docker as a non-root user](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user) post-installation step has been performed, allowing Docker commands to be executed by a non-root user. This is not strictly necessary as long as the current user has `sudo` privileges to execute Docker commands.

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -36,7 +36,7 @@ More advanced users, or those who are interested in using the latest pre-release
 
 > **Note for Arm64/AArch64 users:**
 >
-> In testing performance issues were observed running on Ubuntu 22.04, switching to Ubuntu 24.04 resolved the issues, Arm64 users should consider upgrading to the latest release of their Linux distribution.
+> In testing, performance issues were observed running on Ubuntu 22.04 and switching to Ubuntu 24.04 resolved the issues. Arm64 users should consider upgrading to the latest release of their Linux distribution.
 > In addition to this, Arm64 users should be aware that most but not all Morpheus pipelines are supported on Arm64. Refer to the [Known Issues](./extra_info/known_issues.md) document for more information.
 
 > **Note about Docker:**

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -36,7 +36,7 @@ More advanced users, or those who are interested in using the latest pre-release
 
 > **Note for Arm64/AArch64 users:**
 >
-> In testing performance issues were observed running on Ubuntu 22.04, upgrating to Ubuntu 24.04 resolved the issues, Arm64 users should consider upgrading to the latest release of their Linux distribution.
+> In testing performance issues were observed running on Ubuntu 22.04, switching to Ubuntu 24.04 resolved the issues, Arm64 users should consider upgrading to the latest release of their Linux distribution.
 > In addition to this, Arm64 users should be aware that most but not all Morpheus pipelines are supported on Arm64. Refer to the [Known Issues](./extra_info/known_issues.md) document for more information.
 
 > **Note about Docker:**

--- a/examples/digital_fingerprinting/production/Dockerfile
+++ b/examples/digital_fingerprinting/production/Dockerfile
@@ -50,6 +50,10 @@ COPY . /workspace/examples/digital_fingerprinting/production/
 # Create a conda env with morpheus-dfp and any additional dependencies needed to run the examples
 RUN conda env create --solver=libmamba -y --name morpheus-dfp --file ./conda/environments/dfp_example_cuda-125_arch-$(arch).yaml
 
+# Work-around Torch issues https://github.com/nv-morpheus/Morpheus/issues/2095
+RUN source activate morpheus-dfp && \
+    pip install --index-url https://download.pytorch.org/whl/cu124 torch==2.4.0
+
 ENTRYPOINT [ "/opt/conda/envs/morpheus-dfp/bin/tini", "--", "/workspace/examples/digital_fingerprinting/production/docker/entrypoint.sh" ]
 
 SHELL ["/bin/bash", "-c"]

--- a/examples/digital_fingerprinting/production/Dockerfile
+++ b/examples/digital_fingerprinting/production/Dockerfile
@@ -52,7 +52,7 @@ RUN conda env create --solver=libmamba -y --name morpheus-dfp --file ./conda/env
 
 # Work-around Torch issues https://github.com/nv-morpheus/Morpheus/issues/2095
 RUN source activate morpheus-dfp && \
-    pip install --index-url https://download.pytorch.org/whl/cu124 torch==2.4.0
+    pip install --force-reinstall --index-url https://download.pytorch.org/whl/cu124 torch==2.4.0
 
 ENTRYPOINT [ "/opt/conda/envs/morpheus-dfp/bin/tini", "--", "/workspace/examples/digital_fingerprinting/production/docker/entrypoint.sh" ]
 

--- a/examples/digital_fingerprinting/production/Dockerfile
+++ b/examples/digital_fingerprinting/production/Dockerfile
@@ -50,7 +50,7 @@ COPY . /workspace/examples/digital_fingerprinting/production/
 # Create a conda env with morpheus-dfp and any additional dependencies needed to run the examples
 RUN conda env create --solver=libmamba -y --name morpheus-dfp --file ./conda/environments/dfp_example_cuda-125_arch-$(arch).yaml
 
-# Work-around Torch issues https://github.com/nv-morpheus/Morpheus/issues/2095
+# Work-around PyTorch instalation issue https://github.com/nv-morpheus/Morpheus/issues/2095
 RUN source activate morpheus-dfp && \
     pip install --force-reinstall --index-url https://download.pytorch.org/whl/cu124 torch==2.4.0
 

--- a/examples/digital_fingerprinting/production/grafana/README.md
+++ b/examples/digital_fingerprinting/production/grafana/README.md
@@ -65,26 +65,26 @@ More information about Loki Python logging can be found [here](https://pypi.org/
 
 ## Start Grafana and Loki services:
 
-To start Grafana and Loki, run the following command on host in `examples/digital_fingerprinting/production`:
+To start Grafana and Loki, from the root of the Morpheus repo:
 ```bash
+cd examples/digital_fingerprinting/production
+docker compose build
 docker compose up grafana
 ```
 
 ## Run Azure DFP Training
 
-Start `bash` shell in `morpheus_pipeline` container, run the following command on host in `examples/digital_fingerprinting/production`:
+Open a second terminal and start the `bash` shell in `morpheus_pipeline` container, from the root of the Morpheus repo:
 
 ```bash
+cd examples/digital_fingerprinting/production
 docker compose run --rm morpheus_pipeline bash
 ```
 
-Set `PYTHONPATH` environment variable to allow import of production DFP Morpheus stages:
-```
-export PYTHONPATH=/workspace/examples/digital_fingerprinting/production/morpheus
-```
-
-Run the following in the container to train the Azure models.
+From within the `morpheus_pipeline` container, set `PYTHONPATH` environment variable to allow import of production DFP Morpheus stages, and then begin training the Azure models.
 ```bash
+export PYTHONPATH=/workspace/examples/digital_fingerprinting/production/morpheus
+
 cd /workspace/examples/digital_fingerprinting/production/grafana
 python run.py --log_level DEBUG --train_users generic --start_time "2022-08-01" --input_file="../../../data/dfp/azure-training-data/AZUREAD_2022*.json"
 ```


### PR DESCRIPTION
## Description
* Document Arm64 performance issues on older Linux Kernels
* Manually install PyTorch in the DFP container allowing Arm64 users to run the pipeline work-around issue #2095 (fix slated for PyTorch 2.6 / Morpheus 25.06).

Closes #2120
Closes #2124

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
