### PR TITLE
Fix devcontainer builds

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -99,6 +99,7 @@ ENV SCCACHE_BUCKET="rapids-sccache-devs"
 ENV AWS_ROLE_ARN="arn:aws:iam::279114543810:role/nv-gha-token-sccache-devs"
 ENV HISTFILE="/home/coder/.cache/._bash_history"
 
-ENV MORPHEUS_SUPPORT_DOCA=ON
+ENV MORPHEUS_SUPPORT_DOCA=OFF
+
 COPY ./docker/optional_deps docker/optional_deps
 RUN ./docker/optional_deps/doca.sh /tmp/doca

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -99,6 +99,7 @@ ENV SCCACHE_BUCKET="rapids-sccache-devs"
 ENV AWS_ROLE_ARN="arn:aws:iam::279114543810:role/nv-gha-token-sccache-devs"
 ENV HISTFILE="/home/coder/.cache/._bash_history"
 
+# Temporarily disable DOCA support https://github.com/nv-morpheus/Morpheus/issues/2285
 ENV MORPHEUS_SUPPORT_DOCA=OFF
 
 COPY ./docker/optional_deps docker/optional_deps

--- a/.devcontainer/cuda12.8-conda/devcontainer.json
+++ b/.devcontainer/cuda12.8-conda/devcontainer.json
@@ -52,7 +52,7 @@
   "postAttachCommand": [
     "/bin/bash",
     "-c",
-    "if [ ${CODESPACES:-false} = 'true' ]; then . devcontainer-utils-post-attach-command; . rapids-post-attach-command; fi"
+    "if [ ${CODESPACES:-false} = 'true' ]; then . devcontainer-utils-post-attach-command; . rapids-post-attach-command; fi; /home/coder/morpheus/.devcontainer/unset-safepath.sh"
   ],
   "workspaceFolder": "/home/coder",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/morpheus,type=bind,consistency=consistent",

--- a/.devcontainer/unset-safepath.sh
+++ b/.devcontainer/unset-safepath.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# work-around for https://github.com/nv-morpheus/Morpheus/issues/2286
+# this .bashrc file is coming from the base container
+sed -i -e 's|export PYTHONSAFEPATH|# export PYTHONSAFEPATH|' /home/coder/.bashrc
+
+# This value is being set somewhere else other than the above .bashrc line
+echo "unset PYTHONSAFEPATH" >> /home/coder/.bashrc

--- a/docs/source/extra_info/known_issues.md
+++ b/docs/source/extra_info/known_issues.md
@@ -26,7 +26,7 @@ limitations under the License.
 - Build errors after a CMake reconfigure, work-around is to delete the `build` directory and re-run CMake ([#2279](https://github.com/nv-morpheus/Morpheus/issues/2279)).
 - C++ examples fail to build inside the release container on AArch64 ([#2276](https://github.com/nv-morpheus/Morpheus/issues/2276)).
 - DOCA Builds failing inside devcontainer ([#2285](https://github.com/nv-morpheus/Morpheus/issues/2285))
-- Python stubgen failing for C++ examples inside devcontainer ([#2287](https://github.com/nv-morpheus/Morpheus/issues/2287)), the actual build succeeds, and code is functional, but the Python stub files are not generated.
+- Python `stubgen` failing for C++ examples inside devcontainer ([#2287](https://github.com/nv-morpheus/Morpheus/issues/2287)), the actual build succeeds, and code is functional, but the Python stub files are not generated.
 
 
 Refer to [open issues in the Morpheus project](https://github.com/nv-morpheus/Morpheus/issues)

--- a/docs/source/extra_info/known_issues.md
+++ b/docs/source/extra_info/known_issues.md
@@ -23,5 +23,10 @@ limitations under the License.
 - LLM `vdb_upload` and `rag` pipelines not supported on AArch64 ([#2122](https://github.com/nv-morpheus/Morpheus/issues/2122))
 - `gnn_fraud_detection_pipeline` not working on AArch64 ([#2123](https://github.com/nv-morpheus/Morpheus/issues/2123))
 - DFP visualization fails to install on AArch64 ([#2125](https://github.com/nv-morpheus/Morpheus/issues/2125))
+- Build errors after a CMake reconfigure, work-around is to delete the `build` directory and re-run CMake ([#2279](https://github.com/nv-morpheus/Morpheus/issues/2279)).
+- C++ examples fail to build inside the release container on AArch64 ([#2276](https://github.com/nv-morpheus/Morpheus/issues/2276)).
+- DOCA Builds failing inside devcontainer ([#2285](https://github.com/nv-morpheus/Morpheus/issues/2285))
+- Python stubgen failing for C++ examples inside devcontainer ([#2287](https://github.com/nv-morpheus/Morpheus/issues/2287)), the actual build succeeds, and code is functional, but the Python stub files are not generated.
+
 
 Refer to [open issues in the Morpheus project](https://github.com/nv-morpheus/Morpheus/issues)

--- a/examples/data_loss_prevention/README.md
+++ b/examples/data_loss_prevention/README.md
@@ -26,7 +26,7 @@ All environments require additional Conda packages which can be installed with e
 | Conda | ✔ | |
 | Morpheus Docker Container | ✔ |  |
 | Morpheus Release Container | ✔ |  |
-| Dev Container | ✔ |  |
+| Dev Container | ✔ | Requires using the `dev-triton-start` script to start Triton and adding the `--server_url=triton:8001` flag to the `run.py` command. |
 
 ### Supported Architectures
 | Architecture | Supported | Issue |

--- a/examples/log_parsing/README.md
+++ b/examples/log_parsing/README.md
@@ -24,7 +24,7 @@ Example Morpheus pipeline using Triton Inference server and Morpheus.
 | Conda | ✔ | |
 | Morpheus Docker Container | ✔ | Requires launching Triton on the host |
 | Morpheus Release Container | ✔ | Requires launching Triton on the host |
-| Dev Container | ✔ | Requires using the `dev-triton-start` script. If using the `run.py` script this requires adding the `--server_url=triton:8000` flag. If using the CLI example this requires replacing `--server_url=localhost:8000` with `--server_url=triton:8000` |
+| Dev Container | ✔ | Requires using the `dev-triton-start` script. If using the `run.py` script this requires adding the `--server_url=triton:8001` flag. If using the CLI example this requires replacing `--server_url=localhost:8001` with `--server_url=triton:8001` |
 
 ### Set up Triton Inference Server
 


### PR DESCRIPTION
## Description
* Ensure that the `PYTHONSAFEPATH` environment variable is not set inside the devcontainer.
* Disable DOCA builds inside the devcontainer, work-around for #2285 
* Fix triton server urls for devcontainer examples
* Document known 25.06 issues

Closes #2286

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
