### PR TITLE
Allow empty DataFrame slices

### DIFF
--- a/python/morpheus/morpheus/_lib/src/objects/table_info.cpp
+++ b/python/morpheus/morpheus/_lib/src/objects/table_info.cpp
@@ -65,9 +65,13 @@ TableInfoData get_table_info_data_slice(const TableInfoData& table,
         stop = table.table_view.num_rows();
     }
 
-    CHECK_GT(stop, 0) << "Stop must be > 0";
-    CHECK_LE(stop, table.table_view.num_rows()) << "Stop must be less than the number of rows";
-    CHECK_LE(start, stop) << "Start must be less than stop";
+    // Allow for empty slices
+    if (!(start == 0 && stop == 0))
+    {
+        CHECK_GT(stop, 0) << "Stop must be > 0";
+        CHECK_LE(stop, table.table_view.num_rows()) << "Stop must be less than the number of rows";
+        CHECK_LE(start, stop) << "Start must be less than stop";
+    }
 
     if (column_names.empty())
     {


### PR DESCRIPTION
## Description
* Fixes an issue where a filter stage ends up dropping all rows in an instance of `SlicedMessageMeta`
* Add an exception to one of the pre-flight asserts in table_info.cpp

Closes #2239

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
