### PR TITLE
Remove dependencies on `gmpy2` from Morpheus `24.06` container

### DIFF
--- a/ci/conda/recipes/morpheus/meta.yaml
+++ b/ci/conda/recipes/morpheus/meta.yaml
@@ -107,8 +107,8 @@ outputs:
         - python
         - python-confluent-kafka >=1.9.2,<1.10.0a0
         - python-graphviz
-        - pytorch-cuda
-        - pytorch * *cuda*
+        # - pytorch-cuda
+        # - pytorch * *cuda*
         - rapids-dask-dependency {{ rapids_version }} # provides dask and distributed
         - requests
         - requests-cache =1.1.*

--- a/conda/environments/all_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-121_arch-x86_64.yaml
@@ -92,8 +92,8 @@ dependencies:
 - python-docx==1.1.0
 - python-graphviz
 - python=3.10
-- pytorch-cuda
-- pytorch=*=*cuda*
+# - pytorch-cuda
+# - pytorch=*=*cuda*
 - rapidjson=1.1.0
 - rapids-dask-dependency=24.02
 - rdma-core>=48
@@ -119,6 +119,7 @@ dependencies:
 - yapf=0.40.1
 - zlib=1.2.13
 - pip:
+  - --extra-index-url https://download.pytorch.org/whl/cu121
   - --find-links https://data.dgl.ai/wheels-test/repo.html
   - --find-links https://data.dgl.ai/wheels/cu121/repo.html
   - databricks-cli < 0.100
@@ -133,4 +134,5 @@ dependencies:
   - nemollm==0.3.5
   - pymilvus==2.3.6
   - pytest-kafka==0.6.0
+  - torch==2.4.0+cu121
 name: all_cuda-121_arch-x86_64

--- a/conda/environments/dev_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/dev_cuda-121_arch-x86_64.yaml
@@ -76,8 +76,8 @@ dependencies:
 - python-docx==1.1.0
 - python-graphviz
 - python=3.10
-- pytorch-cuda
-- pytorch=*=*cuda*
+# - pytorch-cuda
+# - pytorch=*=*cuda*
 - rapidjson=1.1.0
 - rapids-dask-dependency=24.02
 - rdma-core>=48
@@ -99,9 +99,11 @@ dependencies:
 - yapf=0.40.1
 - zlib=1.2.13
 - pip:
+  - --extra-index-url https://download.pytorch.org/whl/cu121
   - databricks-cli < 0.100
   - databricks-connect
   - milvus==2.3.5
   - pymilvus==2.3.6
   - pytest-kafka==0.6.0
+  - torch==2.4.0+cu121
 name: dev_cuda-121_arch-x86_64

--- a/conda/environments/examples_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/examples_cuda-121_arch-x86_64.yaml
@@ -49,8 +49,8 @@ dependencies:
 - python-docx==1.1.0
 - python-graphviz
 - python=3.10
-- pytorch-cuda
-- pytorch=*=*cuda*
+# - pytorch-cuda
+# - pytorch=*=*cuda*
 - rapids-dask-dependency=24.02
 - requests
 - requests-cache=1.1
@@ -66,6 +66,7 @@ dependencies:
 - watchdog=3.0
 - websockets
 - pip:
+  - --extra-index-url https://download.pytorch.org/whl/cu121
   - --find-links https://data.dgl.ai/wheels-test/repo.html
   - --find-links https://data.dgl.ai/wheels/cu121/repo.html
   - databricks-cli < 0.100
@@ -79,4 +80,5 @@ dependencies:
   - milvus==2.3.5
   - nemollm==0.3.5
   - pymilvus==2.3.6
+  - torch==2.4.0+cu121
 name: examples_cuda-121_arch-x86_64

--- a/conda/environments/runtime_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/runtime_cuda-121_arch-x86_64.yaml
@@ -37,8 +37,8 @@ dependencies:
 - python-confluent-kafka>=1.9.2,<1.10.0a0
 - python-graphviz
 - python=3.10
-- pytorch-cuda
-- pytorch=*=*cuda*
+# - pytorch-cuda
+# - pytorch=*=*cuda*
 - rapids-dask-dependency=24.02
 - requests
 - requests-cache=1.1
@@ -50,8 +50,10 @@ dependencies:
 - watchdog=3.0
 - websockets
 - pip:
+  - --extra-index-url https://download.pytorch.org/whl/cu121
   - databricks-cli < 0.100
   - databricks-connect
   - milvus==2.3.5
   - pymilvus==2.3.6
+  - torch==2.4.0+cu121
 name: runtime_cuda-121_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -339,8 +339,8 @@ dependencies:
           # - python ##
           - python-confluent-kafka>=1.9.2,<1.10.0a0
           - python-graphviz
-          - pytorch-cuda
-          - pytorch=*=*cuda*
+          # - pytorch-cuda
+          # - pytorch=*=*cuda*
           - pluggy=1.3
           - rapids-dask-dependency=24.02 # provides dask and distributed
           - requests
@@ -354,10 +354,12 @@ dependencies:
           - websockets
           - pip
           - pip:
+            - --extra-index-url https://download.pytorch.org/whl/cu121
             - databricks-cli < 0.100
             - databricks-connect
             - milvus==2.3.5 # update to match pymilvus when available
             - pymilvus==2.3.6
+            - torch==2.4.0+cu121
 
   test_python_morpheus:
     common:


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
This PR removes depenencies on `gmpy2` from Morpheus `24.06` container. Using [PR-1874](https://github.com/nv-morpheus/Morpheus/pull/1874/files) as a reference.

The `24.06` container is having issues with `GPL 3.0` license for the `mpc` dependency, which is pulled in by `gmpy2`. Even a transitive dependency like this causes the viral nature of the GPL license to be invoked in whatever it touches in the process address space. If that's the case, then any NVIDIA proprietary code in that address space would be required to have its source code released.

`gmpy2` is pulled in by `sympy`, which is a dependency of `pytorch` and its related packages. The solution is to ensure pulling `pytorch` from `pypi` rather than `conda-forge`. 

Closes [nvbugs-5239038](https://nvbugspro.nvidia.com/bug/5239038)

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
