### PR TITLE
Replace `conda-mambabuild` with `conda-build`

### DIFF
--- a/ci/conda/recipes/run_conda_build.sh
+++ b/ci/conda/recipes/run_conda_build.sh
@@ -105,9 +105,6 @@ if hasArg upload; then
    fi
 fi
 
-# Some default args
-CONDA_ARGS_ARRAY+=("--use-local")
-
 if [[ "${CONDA_COMMAND}" == "mambabuild" || "${CONDA_COMMAND}" == "build" ]]; then
    # Remove the timestamp from the work folder to allow caching to work better
    CONDA_ARGS_ARRAY+=("--build-id-pat" "{n}-{v}")

--- a/ci/conda/recipes/run_conda_build.sh
+++ b/ci/conda/recipes/run_conda_build.sh
@@ -38,7 +38,7 @@ export x="\033[0m"
 export CONDA_ALWAYS_YES=true
 
 # Change this to switch between build/mambabuild/debug
-export CONDA_COMMAND=${CONDA_COMMAND:-"mambabuild"}
+export CONDA_COMMAND=${CONDA_COMMAND:-"build"}
 
 # Get the path to the morpheus git folder
 export MORPHEUS_ROOT=${MORPHEUS_ROOT:-$(git rev-parse --show-toplevel)}


### PR DESCRIPTION
## Description

These are now equivalent in behavior. However support for `conda-mambabuild` is being dropped. So switch to `conda-build`.

xref: https://github.com/rapidsai/build-planning/issues/149

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
