### PR TITLE
Fix: typo for PROJECT_IS_TOP_LEVEL for building examples

### DIFF
--- a/examples/data_loss_prevention/dlp_stages/_lib/CMakeLists.txt
+++ b/examples/data_loss_prevention/dlp_stages/_lib/CMakeLists.txt
@@ -15,7 +15,7 @@
 
 list(APPEND CMAKE_MESSAGE_CONTEXT "dlp_regex_processor")
 
-if(PROJECT_IS_TOPLEVEL)
+if(PROJECT_IS_TOP_LEVEL)
   find_library(MORPHEUS morpheus REQUIRED)
 else()
   set(MORPHEUS morpheus)

--- a/examples/developer_guide/3_simple_cpp_stage/src/simple_cpp_stage/_lib/CMakeLists.txt
+++ b/examples/developer_guide/3_simple_cpp_stage/src/simple_cpp_stage/_lib/CMakeLists.txt
@@ -15,7 +15,7 @@
 
 list(APPEND CMAKE_MESSAGE_CONTEXT "pass_thru_cpp_stage")
 
-if(PROJECT_IS_TOPLEVEL)
+if(PROJECT_IS_TOP_LEVEL)
   find_library(MORPHEUS morpheus REQUIRED)
 else()
   set(MORPHEUS morpheus)

--- a/examples/developer_guide/4_rabbitmq_cpp_stage/src/rabbitmq_cpp_stage/_lib/CMakeLists.txt
+++ b/examples/developer_guide/4_rabbitmq_cpp_stage/src/rabbitmq_cpp_stage/_lib/CMakeLists.txt
@@ -15,7 +15,7 @@
 
 list(APPEND CMAKE_MESSAGE_CONTEXT "rabbitmq_cpp_stage")
 
-if(PROJECT_IS_TOPLEVEL)
+if(PROJECT_IS_TOP_LEVEL)
   find_library(MORPHEUS morpheus REQUIRED)
 else()
   set(MORPHEUS morpheus)


### PR DESCRIPTION
## Description

This PR fixes a typo in the CMake variable name `PROJECT_IS_TOP_LEVEL` so we can properly detect how to link Morpheus when building the examples as part of Morpheus or separately.

Closes #2276

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
