### PR TITLE
Fix: examples build on aarch64

### DIFF
--- a/examples/data_loss_prevention/dlp_stages/_lib/CMakeLists.txt
+++ b/examples/data_loss_prevention/dlp_stages/_lib/CMakeLists.txt
@@ -15,7 +15,11 @@
 
 list(APPEND CMAKE_MESSAGE_CONTEXT "dlp_regex_processor")
 
-find_library(MORPHEUS morpheus REQUIRED)
+if(PROJECT_IS_TOPLEVEL)
+  find_library(MORPHEUS morpheus REQUIRED)
+else()
+  set(MORPHEUS morpheus)
+endif()
 
 morpheus_add_pybind11_module(regex_processor
   SOURCE_FILES

--- a/examples/data_loss_prevention/dlp_stages/_lib/CMakeLists.txt
+++ b/examples/data_loss_prevention/dlp_stages/_lib/CMakeLists.txt
@@ -15,13 +15,15 @@
 
 list(APPEND CMAKE_MESSAGE_CONTEXT "dlp_regex_processor")
 
+find_library(MORPHEUS morpheus REQUIRED)
+
 morpheus_add_pybind11_module(regex_processor
   SOURCE_FILES
     "regex_processor.cpp"
   INCLUDE_DIRS
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   LINK_TARGETS
-    morpheus
+    ${MORPHEUS}
     CUDA::nvtx3
     cudf::cudf
     glog::glog

--- a/examples/developer_guide/3_simple_cpp_stage/compile.sh
+++ b/examples/developer_guide/3_simple_cpp_stage/compile.sh
@@ -17,6 +17,9 @@
 set -x
 set -e
 
+export CUR_DIR=${CUR_DIR:-"$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"}
+cd ${CUR_DIR}
+
 # Optionally can set INSTALL_PREFIX to build and install to a specific directory. Also causes cmake install to run
 BUILD_DIR=${BUILD_DIR:-"build"}
 

--- a/examples/developer_guide/3_simple_cpp_stage/src/simple_cpp_stage/_lib/CMakeLists.txt
+++ b/examples/developer_guide/3_simple_cpp_stage/src/simple_cpp_stage/_lib/CMakeLists.txt
@@ -15,13 +15,15 @@
 
 list(APPEND CMAKE_MESSAGE_CONTEXT "pass_thru_cpp_stage")
 
+find_library(MORPHEUS morpheus REQUIRED)
+
 morpheus_add_pybind11_module(pass_thru_cpp
   SOURCE_FILES
     "pass_thru.cpp"
   INCLUDE_DIRS
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   LINK_TARGETS
-    morpheus
+    ${MORPHEUS}
     CUDA::nvtx3
     cudf::cudf
     glog::glog

--- a/examples/developer_guide/3_simple_cpp_stage/src/simple_cpp_stage/_lib/CMakeLists.txt
+++ b/examples/developer_guide/3_simple_cpp_stage/src/simple_cpp_stage/_lib/CMakeLists.txt
@@ -15,7 +15,11 @@
 
 list(APPEND CMAKE_MESSAGE_CONTEXT "pass_thru_cpp_stage")
 
-find_library(MORPHEUS morpheus REQUIRED)
+if(PROJECT_IS_TOPLEVEL)
+  find_library(MORPHEUS morpheus REQUIRED)
+else()
+  set(MORPHEUS morpheus)
+endif()
 
 morpheus_add_pybind11_module(pass_thru_cpp
   SOURCE_FILES

--- a/examples/developer_guide/4_rabbitmq_cpp_stage/compile.sh
+++ b/examples/developer_guide/4_rabbitmq_cpp_stage/compile.sh
@@ -17,6 +17,9 @@
 set -x
 set -e
 
+export CUR_DIR=${CUR_DIR:-"$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"}
+cd ${CUR_DIR}
+
 # Optionally can set INSTALL_PREFIX to build and install to a specific directory. Also causes cmake install to run
 BUILD_DIR=${BUILD_DIR:-"build"}
 

--- a/examples/developer_guide/4_rabbitmq_cpp_stage/src/rabbitmq_cpp_stage/_lib/CMakeLists.txt
+++ b/examples/developer_guide/4_rabbitmq_cpp_stage/src/rabbitmq_cpp_stage/_lib/CMakeLists.txt
@@ -15,7 +15,11 @@
 
 list(APPEND CMAKE_MESSAGE_CONTEXT "rabbitmq_cpp_stage")
 
-find_library(MORPHEUS morpheus REQUIRED)
+if(PROJECT_IS_TOPLEVEL)
+  find_library(MORPHEUS morpheus REQUIRED)
+else()
+  set(MORPHEUS morpheus)
+endif()
 
 morpheus_add_pybind11_module(rabbitmq_cpp_stage
   SOURCE_FILES

--- a/examples/developer_guide/4_rabbitmq_cpp_stage/src/rabbitmq_cpp_stage/_lib/CMakeLists.txt
+++ b/examples/developer_guide/4_rabbitmq_cpp_stage/src/rabbitmq_cpp_stage/_lib/CMakeLists.txt
@@ -15,6 +15,8 @@
 
 list(APPEND CMAKE_MESSAGE_CONTEXT "rabbitmq_cpp_stage")
 
+find_library(MORPHEUS morpheus REQUIRED)
+
 morpheus_add_pybind11_module(rabbitmq_cpp_stage
   SOURCE_FILES
     "rabbitmq_source.cpp"
@@ -22,7 +24,7 @@ morpheus_add_pybind11_module(rabbitmq_cpp_stage
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     ${SimpleAmqpClient_SOURCE_DIR}/src
   LINK_TARGETS
-    morpheus
+    ${MORPHEUS}
     CUDA::nvtx3
     cudf::cudf
     glog::glog


### PR DESCRIPTION
There was a linker error on aarch64 indicating that `-lmorpheus` could not be found.

Two possible solutions existed:
1. change the LINK_TARGETS from `morpheus` to `morpheus::morpheus`
2. add `find_library` calls to find the morpheus shared library on the system.

(1) unfortunately resulted in a public link failing of mrc::pymrc -- which probably indicates that we shouldn't be exposing that as a public link dependency.

(2) was chosen because it's what we'd expect the system to do -- find the installed morpheus shared object file and link to it.

It's a bit cumbersome but it works as intended. This is more of a hotfix/patch rather than a complete engineered solution. Improvements and enhancements are welcome.

## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
