### PR TITLE
Invoke `CudfHelper::load()` from the main Python thread

### DIFF
--- a/python/morpheus/morpheus/_lib/common/__init__.pyi
+++ b/python/morpheus/morpheus/_lib/common/__init__.pyi
@@ -20,6 +20,7 @@ __all__ = [
     "Tensor",
     "TypeId",
     "determine_file_type",
+    "load_cudf_helper",
     "read_file_to_df",
     "typeid_is_fully_supported",
     "typeid_to_numpy_str",
@@ -309,6 +310,8 @@ def determine_file_type(filename: os.PathLike) -> FileTypes:
     pass
 @typing.overload
 def determine_file_type(filename: str) -> FileTypes:
+    pass
+def load_cudf_helper() -> None:
     pass
 def read_file_to_df(filename: str, file_type: FileTypes = FileTypes.Auto) -> object:
     pass

--- a/python/morpheus/morpheus/_lib/common/module.cpp
+++ b/python/morpheus/morpheus/_lib/common/module.cpp
@@ -28,6 +28,7 @@
 #include "morpheus/objects/filter_source.hpp"
 #include "morpheus/objects/tensor_object.hpp"  // for TensorObject
 #include "morpheus/objects/wrapped_tensor.hpp"
+#include "morpheus/utilities/cudf_util.hpp"
 #include "morpheus/utilities/http_server.hpp"
 #include "morpheus/version.hpp"
 
@@ -191,6 +192,10 @@ PYBIND11_MODULE(common, _module)
         .value("reverse", indicators::FontStyle::reverse)
         .value("concealed", indicators::FontStyle::concealed)
         .value("crossed", indicators::FontStyle::crossed);
+
+    _module.def("load_cudf_helper", []() {
+        CudfHelper::load();
+    });
 
     _module.attr("__version__") =
         MRC_CONCAT_STR(morpheus_VERSION_MAJOR << "." << morpheus_VERSION_MINOR << "." << morpheus_VERSION_PATCH);

--- a/python/morpheus/morpheus/_lib/include/morpheus/utilities/cudf_util.hpp
+++ b/python/morpheus/morpheus/_lib/include/morpheus/utilities/cudf_util.hpp
@@ -37,7 +37,7 @@ namespace morpheus {
  * the actual generated cython calls. The cython implementation in 'cudf_helpers_api.h' can only appear in the
  * translation unit for the pybind module declaration. These functions should be considered de
  */
-struct CudfHelper
+struct MORPHEUS_EXPORT CudfHelper
 {
   public:
     static void load();

--- a/python/morpheus/morpheus/_lib/include/morpheus/utilities/cudf_util.hpp
+++ b/python/morpheus/morpheus/_lib/include/morpheus/utilities/cudf_util.hpp
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "morpheus/export.h"  // for MORPHEUS_EXPORT
 #include "morpheus/objects/table_info.hpp"
 #include "morpheus/objects/table_info_data.hpp"
 

--- a/python/morpheus/morpheus/_lib/src/io/deserializers.cpp
+++ b/python/morpheus/morpheus/_lib/src/io/deserializers.cpp
@@ -98,6 +98,7 @@ cudf::io::table_with_metadata load_table_from_file(const std::string& filename,
 
 pybind11::object read_file_to_df(const std::string& filename, FileTypes file_type)
 {
+    CudfHelper::load();
     auto table          = load_table_from_file(filename, file_type);
     int index_col_count = prepare_df_index(table);
 

--- a/python/morpheus/morpheus/_lib/src/io/serializers.cpp
+++ b/python/morpheus/morpheus/_lib/src/io/serializers.cpp
@@ -252,6 +252,7 @@ void SerializersProxy::write_df_to_file(pybind11::object df,
                                         FileTypes file_type,
                                         const py::kwargs& kwargs)
 {
+    CudfHelper::load();
     if (file_type == FileTypes::Auto)
     {
         file_type = determine_file_type(filename);  // throws if it is unable to determine the type

--- a/python/morpheus/morpheus/_lib/src/utilities/cudf_util.cpp
+++ b/python/morpheus/morpheus/_lib/src/utilities/cudf_util.cpp
@@ -60,14 +60,12 @@ void CudfHelper::load()
 
 pybind11::object proxy_table_from_table_with_metadata(cudf::io::table_with_metadata&& table, int index_col_count)
 {
-    CudfHelper::load();
     return pybind11::reinterpret_steal<pybind11::object>(
         (PyObject*)make_table_from_table_with_metadata(std::move(table), index_col_count));
 }
 
 morpheus::TableInfoData proxy_table_info_data_from_table(pybind11::object table)
 {
-    CudfHelper::load();
     return make_table_info_data_from_table(table.ptr());
 }
 
@@ -78,7 +76,6 @@ pybind11::object CudfHelper::table_from_table_with_metadata(cudf::io::table_with
 
 pybind11::object CudfHelper::table_from_table_info(const TableInfoBase& table_info)
 {
-    CudfHelper::load();
     // Get the table info data from the table_into
     auto table_info_data = table_info.get_data();
 

--- a/python/morpheus/morpheus/_lib/tests/test_utils/common.cpp
+++ b/python/morpheus/morpheus/_lib/tests/test_utils/common.cpp
@@ -23,6 +23,7 @@
 #include "morpheus/io/loaders/payload.hpp"
 #include "morpheus/io/loaders/rest.hpp"
 #include "morpheus/messages/meta.hpp"
+#include "morpheus/utilities/cudf_util.hpp"
 #include "morpheus/utilities/string_util.hpp"
 
 #include <cpython/initconfig.h>  // for PyStatus_Exception, PyConfig_Clear, PyConfig_InitPythonConfig
@@ -80,6 +81,7 @@ void TestWithPythonInterpreter::SetUp()
         false);
 
     pybind11::gil_scoped_acquire gil;
+    CudfHelper::load();
 }
 
 void TestWithPythonInterpreter::TearDown() {}

--- a/python/morpheus/morpheus/common/__init__.py
+++ b/python/morpheus/morpheus/common/__init__.py
@@ -25,6 +25,7 @@ from morpheus._lib.common import IndicatorsTextColor
 from morpheus._lib.common import Tensor
 from morpheus._lib.common import TypeId
 from morpheus._lib.common import determine_file_type
+from morpheus._lib.common import load_cudf_helper
 from morpheus._lib.common import read_file_to_df
 from morpheus._lib.common import typeid_is_fully_supported
 from morpheus._lib.common import typeid_to_numpy_str
@@ -39,6 +40,7 @@ __all__ = [
     "HttpServer",
     "IndicatorsFontStyle",
     "IndicatorsTextColor",
+    "load_cudf_helper",
     "read_file_to_df",
     "Tensor",
     "typeid_is_fully_supported",

--- a/python/morpheus/morpheus/pipeline/pipeline.py
+++ b/python/morpheus/morpheus/pipeline/pipeline.py
@@ -29,7 +29,9 @@ import networkx
 from tqdm import tqdm
 
 import morpheus.pipeline as _pipeline  # pylint: disable=cyclic-import
+from morpheus.common import load_cudf_helper
 from morpheus.config import Config
+from morpheus.config import ExecutionMode
 from morpheus.utils.type_utils import pretty_print_type_name
 
 logger = logging.getLogger(__name__)
@@ -293,6 +295,9 @@ class Pipeline():
         """
         assert self._state == PipelineState.INITIALIZED, "Pipeline can only be built once!"
         assert len(self._sources) > 0, "Pipeline must have a source stage"
+
+        if (self._execution_mode == ExecutionMode.GPU):
+            load_cudf_helper()
 
         self._pre_build()
 

--- a/python/morpheus/morpheus/stages/input/kafka_source_stage.py
+++ b/python/morpheus/morpheus/stages/input/kafka_source_stage.py
@@ -243,8 +243,7 @@ class KafkaSourceStage(PreallocatorMixin, GpuAndCpuMixin, SingleOutputSource):
 
             # Only use multiple progress engines with C++. The python implementation will duplicate messages with
             # multiple threads
-            # Work-around issue #2204
-            # source.launch_options.pe_count = self._max_concurrent
+            source.launch_options.pe_count = self._max_concurrent
         else:
             self._json_reader = get_json_reader(self._config.execution_mode)
             source = builder.make_source(self.unique_name, self._source_generator)


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->

* Calling  `CudfHelper::load()` from a MRC thread that Python didn't know about was cuassing the deadlock in issue #2204
* The issue appears to be that `CudfHelper::load()` called `import_morpheus___lib__cudf_helpers` which in turn called `PyImport_ImportModule` which would abort the running thread, even though the thread was holding the GIL.

Closes #2204

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
