### PR TITLE
Fix conda package dependency issues

### DIFF
--- a/ci/conda/recipes/morpheus-libs/meta.yaml
+++ b/ci/conda/recipes/morpheus-libs/meta.yaml
@@ -87,7 +87,7 @@ outputs:
         - cupy <13.4
         - datacompy =0.13.1
         - dill =0.3.7
-        - docker-py =5.0.*
+        - docker-py >=7.1,<8
         - elasticsearch ==8.9.0
         - feedparser =6.0.*
         - grpcio =1.62.*

--- a/ci/conda/recipes/morpheus-libs/meta.yaml
+++ b/ci/conda/recipes/morpheus-libs/meta.yaml
@@ -67,6 +67,7 @@ outputs:
         - indicators=2.3
         - libcudf {{ rapids_version }}
         - librdkafka =2.6.1
+        - mlflow>=2.18
         - mrc {{ minor_version }}
         - nlohmann_json 3.11.*
         - pip
@@ -94,7 +95,7 @@ outputs:
         - feedparser =6.0.*
         - grpcio =1.62.*
         - lxml
-        - mlflow>=2.18
+        - mlflow
         - mrc
         - networkx=2.8.8
         - numba=0.60 # Pin version to avoid https://github.com/nv-morpheus/Morpheus/issues/2166

--- a/ci/conda/recipes/morpheus-libs/meta.yaml
+++ b/ci/conda/recipes/morpheus-libs/meta.yaml
@@ -66,7 +66,7 @@ outputs:
         - glog >=0.7.1,<0.8
         - indicators=2.3
         - libcudf {{ rapids_version }}
-        - libgcc>=13, <14.3
+        - libgcc>=13, <14.3  # Work-around for #2066
         - librdkafka =2.6.1
         - mrc {{ minor_version }}
         - nlohmann_json 3.11.*
@@ -162,7 +162,7 @@ outputs:
         # in versions that are not compatible with morpheus-core
         - cuda-cudart-dev {{ cuda_compiler_version }}.*
         - cuda-version {{ cuda_compiler_version }}.*
-        - libgcc>=13, <14.3
+        - libgcc>=13, <14.3  # Work-around for #2066
         - {{ pin_subpackage('morpheus-core', exact=True) }}
         - pip
         - python {{ python }}
@@ -222,7 +222,7 @@ outputs:
         - {{ pin_subpackage('morpheus-core', exact=True) }}
         - cython 3.0.*
         - glog >=0.7.1,<0.8
-        - libgcc>=13, <14.3
+        - libgcc>=13, <14.3  # Work-around for #2066
         - pip
         - pybind11-stubgen 0.10.5
         - python {{ python }}

--- a/ci/conda/recipes/morpheus-libs/meta.yaml
+++ b/ci/conda/recipes/morpheus-libs/meta.yaml
@@ -74,6 +74,8 @@ outputs:
         - python {{ python }}
         - rapidjson 1.1.0
         - scikit-build 0.17.6
+        # We are currently depending on some deprecated functionality removed in setuptools 80+ #2224
+        - setuptools>=75,<80 
         - versioneer-518
         - zlib >=1.3.1,<2 # required to build triton client
       run:
@@ -163,6 +165,8 @@ outputs:
         - pip
         - python {{ python }}
         - scikit-build 0.17.6
+        # We are currently depending on some deprecated functionality removed in setuptools 80+ #2224
+        - setuptools>=75,<80 
         - versioneer-518
       run:
         - {{ pin_subpackage('morpheus-core', exact=True) }}
@@ -221,6 +225,8 @@ outputs:
         - python {{ python }}
         - rapidjson 1.1.0
         - scikit-build 0.17.6
+        # We are currently depending on some deprecated functionality removed in setuptools 80+ #2224
+        - setuptools>=75,<80 
         - versioneer-518
         - zlib >=1.3.1,<2 # required to build triton client
       run:

--- a/ci/conda/recipes/morpheus-libs/meta.yaml
+++ b/ci/conda/recipes/morpheus-libs/meta.yaml
@@ -67,6 +67,8 @@ outputs:
         - indicators=2.3
         - libcudf {{ rapids_version }}
         - librdkafka =2.6.1
+        # Listing mlflow in the host depencies so that it solves along with libgcc this avoids an incompaible
+        # runtime environment
         - mlflow>=2.18
         - mrc {{ minor_version }}
         - nlohmann_json 3.11.*

--- a/ci/conda/recipes/morpheus-libs/meta.yaml
+++ b/ci/conda/recipes/morpheus-libs/meta.yaml
@@ -61,6 +61,7 @@ outputs:
         - cuda-nvtx-dev {{ cuda_compiler_version }}.*
         - cuda-version {{ cuda_compiler_version }}.*
         # Non-CUDA dependencies
+        - cuda-python {{ cuda_compiler_version }}.*
         - cudf {{ rapids_version }}
         - cython 3.0.*
         - glog >=0.7.1,<0.8

--- a/ci/conda/recipes/morpheus-libs/meta.yaml
+++ b/ci/conda/recipes/morpheus-libs/meta.yaml
@@ -66,7 +66,6 @@ outputs:
         - glog >=0.7.1,<0.8
         - indicators=2.3
         - libcudf {{ rapids_version }}
-        - libgcc>=13, <14.3  # Work-around for #2066
         - librdkafka =2.6.1
         - mrc {{ minor_version }}
         - nlohmann_json 3.11.*
@@ -95,7 +94,7 @@ outputs:
         - feedparser =6.0.*
         - grpcio =1.62.*
         - lxml
-        - mlflow>=2.10.0,<2.18
+        - mlflow>=2.18
         - mrc
         - networkx=2.8.8
         - numba=0.60 # Pin version to avoid https://github.com/nv-morpheus/Morpheus/issues/2166
@@ -162,7 +161,6 @@ outputs:
         # in versions that are not compatible with morpheus-core
         - cuda-cudart-dev {{ cuda_compiler_version }}.*
         - cuda-version {{ cuda_compiler_version }}.*
-        - libgcc>=13, <14.3  # Work-around for #2066
         - {{ pin_subpackage('morpheus-core', exact=True) }}
         - pip
         - python {{ python }}
@@ -222,7 +220,6 @@ outputs:
         - {{ pin_subpackage('morpheus-core', exact=True) }}
         - cython 3.0.*
         - glog >=0.7.1,<0.8
-        - libgcc>=13, <14.3  # Work-around for #2066
         - pip
         - pybind11-stubgen 0.10.5
         - python {{ python }}

--- a/ci/conda/recipes/morpheus-libs/meta.yaml
+++ b/ci/conda/recipes/morpheus-libs/meta.yaml
@@ -66,7 +66,7 @@ outputs:
         - glog >=0.7.1,<0.8
         - indicators=2.3
         - libcudf {{ rapids_version }}
-        - libgcc>=13, <15
+        - libgcc>=13, <14.3
         - librdkafka =2.6.1
         - mrc {{ minor_version }}
         - nlohmann_json 3.11.*
@@ -162,7 +162,7 @@ outputs:
         # in versions that are not compatible with morpheus-core
         - cuda-cudart-dev {{ cuda_compiler_version }}.*
         - cuda-version {{ cuda_compiler_version }}.*
-        - libgcc>=13, <15
+        - libgcc>=13, <14.3
         - {{ pin_subpackage('morpheus-core', exact=True) }}
         - pip
         - python {{ python }}
@@ -222,7 +222,7 @@ outputs:
         - {{ pin_subpackage('morpheus-core', exact=True) }}
         - cython 3.0.*
         - glog >=0.7.1,<0.8
-        - libgcc>=13, <15
+        - libgcc>=13, <14.3
         - pip
         - pybind11-stubgen 0.10.5
         - python {{ python }}

--- a/ci/conda/recipes/morpheus-libs/meta.yaml
+++ b/ci/conda/recipes/morpheus-libs/meta.yaml
@@ -81,7 +81,7 @@ outputs:
         # This should be synced with `runtime` in dependencies.yaml
         - appdirs
         - beautifulsoup4
-        - click >=8
+        - click>=8, <8.2 # work-around for #2219
         - cuda-version {{ cuda_compiler_version }}.*
         - cudf
         - cupy <13.4

--- a/ci/conda/recipes/morpheus-libs/meta.yaml
+++ b/ci/conda/recipes/morpheus-libs/meta.yaml
@@ -49,7 +49,7 @@ outputs:
         - {{ compiler("cxx") }}
         - ccache
         - cmake =3.27
-        - libgcc={{ c_compiler_version }}.*
+        - libgcc=12.*
         - ninja =1.11
         - pkg-config =0.29
         - sysroot_linux-64>=2.28
@@ -155,7 +155,7 @@ outputs:
         - {{ compiler("cxx") }}
         - ccache
         - cmake =3.27
-        - libgcc={{ c_compiler_version }}.*
+        - libgcc=12.*
         - ninja =1.11
         - pkg-config =0.29
       host:
@@ -212,7 +212,7 @@ outputs:
         - {{ compiler("cxx") }}
         - ccache
         - cmake =3.27
-        - libgcc={{ c_compiler_version }}.*
+        - libgcc=12.*
         - ninja =1.11
         - pkg-config =0.29
       host:

--- a/ci/conda/recipes/morpheus-libs/meta.yaml
+++ b/ci/conda/recipes/morpheus-libs/meta.yaml
@@ -66,7 +66,7 @@ outputs:
         - glog >=0.7.1,<0.8
         - indicators=2.3
         - libcudf {{ rapids_version }}
-        - libgcc=12.*
+        - libgcc>=13, <15
         - librdkafka =2.6.1
         - mrc {{ minor_version }}
         - nlohmann_json 3.11.*
@@ -162,7 +162,7 @@ outputs:
         # in versions that are not compatible with morpheus-core
         - cuda-cudart-dev {{ cuda_compiler_version }}.*
         - cuda-version {{ cuda_compiler_version }}.*
-        - libgcc=12.*
+        - libgcc>=13, <15
         - {{ pin_subpackage('morpheus-core', exact=True) }}
         - pip
         - python {{ python }}
@@ -222,7 +222,7 @@ outputs:
         - {{ pin_subpackage('morpheus-core', exact=True) }}
         - cython 3.0.*
         - glog >=0.7.1,<0.8
-        - libgcc=12.*
+        - libgcc>=13, <15
         - pip
         - pybind11-stubgen 0.10.5
         - python {{ python }}

--- a/ci/conda/recipes/morpheus-libs/meta.yaml
+++ b/ci/conda/recipes/morpheus-libs/meta.yaml
@@ -50,9 +50,6 @@ outputs:
         - ccache
         - cmake =3.27
         - libgcc={{ c_compiler_version }}.*
-        - libgcc-ng={{ c_compiler_version }}.*
-        - libstdcxx={{ cxx_compiler_version }}.*
-        - libstdcxx-ng={{ cxx_compiler_version }}.*
         - ninja =1.11
         - pkg-config =0.29
         - sysroot_linux-64>=2.28
@@ -159,9 +156,6 @@ outputs:
         - ccache
         - cmake =3.27
         - libgcc={{ c_compiler_version }}.*
-        - libgcc-ng={{ c_compiler_version }}.*
-        - libstdcxx={{ cxx_compiler_version }}.*
-        - libstdcxx-ng={{ cxx_compiler_version }}.*
         - ninja =1.11
         - pkg-config =0.29
       host:
@@ -219,9 +213,6 @@ outputs:
         - ccache
         - cmake =3.27
         - libgcc={{ c_compiler_version }}.*
-        - libgcc-ng={{ c_compiler_version }}.*
-        - libstdcxx={{ cxx_compiler_version }}.*
-        - libstdcxx-ng={{ cxx_compiler_version }}.*
         - ninja =1.11
         - pkg-config =0.29
       host:

--- a/ci/conda/recipes/morpheus-libs/meta.yaml
+++ b/ci/conda/recipes/morpheus-libs/meta.yaml
@@ -49,6 +49,10 @@ outputs:
         - {{ compiler("cxx") }}
         - ccache
         - cmake =3.27
+        - libgcc={{ c_compiler_version }}.*
+        - libgcc-ng={{ c_compiler_version }}.*
+        - libstdcxx={{ cxx_compiler_version }}.*
+        - libstdcxx-ng={{ cxx_compiler_version }}.*
         - ninja =1.11
         - pkg-config =0.29
         - sysroot_linux-64>=2.28
@@ -75,7 +79,7 @@ outputs:
         - rapidjson 1.1.0
         - scikit-build 0.17.6
         # We are currently depending on some deprecated functionality removed in setuptools 80+ #2224
-        - setuptools>=75,<80 
+        - setuptools>=75,<80
         - versioneer-518
         - zlib >=1.3.1,<2 # required to build triton client
       run:
@@ -154,6 +158,10 @@ outputs:
         - {{ compiler("cxx") }}
         - ccache
         - cmake =3.27
+        - libgcc={{ c_compiler_version }}.*
+        - libgcc-ng={{ c_compiler_version }}.*
+        - libstdcxx={{ cxx_compiler_version }}.*
+        - libstdcxx-ng={{ cxx_compiler_version }}.*
         - ninja =1.11
         - pkg-config =0.29
       host:
@@ -166,7 +174,7 @@ outputs:
         - python {{ python }}
         - scikit-build 0.17.6
         # We are currently depending on some deprecated functionality removed in setuptools 80+ #2224
-        - setuptools>=75,<80 
+        - setuptools>=75,<80
         - versioneer-518
       run:
         - {{ pin_subpackage('morpheus-core', exact=True) }}
@@ -210,6 +218,10 @@ outputs:
         - {{ compiler("cxx") }}
         - ccache
         - cmake =3.27
+        - libgcc={{ c_compiler_version }}.*
+        - libgcc-ng={{ c_compiler_version }}.*
+        - libstdcxx={{ cxx_compiler_version }}.*
+        - libstdcxx-ng={{ cxx_compiler_version }}.*
         - ninja =1.11
         - pkg-config =0.29
       host:
@@ -226,7 +238,7 @@ outputs:
         - rapidjson 1.1.0
         - scikit-build 0.17.6
         # We are currently depending on some deprecated functionality removed in setuptools 80+ #2224
-        - setuptools>=75,<80 
+        - setuptools>=75,<80
         - versioneer-518
         - zlib >=1.3.1,<2 # required to build triton client
       run:

--- a/ci/conda/recipes/morpheus-libs/meta.yaml
+++ b/ci/conda/recipes/morpheus-libs/meta.yaml
@@ -49,7 +49,6 @@ outputs:
         - {{ compiler("cxx") }}
         - ccache
         - cmake =3.27
-        - libgcc=12.*
         - ninja =1.11
         - pkg-config =0.29
         - sysroot_linux-64>=2.28
@@ -67,6 +66,7 @@ outputs:
         - glog >=0.7.1,<0.8
         - indicators=2.3
         - libcudf {{ rapids_version }}
+        - libgcc=12.*
         - librdkafka =2.6.1
         - mrc {{ minor_version }}
         - nlohmann_json 3.11.*
@@ -155,7 +155,6 @@ outputs:
         - {{ compiler("cxx") }}
         - ccache
         - cmake =3.27
-        - libgcc=12.*
         - ninja =1.11
         - pkg-config =0.29
       host:
@@ -163,6 +162,7 @@ outputs:
         # in versions that are not compatible with morpheus-core
         - cuda-cudart-dev {{ cuda_compiler_version }}.*
         - cuda-version {{ cuda_compiler_version }}.*
+        - libgcc=12.*
         - {{ pin_subpackage('morpheus-core', exact=True) }}
         - pip
         - python {{ python }}
@@ -212,7 +212,6 @@ outputs:
         - {{ compiler("cxx") }}
         - ccache
         - cmake =3.27
-        - libgcc=12.*
         - ninja =1.11
         - pkg-config =0.29
       host:
@@ -223,6 +222,7 @@ outputs:
         - {{ pin_subpackage('morpheus-core', exact=True) }}
         - cython 3.0.*
         - glog >=0.7.1,<0.8
+        - libgcc=12.*
         - pip
         - pybind11-stubgen 0.10.5
         - python {{ python }}

--- a/ci/conda/recipes/morpheus-libs/meta.yaml
+++ b/ci/conda/recipes/morpheus-libs/meta.yaml
@@ -67,8 +67,8 @@ outputs:
         - indicators=2.3
         - libcudf {{ rapids_version }}
         - librdkafka =2.6.1
-        # Listing mlflow in the host depencies so that it solves along with libgcc this avoids an incompaible
-        # runtime environment
+        # Listing mlflow in the host dependencies so that it solves along with libgcc this avoids an
+        # incompatible runtime environment
         - mlflow>=2.18
         - mrc {{ minor_version }}
         - nlohmann_json 3.11.*

--- a/ci/conda/recipes/morpheus/meta.yaml
+++ b/ci/conda/recipes/morpheus/meta.yaml
@@ -81,7 +81,7 @@ outputs:
         - rdma-core >=48 # Needed for DOCA.
         - scikit-build 0.17.6
         # We are currently depending on some deprecated functionality removed in setuptools 80+ #2224
-        - setuptools>=75,<80 
+        - setuptools>=75,<80
         - versioneer-518
         - zlib >=1.3.1,<2 # required to build triton client
       run:
@@ -100,7 +100,7 @@ outputs:
         - feedparser =6.0.*
         - grpcio =1.62.*
         - libwebp>=1.3.2 # Required for CVE mitigation: https://nvd.nist.gov/vuln/detail/CVE-2023-4863
-        - mlflow>=2.10.0,<2.18
+        - mlflow>=2.18
         - mrc
         - networkx=2.8.8
         - numba=0.60 # Pin version to avoid https://github.com/nv-morpheus/Morpheus/issues/2166

--- a/ci/conda/recipes/morpheus/meta.yaml
+++ b/ci/conda/recipes/morpheus/meta.yaml
@@ -87,7 +87,7 @@ outputs:
         # This should be synced with `runtime` in dependencies.yaml
         - appdirs
         - beautifulsoup4
-        - click >=8
+        - click>=8, <8.2 # work-around for #2219
         - cuda-version {{ cuda_compiler_version }}.*
         - cudf
         - cupy <13.4

--- a/ci/conda/recipes/morpheus/meta.yaml
+++ b/ci/conda/recipes/morpheus/meta.yaml
@@ -80,6 +80,8 @@ outputs:
         - rapidjson 1.1.0
         - rdma-core >=48 # Needed for DOCA.
         - scikit-build 0.17.6
+        # We are currently depending on some deprecated functionality removed in setuptools 80+ #2224
+        - setuptools>=75,<80 
         - versioneer-518
         - zlib >=1.3.1,<2 # required to build triton client
       run:

--- a/ci/conda/recipes/morpheus/meta.yaml
+++ b/ci/conda/recipes/morpheus/meta.yaml
@@ -93,7 +93,7 @@ outputs:
         - cupy <13.4
         - datacompy =0.13.1
         - dill =0.3.7
-        - docker-py =5.0.*
+        - docker-py >=7.1,<8
         - elasticsearch ==8.9.0
         - feedparser =6.0.*
         - grpcio =1.62.*

--- a/ci/conda/recipes/morpheus/meta.yaml
+++ b/ci/conda/recipes/morpheus/meta.yaml
@@ -66,6 +66,7 @@ outputs:
         - cuda-nvtx-dev {{ cuda_compiler_version }}.*
         - cuda-version {{ cuda_compiler_version }}.*
         # Non-CUDA dependencies
+        - cuda-python {{ cuda_compiler_version }}.*
         - cudf {{ rapids_version }}
         - cython 3.0.*
         - glog >=0.7.1,<0.8

--- a/ci/scripts/run_ci_local.sh
+++ b/ci/scripts/run_ci_local.sh
@@ -65,7 +65,7 @@ CUDA_FULL_VER=${CUDA_FULL_VER:-12.8.0}
 DOCKER_EXTRA_ARGS=${DOCKER_EXTRA_ARGS:-""}
 
 # Configure the base docker img
-CONDA_CONTAINER="rapidsai/ci-conda:cuda${CUDA_FULL_VER}-ubuntu22.04-py3.10"
+CONDA_CONTAINER="rapidsai/ci-conda:cuda${CUDA_FULL_VER}-ubuntu22.04-py3.12"
 BUILD_CONTAINER="nvcr.io/ea-nvidia-morpheus/morpheus:morpheus-ci-build-${CONTAINER_VER}"
 TEST_CONTAINER="nvcr.io/ea-nvidia-morpheus/morpheus:morpheus-ci-test-${CONTAINER_VER}"
 

--- a/conda/environments/all_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-128_arch-aarch64.yaml
@@ -30,6 +30,7 @@ dependencies:
 - cuda-nvrtc=12.8
 - cuda-nvtx-dev=12.8
 - cuda-nvtx=12.8
+- cuda-python=12.8
 - cuda-sanitizer-api
 - cuda-version=12.8
 - cudf=25.02

--- a/conda/environments/all_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-128_arch-aarch64.yaml
@@ -66,7 +66,7 @@ dependencies:
 - libtool
 - libwebp=1.3.2
 - libzlib>=1.3.1,<1.4
-- mlflow>=2.10.0,<2.18
+- mlflow>=2.18
 - mrc=25.06
 - myst-parser>=4.0
 - nbsphinx

--- a/conda/environments/all_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-128_arch-aarch64.yaml
@@ -20,7 +20,7 @@ dependencies:
 - c-ares=1.32
 - ccache
 - clangdev=16
-- click>=8
+- click>=8, <8.2
 - cmake=3.27
 - cuda-cudart-dev=12.8
 - cuda-cudart=12.8

--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -30,6 +30,7 @@ dependencies:
 - cuda-nvrtc=12.8
 - cuda-nvtx-dev=12.8
 - cuda-nvtx=12.8
+- cuda-python=12.8
 - cuda-sanitizer-api
 - cuda-version=12.8
 - cudf=25.02

--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -20,7 +20,7 @@ dependencies:
 - c-ares=1.32
 - ccache
 - clangdev=16
-- click>=8
+- click>=8, <8.2
 - cmake=3.27
 - cuda-cudart-dev=12.8
 - cuda-cudart=12.8

--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -67,7 +67,7 @@ dependencies:
 - libtool
 - libwebp=1.3.2
 - libzlib>=1.3.1,<1.4
-- mlflow>=2.10.0,<2.18
+- mlflow>=2.18
 - mrc=25.06
 - myst-parser>=4.0
 - nbsphinx

--- a/conda/environments/dev_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/dev_cuda-128_arch-aarch64.yaml
@@ -24,6 +24,7 @@ dependencies:
 - cuda-nvml-dev=12.8
 - cuda-nvrtc-dev=12.8
 - cuda-nvtx-dev=12.8
+- cuda-python=12.8
 - cuda-sanitizer-api
 - cuda-version=12.8
 - cudf=25.02

--- a/conda/environments/dev_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/dev_cuda-128_arch-aarch64.yaml
@@ -55,7 +55,7 @@ dependencies:
 - libtool
 - libwebp=1.3.2
 - libzlib>=1.3.1,<1.4
-- mlflow>=2.10.0,<2.18
+- mlflow>=2.18
 - mrc=25.06
 - myst-parser>=4.0
 - nbsphinx

--- a/conda/environments/dev_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/dev_cuda-128_arch-aarch64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - c-ares=1.32
 - ccache
 - clangdev=16
-- click>=8
+- click>=8, <8.2
 - cmake=3.27
 - cuda-cudart-dev=12.8
 - cuda-nvcc=12.8

--- a/conda/environments/dev_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/dev_cuda-128_arch-x86_64.yaml
@@ -24,6 +24,7 @@ dependencies:
 - cuda-nvml-dev=12.8
 - cuda-nvrtc-dev=12.8
 - cuda-nvtx-dev=12.8
+- cuda-python=12.8
 - cuda-sanitizer-api
 - cuda-version=12.8
 - cudf=25.02

--- a/conda/environments/dev_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/dev_cuda-128_arch-x86_64.yaml
@@ -56,7 +56,7 @@ dependencies:
 - libtool
 - libwebp=1.3.2
 - libzlib>=1.3.1,<1.4
-- mlflow>=2.10.0,<2.18
+- mlflow>=2.18
 - mrc=25.06
 - myst-parser>=4.0
 - nbsphinx

--- a/conda/environments/dev_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/dev_cuda-128_arch-x86_64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - c-ares=1.32
 - ccache
 - clangdev=16
-- click>=8
+- click>=8, <8.2
 - cmake=3.27
 - cuda-cudart-dev=12.8
 - cuda-nvcc=12.8

--- a/conda/environments/examples_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/examples_cuda-128_arch-aarch64.yaml
@@ -14,7 +14,7 @@ dependencies:
 - arxiv=1.4
 - beautifulsoup4=4.12
 - boto3=1.35
-- click>=8
+- click>=8, <8.2
 - cudf=25.02
 - cuml=25.02.*
 - cupy<13.4

--- a/conda/environments/examples_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/examples_cuda-128_arch-aarch64.yaml
@@ -30,7 +30,7 @@ dependencies:
 - jsonpatch>=1.33
 - kfp
 - libwebp=1.3.2
-- mlflow>=2.10.0,<2.18
+- mlflow>=2.18
 - mrc=25.06
 - networkx=2.8.8
 - nodejs=18.*

--- a/conda/environments/examples_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/examples_cuda-128_arch-x86_64.yaml
@@ -14,7 +14,7 @@ dependencies:
 - arxiv=1.4
 - beautifulsoup4=4.12
 - boto3=1.35
-- click>=8
+- click>=8, <8.2
 - cudf=25.02
 - cuml=25.02.*
 - cupy<13.4

--- a/conda/environments/examples_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/examples_cuda-128_arch-x86_64.yaml
@@ -30,7 +30,7 @@ dependencies:
 - jsonpatch>=1.33
 - kfp
 - libwebp=1.3.2
-- mlflow>=2.10.0,<2.18
+- mlflow>=2.18
 - mrc=25.06
 - networkx=2.8.8
 - newspaper3k==0.2.8

--- a/conda/environments/runtime_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/runtime_cuda-128_arch-aarch64.yaml
@@ -11,7 +11,7 @@ channels:
 dependencies:
 - appdirs
 - beautifulsoup4=4.12
-- click>=8
+- click>=8, <8.2
 - cuda-cudart=12.8
 - cuda-nvrtc=12.8
 - cuda-nvtx=12.8

--- a/conda/environments/runtime_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/runtime_cuda-128_arch-aarch64.yaml
@@ -26,7 +26,7 @@ dependencies:
 - grpcio
 - grpcio-status
 - libwebp=1.3.2
-- mlflow>=2.10.0,<2.18
+- mlflow>=2.18
 - mrc=25.06
 - networkx=2.8.8
 - numba=0.60

--- a/conda/environments/runtime_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/runtime_cuda-128_arch-x86_64.yaml
@@ -11,7 +11,7 @@ channels:
 dependencies:
 - appdirs
 - beautifulsoup4=4.12
-- click>=8
+- click>=8, <8.2
 - cuda-cudart=12.8
 - cuda-nvrtc=12.8
 - cuda-nvtx=12.8

--- a/conda/environments/runtime_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/runtime_cuda-128_arch-x86_64.yaml
@@ -26,7 +26,7 @@ dependencies:
 - grpcio
 - grpcio-status
 - libwebp=1.3.2
-- mlflow>=2.10.0,<2.18
+- mlflow>=2.18
 - mrc=25.06
 - networkx=2.8.8
 - numba=0.60

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -383,7 +383,7 @@ dependencies:
           # Include: cve-mitigation
           - appdirs
           - beautifulsoup4=4.12
-          - click>=8
+          - click>=8, <8.2 # work-around for #2219
           # - cuda-version=12.8 ##
           - *cudf
           - cupy<13.4

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -397,7 +397,7 @@ dependencies:
           - grpcio
           - grpcio-status
           # - libwebp=1.3.2 # Required for CVE mitigation: https://nvd.nist.gov/vuln/detail/CVE-2023-4863 ##
-          - mlflow>=2.18 # Pin version to avoid breaking change in 2.18 to thread local variable code commit id: 5541888
+          - mlflow>=2.18
           - *mrc
           - networkx=2.8.8
           - numba=0.60 # Pin version to avoid https://github.com/nv-morpheus/Morpheus/issues/2166

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -296,6 +296,7 @@ dependencies:
       - output_types: [conda]
         packages:
           # Include: cudatoolkit-dev
+          - cuda-python=12.8
           - &cudf cudf=25.02
           - cython=3.0
           - glog>=0.7.1,<0.8

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -334,7 +334,7 @@ dependencies:
           - pylint=3.0.3
           - pynvml=12
           # We are currently depending on some deprecated functionality removed in setuptools 80+ #2224
-          - setuptools>=75,<80 
+          - setuptools>=75,<80
           - versioneer
           - yapf=0.43
     specific:
@@ -397,7 +397,7 @@ dependencies:
           - grpcio
           - grpcio-status
           # - libwebp=1.3.2 # Required for CVE mitigation: https://nvd.nist.gov/vuln/detail/CVE-2023-4863 ##
-          - mlflow>=2.10.0,<2.18 # Pin version to avoid breaking change in 2.18 to thread local variable code commit id: 5541888
+          - mlflow>=2.18 # Pin version to avoid breaking change in 2.18 to thread local variable code commit id: 5541888
           - *mrc
           - networkx=2.8.8
           - numba=0.60 # Pin version to avoid https://github.com/nv-morpheus/Morpheus/issues/2166

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -204,6 +204,16 @@ def pytest_runtest_teardown(item, nextitem):
     reset_logging(logger_name=None)  # Reset the root logger as well
 
 
+@pytest.fixture(scope="session", autouse=True)
+def ensure_cudf_helper():
+    """
+    Ensures that the cudf helper is loaded before any tests are run. This is necessary to ensure that the
+    `cudf` module is available for tests that require it.
+    """
+    from morpheus.common import load_cudf_helper
+    load_cudf_helper()
+
+
 @pytest.fixture(scope="function")
 def df_type(request: pytest.FixtureRequest):
 

--- a/tests/morpheus/test_cli.py
+++ b/tests/morpheus/test_cli.py
@@ -118,7 +118,7 @@ def mlflow_uri(tmp_path):
 
     yield uri
 
-    num_runs = len(fluent._active_run_stack)
+    num_runs = len(fluent._active_run_stack.get())
     for _ in range(num_runs):
         mlflow.end_run()
 


### PR DESCRIPTION
## Description
* Looks like I forgot to update this dep the conda recipe in PR #2203
* Remove pin for mlflow and fix tests, thanks to suggestion from @willkill07 
* Fix out of date container image in `ci/scripts/run_ci_local.sh` script
* Pin setuptools to a range of `>=75,<80` to work-around deprecated functionality which was removed in v80 (#2224).
* Ensure cudf helper is loaded prior to running tests

Closes #2066
Closes #2228


## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
