### PR TITLE
Update Triton Server container to v25.01

### DIFF
--- a/ci/release/download_deps.py
+++ b/ci/release/download_deps.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ci/release/download_deps.py
+++ b/ci/release/download_deps.py
@@ -99,6 +99,7 @@ KNOWN_GITHUB_URLS = {  # <package>: <github repo>, please keep sorted
     'pytorch': 'https://github.com/pytorch/pytorch',
     'tqdm': 'https://github.com/tqdm/tqdm',
     'typing_utils': 'https://github.com/bojiang/typing_utils',
+    'urllib3': 'https://github.com/urllib3/urllib3',
     'versioneer-518': 'https://github.com/python-versioneer/versioneer-518',
     'watchdog': 'https://github.com/gorakhargosh/watchdog',
     'websockets': 'https://github.com/python-websockets/websockets',
@@ -112,9 +113,8 @@ KNOWN_GITLAB_URLS = {
 OTHER_REPOS: dict[str, PACKAGE_TO_URL_FN_T] = {
     # While boost is available on GitHub, the sub-libraries are in separate repos.
     'beautifulsoup4':
-        lambda name,
-        ver: ("https://www.crummy.com/software/BeautifulSoup/bs4/download/"
-              f"{'.'.join(ver.split('.')[:-1])}/{name}-{ver}.tar.gz"),
+        lambda name, ver: ("https://www.crummy.com/software/BeautifulSoup/bs4/download/"
+                           f"{'.'.join(ver.split('.')[:-1])}/{name}-{ver}.tar.gz"),
 }
 
 # Please keep sorted
@@ -164,6 +164,7 @@ GIT_TAG_FORMAT = {  # any packages not in this dict are assumned to have the TAG
     'python-versioneer': TAG_BARE,
     'scikit-learn': TAG_BARE,
     'sqlalchemy': lambda ver: f"rel_{ver.replace('.', '_')}",
+    'urllib3': TAG_BARE,
     'websockets': TAG_BARE,
 }
 

--- a/models/docker/Dockerfile
+++ b/models/docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 ARG FROM_IMAGE="nvcr.io/nvidia/tritonserver"
-ARG FROM_IMAGE_TAG="24.09-py3"
+ARG FROM_IMAGE_TAG="25.01-py3"
 ARG MORPHEUS_ROOT_HOST=.
 FROM --platform=$TARGETPLATFORM ${FROM_IMAGE}:${FROM_IMAGE_TAG} AS base
 

--- a/models/docker/build_container.sh
+++ b/models/docker/build_container.sh
@@ -39,7 +39,7 @@ SHORT_VERSION=${MAJOR_VERSION}.${MINOR_VERSION}
 
 # Build args
 FROM_IMAGE=${FROM_IMAGE:-"nvcr.io/nvidia/tritonserver"}
-FROM_IMAGE_TAG=${FROM_IMAGE_TAG:-"24.09-py3"}
+FROM_IMAGE_TAG=${FROM_IMAGE_TAG:-"25.01-py3"}
 
 DOCKER_IMAGE_NAME=${DOCKER_IMAGE_NAME:-"nvcr.io/nvidia/morpheus/morpheus-tritonserver-models"}
 DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG:-"${SHORT_VERSION}"}


### PR DESCRIPTION
## Description
* v25.01 contains a fix for [CVE-2022-29501](https://ubuntu.com/security/CVE-2022-29501)
* Add `urllib3` to `ci/release/download_deps.py` (unrelated fix)


## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
