### PR TITLE
Clamp marshmallow to <4 to avoid version incompatibilities

### DIFF
--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -143,6 +143,7 @@ dependencies:
   - langchain-nvidia-ai-endpoints==0.0.11
   - langchain-openai==0.1.3
   - langchain==0.1.16
+  - marshmallow>=3.18,<4.0
   - milvus==2.3.5
   - nemollm==0.3.5
   - nvidia-sphinx-theme>=0.0.7

--- a/conda/environments/dev_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/dev_cuda-128_arch-x86_64.yaml
@@ -115,6 +115,7 @@ dependencies:
   - databricks-connect
   - exhale>=0.3.7
   - gpudb>=7.2.2.3
+  - marshmallow>=3.18,<4.0
   - milvus==2.3.5
   - nvidia-sphinx-theme>=0.0.7
   - pymilvus==2.3.6

--- a/conda/environments/examples_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/examples_cuda-128_arch-x86_64.yaml
@@ -78,6 +78,7 @@ dependencies:
   - langchain-nvidia-ai-endpoints==0.0.11
   - langchain-openai==0.1.3
   - langchain==0.1.16
+  - marshmallow>=3.18,<4.0
   - milvus==2.3.5
   - nemollm==0.3.5
   - pymilvus==2.3.6

--- a/conda/environments/runtime_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/runtime_cuda-128_arch-x86_64.yaml
@@ -53,6 +53,7 @@ dependencies:
   - databricks-cli < 0.100
   - databricks-connect
   - gpudb>=7.2.2.3
+  - marshmallow>=3.18,<4.0
   - milvus==2.3.5
   - pymilvus==2.3.6
   - torch==2.4.0+cu124

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -431,6 +431,7 @@ dependencies:
               arch: x86_64
             packages:
               - pip:
+                - &marshmallow marshmallow>=3.18,<4.0 # Avoid marshmallow 4.0+ which is incompatible #2232
                 # Milvus does not have arm64 builds for linux
                 - &milvus milvus==2.3.5 # update to match pymilvus when available
                 - &pymilvus pymilvus==2.3.6
@@ -495,6 +496,7 @@ dependencies:
            - &langchain langchain==0.1.16
            - &langchain-nvidia-ai-endpoints langchain-nvidia-ai-endpoints==0.0.11
            - &langchain-openai langchain-openai==0.1.3
+           - *marshmallow
            - *milvus
            - &nemollm nemollm==0.3.5
            - &openai openai==1.13.*

--- a/python/morpheus_llm/morpheus_llm/requirements_morpheus_llm_arch-aarch64.txt
+++ b/python/morpheus_llm/morpheus_llm/requirements_morpheus_llm_arch-aarch64.txt
@@ -7,6 +7,7 @@ gpudb>=7.2.2.3
 langchain-nvidia-ai-endpoints==0.0.11
 langchain-openai==0.1.3
 langchain==0.1.16
+marshmallow>=3.18,<4.0
 milvus==2.3.5
 nemollm==0.3.5
 openai==1.13.*

--- a/python/morpheus_llm/morpheus_llm/requirements_morpheus_llm_arch-x86_64.txt
+++ b/python/morpheus_llm/morpheus_llm/requirements_morpheus_llm_arch-x86_64.txt
@@ -7,6 +7,7 @@ gpudb>=7.2.2.3
 langchain-nvidia-ai-endpoints==0.0.11
 langchain-openai==0.1.3
 langchain==0.1.16
+marshmallow>=3.18,<4.0
 milvus==2.3.5
 nemollm==0.3.5
 openai==1.13.*


### PR DESCRIPTION
## Description

The dataclasses package currently clamps <4 but that package doesn't appear in the dev env, only in the all env.

Closes #2232

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
