### PR TITLE
Fix MLflow writer breakage across MLflow versions

### DIFF
--- a/python/morpheus/morpheus/controllers/mlflow_model_writer_controller.py
+++ b/python/morpheus/morpheus/controllers/mlflow_model_writer_controller.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# Copyright (c) 2021-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/morpheus/morpheus/controllers/mlflow_model_writer_controller.py
+++ b/python/morpheus/morpheus/controllers/mlflow_model_writer_controller.py
@@ -253,7 +253,7 @@ class MLFlowModelWriterController:
             with mlflow.start_run(run_name="autoencoder model training run",
                                   experiment_id=experiment.experiment_id) as run:
 
-                model_path = f"{model_path}-{run.info.run_uuid}"
+                model_path = f"{model_path}-{run.info.run_id}"
 
                 # Log all params in one dict to avoid round trips
                 mlflow.log_params({
@@ -322,7 +322,14 @@ class MLFlowModelWriterController:
                     # Need to apply permissions
                     self._apply_model_permissions(reg_model_name=reg_model_name)
 
-                model_src = RunsArtifactRepository.get_underlying_uri(model_info.model_uri)
+                model_uri = model_info.model_uri
+                if model_uri.startswith("models:/"):
+                    # MLflow 3.x returns "logged model" URIs (models:/m-<hash>) which are not
+                    # compatible with RunsArtifactRepository. Derive the artifact URI directly
+                    # from the active run context instead.
+                    model_src = mlflow.get_artifact_uri(model_path)
+                else:
+                    model_src = RunsArtifactRepository.get_underlying_uri(model_uri)
 
                 tags = {
                     "start": message.payload().get_data(self._timestamp_column_name).min(),

--- a/tests/morpheus_dfp/stages/test_dfp_mlflow_model_writer.py
+++ b/tests/morpheus_dfp/stages/test_dfp_mlflow_model_writer.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -84,6 +84,7 @@ def mock_mlflow():
         mock_model_signature.return_value = mock_model_signature
 
         mock_model_info = mock.MagicMock()
+        mock_model_info.model_uri = "runs:/test_run_id/dfencoder-test_run_id"
         mock_mlflow_pytorch_log_model.return_value = mock_model_info
 
         mock_model_src = mock.MagicMock()
@@ -345,7 +346,6 @@ def test_on_data_mlflow_3x_uri(
     """MLflow 3.x returns models:/m-<hash> URIs from log_model; verify the writer falls back to
     mlflow.get_artifact_uri() instead of the incompatible RunsArtifactRepository path."""
     from morpheus_dfp.stages.dfp_mlflow_model_writer import DFPMLFlowModelWriterStage
-    from morpheus_dfp.stages.dfp_mlflow_model_writer import conda_env
 
     # Simulate MLflow 3.x "logged model" URI
     mock_mlflow.model_info.model_uri = "models:/m-abc123def456"

--- a/tests/morpheus_dfp/stages/test_dfp_mlflow_model_writer.py
+++ b/tests/morpheus_dfp/stages/test_dfp_mlflow_model_writer.py
@@ -37,6 +37,7 @@ MockedMLFlow = namedtuple("MockedMLFlow",
                               'ModelSignature',
                               'RunsArtifactRepository',
                               'end_run',
+                              'get_artifact_uri',
                               'get_tracking_uri',
                               'log_metrics',
                               'log_params',
@@ -71,6 +72,7 @@ def mock_mlflow():
           mock.patch("morpheus.controllers.mlflow_model_writer_controller.RunsArtifactRepository") as
           mock_runs_artifact_repository,
           mock.patch("mlflow.end_run") as mock_mlflow_end_run,
+          mock.patch("mlflow.get_artifact_uri") as mock_mlflow_get_artifact_uri,
           mock.patch("mlflow.get_tracking_uri") as mock_mlflow_get_tracking_uri,
           mock.patch("mlflow.log_metrics") as mock_mlflow_log_metrics,
           mock.patch("mlflow.log_params") as mock_mlflow_log_params,
@@ -94,12 +96,12 @@ def mock_mlflow():
         mock_mlflow_start_run.return_value = mock_mlflow_start_run
         mock_mlflow_start_run.__enter__.return_value = mock_mlflow_start_run
         mock_mlflow_start_run.info.run_id = "test_run_id"
-        mock_mlflow_start_run.info.run_uuid = "test_run_uuid"
 
         yield MockedMLFlow(mock_mlflow_client,
                            mock_model_signature,
                            mock_runs_artifact_repository,
                            mock_mlflow_end_run,
+                           mock_mlflow_get_artifact_uri,
                            mock_mlflow_get_tracking_uri,
                            mock_mlflow_log_metrics,
                            mock_mlflow_log_params,
@@ -306,7 +308,7 @@ def test_on_data(
     mock_mlflow.ModelSignature.assert_called_once()
 
     mock_mlflow.pytorch_log_model.assert_called_once_with(pytorch_model=mock_model,
-                                                          artifact_path="dfencoder-test_run_uuid",
+                                                          artifact_path="dfencoder-test_run_id",
                                                           conda_env=conda_env,
                                                           signature=mock_mlflow.ModelSignature)
 
@@ -325,10 +327,69 @@ def test_on_data(
         mock_requests.patch.assert_not_called()
 
     mock_mlflow.RunsArtifactRepository.get_underlying_uri.assert_called_once_with(mock_mlflow.model_info.model_uri)
+    mock_mlflow.get_artifact_uri.assert_not_called()
 
     expected_tags = {"start": min_time, "end": max_time, "count": len(df)}
 
     mock_mlflow.MlflowClient.create_model_version.assert_called_once_with(name="dfp-Account-123456789",
                                                                           source=mock_mlflow.model_src,
+                                                                          run_id="test_run_id",
+                                                                          tags=expected_tags)
+
+
+def test_on_data_mlflow_3x_uri(
+        config: Config,
+        mock_mlflow: MockedMLFlow,  # pylint: disable=redefined-outer-name
+        mock_requests: MockedRequests,
+        dataset_pandas: DatasetManager):
+    """MLflow 3.x returns models:/m-<hash> URIs from log_model; verify the writer falls back to
+    mlflow.get_artifact_uri() instead of the incompatible RunsArtifactRepository path."""
+    from morpheus_dfp.stages.dfp_mlflow_model_writer import DFPMLFlowModelWriterStage
+    from morpheus_dfp.stages.dfp_mlflow_model_writer import conda_env
+
+    # Simulate MLflow 3.x "logged model" URI
+    mock_mlflow.model_info.model_uri = "models:/m-abc123def456"
+
+    mock_artifact_uri = mock.MagicMock()
+    mock_mlflow.get_artifact_uri.return_value = mock_artifact_uri
+
+    mock_requests.get.side_effect = RuntimeError("should not be called")
+    mock_requests.patch.side_effect = RuntimeError("should not be called")
+
+    config.ae.timestamp_column_name = 'eventTime'
+
+    input_file = os.path.join(TEST_DIRS.validation_data_dir, "dfp-cloudtrail-role-g-validation-data-input.csv")
+    df = dataset_pandas[input_file]
+
+    mock_model = mock.MagicMock()
+    mock_model.learning_rate_decay.state_dict.return_value = {'last_epoch': 1}
+    mock_model.learning_rate = 0.01
+    mock_model.batch_size = 32
+    mock_model.categorical_fts = {}
+    mock_model.prepare_df.return_value = df
+    mock_model.get_anomaly_score.return_value = pd.Series(float(i) for i in range(len(df)))
+
+    msg = ControlMessage()
+    msg.payload(MessageMeta(df))
+    msg.set_metadata("model", mock_model)
+    msg.set_metadata("user_id", 'Account-123456789')
+
+    stage = DFPMLFlowModelWriterStage(config, timeout=10)
+    assert stage._controller.on_data(msg) is msg
+
+    # RunsArtifactRepository must NOT be called for models:/ URIs
+    mock_mlflow.RunsArtifactRepository.get_underlying_uri.assert_not_called()
+
+    # mlflow.get_artifact_uri must be called with the model_path used in log_model
+    mock_mlflow.get_artifact_uri.assert_called_once_with("dfencoder-test_run_id")
+
+    expected_tags = {
+        "start": df['eventTime'].min(),
+        "end": df['eventTime'].max(),
+        "count": df['eventTime'].count()
+    }
+
+    mock_mlflow.MlflowClient.create_model_version.assert_called_once_with(name="dfp-Account-123456789",
+                                                                          source=mock_artifact_uri,
                                                                           run_id="test_run_id",
                                                                           tags=expected_tags)


### PR DESCRIPTION
## Description

Fixes two bugs in `MLFlowModelWriterController` that break the DFP MLflow model writer across MLflow versions.

**Bug 1 — `run_uuid` removed in newer MLflow:**
`run.info.run_uuid` no longer exists in newer MLflow versions, raising `AttributeError: 'RunInfo' object has no attribute 'run_uuid'`. Replaced with `run.info.run_id`.

**Bug 2 — MLflow 3.x "logged model" URIs:**
Starting with MLflow 3.x, `mlflow.pytorch.log_model()` returns `models:/m-<hash>` URIs. Passing these to `RunsArtifactRepository.get_underlying_uri()` raises `"Not a proper runs:/ URI"`. When the URI starts with `models:/`, the fix derives the artifact URI from the active run context via `mlflow.get_artifact_uri()` instead.

Closes #2315

## Changes

- `python/morpheus/morpheus/controllers/mlflow_model_writer_controller.py`: both fixes
- `tests/morpheus_dfp/stages/test_dfp_mlflow_model_writer.py`: updated assertions + new `test_on_data_mlflow_3x_uri` test covering the MLflow 3.x URI branch

## By Submitting this PR I confirm:
- I am familiar with the Contributing Guidelines.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.