### PR TITLE
Misc version and CI fixes

### DIFF
--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -131,7 +131,8 @@ jobs:
 
   test:
     name: Test
-    runs-on: linux-amd64-gpu-v100-latest-1
+    # Using earliest to avoid Morpheus conflict with driver version 580+ #2305
+    runs-on: linux-amd64-gpu-v100-earliest-1
     timeout-minutes: 60
     container:
       credentials:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -76,7 +76,7 @@ jobs:
     # Only run the CI pipeline if the PR does not have the skip-ci label and we are on a PR branch
     if: ${{ !fromJSON(needs.prepare.outputs.has_skip_ci_label) && fromJSON(needs.prepare.outputs.is_pr )}}
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-24.02
+    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-24.10
     with:
       enable_check_generated_files: false
 

--- a/ci/conda/recipes/morpheus/meta.yaml
+++ b/ci/conda/recipes/morpheus/meta.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ci/conda/recipes/morpheus/meta.yaml
+++ b/ci/conda/recipes/morpheus/meta.yaml
@@ -100,6 +100,7 @@ outputs:
         - mlflow>=2.10.0,<3
         - mrc
         - networkx=2.8.8
+        - npy-append-array=0.9.16 # Avoids a version conflict introduced by 0.9.19 and possibly other versions
         - numpydoc =1.5.*
         - nvtabular =23.08.00
         - pydantic

--- a/conda/environments/all_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-121_arch-x86_64.yaml
@@ -19,7 +19,7 @@ dependencies:
 - breathe=4.35.0
 - ccache
 - clangdev=16
-- click>=8
+- click>=8, <8.2
 - cmake=3.27
 - cuda-cudart-dev=12.1
 - cuda-cudart=12.1

--- a/conda/environments/all_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-121_arch-x86_64.yaml
@@ -122,6 +122,8 @@ dependencies:
   - --extra-index-url https://download.pytorch.org/whl/cu121
   - --find-links https://data.dgl.ai/wheels-test/repo.html
   - --find-links https://data.dgl.ai/wheels/cu121/repo.html
+  - databricks-cli < 0.100
+  - databricks-connect
   - dgl==2.0.0
   - dglgo
   - faiss-gpu==1.7.*

--- a/conda/environments/all_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-121_arch-x86_64.yaml
@@ -69,6 +69,7 @@ dependencies:
 - ninja=1.11
 - nlohmann_json=3.11
 - nodejs=18.*
+- npy-append-array=0.9.16
 - numexpr
 - numpydoc=1.5
 - nvtabular=23.08.00

--- a/conda/environments/all_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-121_arch-x86_64.yaml
@@ -50,6 +50,7 @@ dependencies:
 - grpcio-status=1.59
 - grpcio=1.59
 - gxx_linux-64=11.2
+- httpx>=0.23,<0.28
 - huggingface_hub=0.20.2
 - include-what-you-use=0.20
 - ipython

--- a/conda/environments/dev_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/dev_cuda-121_arch-x86_64.yaml
@@ -58,6 +58,7 @@ dependencies:
 - ninja=1.11
 - nlohmann_json=3.11
 - nodejs=18.*
+- npy-append-array=0.9.16
 - numpydoc=1.5
 - nvtabular=23.08.00
 - pip

--- a/conda/environments/dev_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/dev_cuda-121_arch-x86_64.yaml
@@ -16,7 +16,7 @@ dependencies:
 - breathe=4.35.0
 - ccache
 - clangdev=16
-- click>=8
+- click>=8, <8.2
 - cmake=3.27
 - cuda-cudart-dev=12.1
 - cuda-nvcc=12.1

--- a/conda/environments/examples_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/examples_cuda-121_arch-x86_64.yaml
@@ -34,6 +34,7 @@ dependencies:
 - networkx=2.8.8
 - newspaper3k=0.2
 - nodejs=18.*
+- npy-append-array=0.9.16
 - numexpr
 - numpydoc=1.5
 - nvtabular=23.08.00

--- a/conda/environments/examples_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/examples_cuda-121_arch-x86_64.yaml
@@ -14,7 +14,7 @@ dependencies:
 - arxiv=1.4
 - beautifulsoup4=4.12
 - boto3
-- click>=8
+- click>=8, <8.2
 - cudf=24.02
 - cuml=24.02.*
 - cupy

--- a/conda/environments/examples_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/examples_cuda-121_arch-x86_64.yaml
@@ -25,6 +25,7 @@ dependencies:
 - feedparser=6.0
 - grpcio-status=1.59
 - grpcio=1.59
+- httpx>=0.23,<0.28
 - huggingface_hub=0.20.2
 - jsonpatch>=1.33
 - kfp
@@ -68,6 +69,8 @@ dependencies:
   - --extra-index-url https://download.pytorch.org/whl/cu121
   - --find-links https://data.dgl.ai/wheels-test/repo.html
   - --find-links https://data.dgl.ai/wheels/cu121/repo.html
+  - databricks-cli < 0.100
+  - databricks-connect
   - dgl==2.0.0
   - dglgo
   - faiss-gpu==1.7.*

--- a/conda/environments/runtime_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/runtime_cuda-121_arch-x86_64.yaml
@@ -11,7 +11,7 @@ channels:
 dependencies:
 - appdirs
 - beautifulsoup4=4.12
-- click>=8
+- click>=8, <8.2
 - cuda-cudart=12.1
 - cuda-nvrtc=12.1
 - cuda-nvtx=12.1

--- a/conda/environments/runtime_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/runtime_cuda-121_arch-x86_64.yaml
@@ -29,6 +29,7 @@ dependencies:
 - mlflow>=2.10.0,<3
 - mrc=24.06
 - networkx=2.8.8
+- npy-append-array=0.9.16
 - numpydoc=1.5
 - nvtabular=23.08.00
 - pip

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -402,6 +402,7 @@ dependencies:
           - &transformers transformers=4.36.2 # newer versions are incompatible with our pinned version of huggingface_hub
           - anyio>=3.7
           - arxiv=1.4
+          - httpx>=0.23,<0.28 # work-around for https://github.com/openai/openai-python/issues/1915
           - huggingface_hub=0.20.2 # work-around for https://github.com/UKPLab/sentence-transformers/issues/1762
           - jsonpatch>=1.33
           - newspaper3k=0.2

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -333,6 +333,7 @@ dependencies:
           - mlflow>=2.10.0,<3
           - mrc=24.06
           - networkx=2.8.8
+          - npy-append-array=0.9.16 # Avoids a version conflict introduced by 0.9.19 and possibly other versions
           - numpydoc=1.5
           - nvtabular=23.08.00
           - pydantic

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -154,6 +154,8 @@ files:
       - example-llms
       - python
       - runtime
+      - databricks_example
+
 
   # Dependencies which are needed to run the model generation scripts in the `models` directory.
   # Includes: none
@@ -305,6 +307,15 @@ dependencies:
       - output_types: [conda]
         packages:
           - benchmark=1.8.3
+
+  databricks_example:
+    common:
+      - output_types: [conda]
+        packages:    
+          - pip
+          - pip:
+            - databricks-cli < 0.100
+            - databricks-connect
 
   # Runtime dependencies for Morpheus. Included in nearly all output files so dependencies should
   # be added only if it is needed to run the core Morpheus library.

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -35,6 +35,7 @@ files:
       - example-dfp-prod
       - example-gnn
       - example-llms
+      - optional_databricks
       - python
       - runtime
       - test_python_morpheus

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -318,7 +318,7 @@ dependencies:
           # Include: cve-mitigation
           - appdirs
           - beautifulsoup4=4.12
-          - click>=8
+          - click>=8, <8.2 # work-around for #2219
           # - cuda-version=12.1 ##
           - cudf=24.02
           - cupy # Version determined from cudf

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -154,7 +154,7 @@ files:
       - example-llms
       - python
       - runtime
-      - databricks_example
+      - optional_databricks
 
 
   # Dependencies which are needed to run the model generation scripts in the `models` directory.
@@ -308,7 +308,7 @@ dependencies:
         packages:
           - benchmark=1.8.3
 
-  databricks_example:
+  optional_databricks:
     common:
       - output_types: [conda]
         packages:    

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(Sphinx REQUIRED)
 
 set(SPHINX_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/source)
 set(SPHINX_BUILD ${CMAKE_CURRENT_BINARY_DIR}/html)
-set(SPHINX_ARGS -b html -j auto -T -W)
+set(SPHINX_ARGS -b html -j auto -T)
 
 add_custom_target(${PROJECT_NAME}_docs
    COMMAND

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(Sphinx REQUIRED)
 
 set(SPHINX_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/source)
 set(SPHINX_BUILD ${CMAKE_CURRENT_BINARY_DIR}/html)
-set(SPHINX_ARGS -v -b html -j auto -T)
+set(SPHINX_ARGS -b html -j auto -T -W)
 
 add_custom_target(${PROJECT_NAME}_docs
    COMMAND

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(Sphinx REQUIRED)
 
 set(SPHINX_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/source)
 set(SPHINX_BUILD ${CMAKE_CURRENT_BINARY_DIR}/html)
-set(SPHINX_ARGS -b html -j auto -T -W)
+set(SPHINX_ARGS -v -b html -j auto -T)
 
 add_custom_target(${PROJECT_NAME}_docs
    COMMAND

--- a/docs/source/extra_info/known_issues.md
+++ b/docs/source/extra_info/known_issues.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/docs/source/extra_info/known_issues.md
+++ b/docs/source/extra_info/known_issues.md
@@ -17,6 +17,7 @@ limitations under the License.
 
 # Known Issues
 
+- numba triggering IndexError on systems with driver version 580+ ([#2305](https://github.com/nv-morpheus/Morpheus/issues/2305))
 - TrainAEStage fails with a Segmentation fault ([#1641](https://github.com/nv-morpheus/Morpheus/issues/1641))
 - vdb_upload example pipeline triggers an internal error in Triton ([#1649](https://github.com/nv-morpheus/Morpheus/issues/1649))
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -125,7 +125,7 @@ def mlflow_uri(tmp_path):
 
     yield uri
 
-    num_runs = len(fluent._active_run_stack)
+    num_runs = len(fluent._active_run_stack.get())
     for _ in range(num_runs):
         mlflow.end_run()
 
@@ -140,7 +140,7 @@ def config_warning_fixture():
 
 
 @pytest.mark.reload_modules(commands)
-@pytest.mark.usefixtures("chdir_tmpdir", "reload_modules")
+@pytest.mark.usefixtures("chdir_tmpdir", "reload_modules", "reset_logging")
 @pytest.mark.use_python
 class TestCLI:
 


### PR DESCRIPTION
## Description
* Set GPU runner to an earlier driver version
* Document #2305 as a known issue
* Pin `npy-append-array` to avoid version conflict with nvtabular
* Update rapids shared workflows to 24.10 to fix the check action
* Pin click version to <8.2 to avoid #2219
* Ensure the logger is reset in `test_cli.py`

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
